### PR TITLE
feat(web): improve a11y of reader and home pages

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -4,7 +4,8 @@
   --border: #1f2a27;
   --fg: #e7efe9;
   --muted: #9fb3a6;
-  --faint: #5b6b61;
+  /* ~5.6:1 on --bg — meets WCAG AA for the small print it's used on. */
+  --faint: #7a8f83;
   --accent: #3fae7d;
   --accent-soft: #16241d;
 }
@@ -29,6 +30,44 @@ body {
 a {
   color: inherit;
   text-decoration: none;
+}
+
+/* ---- Accessibility ---- */
+
+/* Visible keyboard focus for every interactive element (links, buttons,
+   chips, selects). Mouse clicks stay un-ringed via :focus-visible. */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Skip link: off-screen until focused, then pinned to the top-left. */
+.skip-link {
+  position: absolute;
+  left: 0.5rem;
+  top: -3rem;
+  z-index: 10;
+  padding: 0.5rem 0.9rem;
+  background: var(--accent);
+  color: var(--bg);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  transition: top 0.15s ease;
+}
+.skip-link:focus {
+  top: 0.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 .container {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -35,7 +35,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={amiri.variable}>
       <body>
-        <div className="container">{children}</div>
+        <a href="#main" className="skip-link">
+          Skip to content
+        </a>
+        <main id="main" className="container">
+          {children}
+        </main>
         <ServiceWorkerRegister />
       </body>
     </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -25,7 +25,7 @@ export default async function HomePage() {
         }))}
       />
 
-      <nav className="surah-grid">
+      <nav className="surah-grid" aria-label="All surahs">
         {surahs.map((surah) => (
           <Link key={surah.number} href={`/surah/${surah.number}`} className="surah-card">
             <span className="surah-num">{surah.number}</span>
@@ -36,7 +36,9 @@ export default async function HomePage() {
                 {surah.englishName} · {surah.ayahCount} āyāt
               </span>
             </span>
-            <span className="name-ar arabic">{surah.name}</span>
+            <span className="name-ar arabic" lang="ar" dir="rtl">
+              {surah.name}
+            </span>
           </Link>
         ))}
       </nav>

--- a/apps/web/src/app/surah/[number]/page.tsx
+++ b/apps/web/src/app/surah/[number]/page.tsx
@@ -69,10 +69,12 @@ export default async function SurahPage({ params }: { params: Promise<{ number: 
       </Link>
 
       <header className="reader-head">
-        <div className="name-ar arabic">{surah.name}</div>
-        <div className="name-en">
-          {surah.transliteration} · {surah.englishName}
+        <div className="name-ar arabic" lang="ar" dir="rtl">
+          {surah.name}
         </div>
+        <h1 className="name-en">
+          {surah.transliteration} · {surah.englishName}
+        </h1>
         <div className="sub">
           Surah {surah.number} · {surah.ayahCount} āyāt ·{" "}
           {surah.revelationPlace === "meccan" ? "Meccan" : "Medinan"}
@@ -87,12 +89,16 @@ export default async function SurahPage({ params }: { params: Promise<{ number: 
       <SurahAudio surah={surah.number} ayahCount={surah.ayahCount} reciters={RECITERS} />
 
       {/* Surah 1's Basmala is ayah 1 itself; others show it as a header. */}
-      {surah.hasBismillah && surah.number !== 1 && <p className="basmala arabic">{bismillah}</p>}
+      {surah.hasBismillah && surah.number !== 1 && (
+        <p className="basmala arabic" lang="ar" dir="rtl">
+          {bismillah}
+        </p>
+      )}
 
       <div>
         {ayahs.map((ayah) => (
           <div key={ayah.aya} id={`${surah.number}:${ayah.aya}`} className="ayah">
-            <p className="ayah-ar arabic">
+            <p className="ayah-ar arabic" lang="ar" dir="rtl">
               {ayah.text}
               <button
                 type="button"
@@ -135,7 +141,7 @@ export default async function SurahPage({ params }: { params: Promise<{ number: 
         ))}
       </div>
 
-      <nav className="reader-nav">
+      <nav className="reader-nav" aria-label="Surah navigation">
         {number > 1 ? <Link href={`/surah/${number - 1}`}>← Previous surah</Link> : <span />}
         {number < TOTAL_SURAHS ? <Link href={`/surah/${number + 1}`}>Next surah →</Link> : <span />}
       </nav>

--- a/apps/web/src/components/SurahAudio.tsx
+++ b/apps/web/src/components/SurahAudio.tsx
@@ -97,12 +97,13 @@ export function SurahAudio({
       <button type="button" className="audio-play" onClick={toggle} aria-pressed={isPlaying}>
         {isPlaying ? "❚❚ Pause" : "▶ Play surah"}
       </button>
-      <span className="audio-status">
+      <span className="audio-status" aria-live="polite">
         {current !== null ? `Playing āyah ${current}` : "Tap an āyah number to play"}
       </span>
       {reciters.length > 1 && (
         <select
           className="audio-reciter"
+          aria-label="Reciter"
           value={reciterId}
           onChange={(e) => {
             setReciterId(e.target.value);


### PR DESCRIPTION
## What & why

Improves accessibility on the reader and home pages so the app is fully
keyboard-navigable and clears basic axe/Lighthouse checks.

Add a skip-to-content link and a `<main>` landmark, visible `:focus-visible`
styles, and `prefers-reduced-motion` support. Give the reader page an `<h1>`,
label the nav landmarks and reciter select, mark Arabic blocks with `lang`/`dir`,
and announce audio status via `aria-live`. Fix `--faint` contrast to meet WCAG AA.

`aria-pressed` on the bookmark, edition picker, Hifz, and play buttons was
already correct, so it was left as-is.

Closes #10 

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [x] `pnpm build` passes
- [x] No module-boundary violations (`apps → packages` only; `core` imports nothing)
- [ ] Any Islamic content is attributed and flagged `needs-scholar-review` if applicable
