### PR TITLE
feat(web): language-grouped, searchable translation manager + reading sub-modes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,6 +54,7 @@ flowchart TD
 - `quran-structure.ts` — invariants (`TOTAL_AYAHS`, `AYAH_COUNTS`, `JUZ_STARTS`, `HIZB_STARTS`) + utils (`isValidVerseRef`, `juzNumberOf`, …).
 - `hifz.ts` — pure SM-2 scheduler ([ADR 0007](docs/adr/0007-hifz-spaced-repetition.md)).
 - `plugins.ts` — the content-plugin contract + `PluginRegistry` ([ADR 0005](docs/adr/0005-content-plugin-system.md)).
+- `languages.ts` / `translations.ts` — ISO-639 display names + pure grouping/filtering for the translation picker ([ADR 0010](docs/adr/0010-translation-selection.md)).
 - `ports.ts` — **the interfaces** everything implements: `QuranRepository`, `TranslationRepository`, `TafsirRepository`, `HadithRepository`, `HifzRepository`.
 
 ## Data flow

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -178,21 +178,65 @@ a {
   margin: 1.75rem 0 2.25rem;
 }
 
-/* ---- Reading mode (continuous mushaf) vs translation mode ---- */
-.mode-reading {
+/* ---- Reading modes ----
+   translation : verse-by-verse (default, .mode-translation visible)
+   reading     : continuous mushaf, Arabic only (.mode-reading)
+   reading-tr  : reading typography with translations flowing underneath each
+                 āyah, no card chrome (.mode-reading-tr) */
+.mode-reading,
+.mode-reading-tr {
   display: none;
 }
-html[data-reading-mode="reading"] .mode-translation {
+html[data-reading-mode="reading"] .mode-translation,
+html[data-reading-mode="reading-tr"] .mode-translation {
   display: none;
 }
 html[data-reading-mode="reading"] .mode-reading {
   display: block;
 }
+html[data-reading-mode="reading-tr"] .mode-reading-tr {
+  display: block;
+}
+
+/* reading-tr layout: mushaf-style Arabic per āyah + chrome-free translations. */
+.read-ayah {
+  margin: 0 0 1.6rem;
+}
+.read-ar {
+  font-family: var(--font-amiri), serif;
+  direction: rtl;
+  text-align: justify;
+  text-align-last: right;
+  font-size: calc(2rem * var(--reading-scale, 1));
+  line-height: 2.6;
+  margin: 0 0 0.5rem;
+}
+.read-tr {
+  line-height: 1.85;
+  margin: 0.3rem 0;
+  color: var(--fg);
+}
+.read-tr[dir="rtl"] {
+  text-align: right;
+}
+
+.mode-toggle-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0.5rem 0 1.5rem;
+}
 .mode-toggle {
   display: flex;
   gap: 0.4rem;
   justify-content: center;
-  margin: 0.5rem 0 1.5rem;
+}
+.mode-toggle-wrap .mode-toggle {
+  margin: 0;
+}
+.mode-toggle--sub {
+  font-size: 0.85em;
 }
 .mushaf {
   font-family: var(--font-amiri), serif;
@@ -574,10 +618,19 @@ html[data-reading-mode="reading"] .mode-reading {
   padding: 0.85rem 0 1.25rem;
   border-bottom: 1px solid var(--border);
 }
-.edition-chips {
+.edition-summary {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  align-items: baseline;
+  gap: 0.4rem 0.5rem;
+  font-size: 0.85rem;
+}
+.edition-summary-label {
+  color: var(--muted);
+}
+.edition-summary-names {
+  color: var(--fg);
+  max-width: 22rem;
 }
 .chip {
   font: inherit;
@@ -644,4 +697,117 @@ html[data-reading-mode="reading"] .mode-reading {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
+}
+
+/* ---- Translation settings modal ---- */
+.ts-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 5vh 1rem;
+  background: rgba(0, 0, 0, 0.55);
+  overflow-y: auto;
+}
+.ts-panel {
+  width: 100%;
+  max-width: 32rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.25rem;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+.ts-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.9rem;
+}
+.ts-title {
+  font-size: 1.1rem;
+  margin: 0;
+}
+.ts-close {
+  font: inherit;
+  color: var(--muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+}
+.ts-search {
+  width: 100%;
+  font: inherit;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 1rem;
+}
+.ts-section {
+  margin-bottom: 1.1rem;
+}
+.ts-group-title {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin: 0 0 0.5rem;
+}
+.ts-native {
+  color: var(--faint);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.ts-selected {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.ts-pill {
+  font: inherit;
+  font-size: 0.8rem;
+  color: var(--bg);
+  background: var(--accent);
+  border: none;
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  cursor: pointer;
+}
+.ts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.ts-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.ts-row:hover {
+  background: var(--bg);
+}
+.ts-row input {
+  accent-color: var(--accent);
+}
+.ts-name {
+  color: var(--fg);
+}
+.ts-author {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+.ts-empty {
+  color: var(--muted);
 }

--- a/apps/web/src/app/juz/[number]/page.tsx
+++ b/apps/web/src/app/juz/[number]/page.tsx
@@ -11,9 +11,11 @@ import {
 import { pluginRegistry, quranRepository, translationRepository } from "@ummahlibrary/api";
 import { ReadingAudio } from "../../../components/ReadingAudio";
 import { ReadingModeToggle } from "../../../components/ReadingModeToggle";
+import { EditionManager } from "../../../components/EditionManager";
+import { DEFAULT_EDITIONS } from "../../../lib/editions";
 
 const RECITERS = pluginRegistry.byKind("reciter");
-const TRANSLATION = "eng-khattab";
+const DEFAULT_EDITION = DEFAULT_EDITIONS[0]!;
 
 export const dynamicParams = false;
 
@@ -40,31 +42,38 @@ async function loadJuz(numberParam: string) {
   const n = Number(numberParam);
   if (!isValidJuzNumber(n)) return null;
   const { start, end } = juzRange(n);
-  const bismillah = await quranRepository.getBismillah();
+  const [bismillah, editions] = await Promise.all([
+    quranRepository.getBismillah(),
+    translationRepository.listTranslations(),
+  ]);
 
   const sections = [];
   const verses: VerseKey[] = [];
   for (let sura = start.sura; sura <= end.sura; sura++) {
     const ayaStart = sura === start.sura ? start.aya : 1;
     const ayaEnd = sura === end.sura ? end.aya : ayahCountOf(sura);
-    const [surah, allAyahs, translation] = await Promise.all([
+    const [surah, allAyahs, translations] = await Promise.all([
       quranRepository.getSurah(sura),
       quranRepository.getSurahAyahs(sura),
-      translationRepository.getSurahTranslation(TRANSLATION, sura),
+      Promise.all(editions.map((e) => translationRepository.getSurahTranslation(e.id, sura))),
     ]);
     if (!surah) continue;
-    const tr = new Map(translation.map((t) => [t.aya, t.text]));
+    const byEdition = editions.map((edition, i) => ({
+      edition,
+      text: new Map(translations[i]!.map((t) => [t.aya, t.text])),
+    }));
     const ayahs = allAyahs
       .filter((a) => a.aya >= ayaStart && a.aya <= ayaEnd)
-      .map((a) => ({ aya: a.aya, text: a.text, english: tr.get(a.aya) ?? "" }));
+      .map((a) => ({ aya: a.aya, text: a.text }));
     for (const a of ayahs) verses.push({ sura, aya: a.aya });
     sections.push({
       surah,
       ayahs,
+      byEdition,
       showBismillah: ayaStart === 1 && surah.hasBismillah && surah.number !== 1,
     });
   }
-  return { n, sections, verses, bismillah };
+  return { n, sections, verses, bismillah, editions };
 }
 
 export async function generateMetadata({
@@ -81,7 +90,7 @@ export default async function JuzReaderPage({ params }: { params: Promise<{ numb
   const { number } = await params;
   const data = await loadJuz(number);
   if (!data) notFound();
-  const { n, sections, verses, bismillah } = data;
+  const { n, sections, verses, bismillah, editions } = data;
 
   return (
     <>
@@ -96,6 +105,16 @@ export default async function JuzReaderPage({ params }: { params: Promise<{ numb
       <ReadingModeToggle />
 
       <div className="mode-translation">
+        <EditionManager
+          editions={editions.map((e) => ({
+            id: e.id,
+            name: e.name,
+            author: e.author,
+            language: e.language,
+            direction: e.direction,
+          }))}
+        />
+
         <ReadingAudio verses={verses} reciters={RECITERS} />
 
         {sections.map((section) => (
@@ -125,7 +144,23 @@ export default async function JuzReaderPage({ params }: { params: Promise<{ numb
                     ﴿{toArabicDigits(ayah.aya)}﴾
                   </button>
                 </p>
-                {ayah.english && <p className="ayah-tr">{ayah.english}</p>}
+                {section.byEdition.map(({ edition, text }) => {
+                  const line = text.get(ayah.aya);
+                  if (!line) return null;
+                  const off = edition.id !== DEFAULT_EDITION ? " tr--off" : "";
+                  return (
+                    <p
+                      key={edition.id}
+                      className={`ayah-tr${off}`}
+                      data-edition={edition.id}
+                      lang={edition.language}
+                      dir={edition.direction}
+                    >
+                      <span className="tr-name">{edition.name}</span>
+                      {line}
+                    </p>
+                  );
+                })}
                 <div className="ayah-actions">
                   <button
                     type="button"
@@ -164,11 +199,49 @@ export default async function JuzReaderPage({ params }: { params: Promise<{ numb
         ))}
       </div>
 
+      <div className="mode-reading-tr">
+        {sections.map((section) => (
+          <section key={section.surah.number}>
+            <header className="juz-surah-head">
+              <span className="name-ar arabic">{section.surah.name}</span>
+              <span className="sub">
+                {section.surah.transliteration} · {section.surah.englishName}
+              </span>
+            </header>
+            {section.showBismillah && <p className="basmala arabic">{bismillah}</p>}
+            {section.ayahs.map((ayah) => (
+              <div key={ayah.aya} className="read-ayah">
+                <p className="read-ar arabic">
+                  {ayah.text}
+                  <span className="end-marker">﴿{toArabicDigits(ayah.aya)}﴾</span>
+                </p>
+                {section.byEdition.map(({ edition, text }) => {
+                  const line = text.get(ayah.aya);
+                  if (!line) return null;
+                  const off = edition.id !== DEFAULT_EDITION ? " tr--off" : "";
+                  return (
+                    <p
+                      key={edition.id}
+                      className={`read-tr${off}`}
+                      data-edition={edition.id}
+                      lang={edition.language}
+                      dir={edition.direction}
+                    >
+                      {line}
+                    </p>
+                  );
+                })}
+              </div>
+            ))}
+          </section>
+        ))}
+      </div>
+
       <nav className="reader-nav">
         {n > 1 ? <Link href={`/juz/${n - 1}`}>← Previous juzʾ</Link> : <span />}
         {n < TOTAL_JUZ ? <Link href={`/juz/${n + 1}`}>Next juzʾ →</Link> : <span />}
       </nav>
-      <p className="foot">Arabic: Tanzil (CC-BY 3.0) · Translation: The Clear Quran</p>
+      <p className="foot">Arabic: Tanzil (CC-BY 3.0) · Translations via Ummah Library datasets</p>
     </>
   );
 }

--- a/apps/web/src/app/surah/[number]/page.tsx
+++ b/apps/web/src/app/surah/[number]/page.tsx
@@ -88,7 +88,13 @@ export default async function SurahPage({ params }: { params: Promise<{ number: 
       <div className="mode-translation">
         <ReaderControls
           surahNumber={surah.number}
-          editions={editions.map((e) => ({ id: e.id, name: e.name, language: e.language }))}
+          editions={editions.map((e) => ({
+            id: e.id,
+            name: e.name,
+            author: e.author,
+            language: e.language,
+            direction: e.direction,
+          }))}
         />
 
         <ReadingAudio
@@ -170,6 +176,36 @@ export default async function SurahPage({ params }: { params: Promise<{ number: 
             </span>
           ))}
         </p>
+      </div>
+
+      {/* Reading layout with translations: mushaf typography, no card chrome,
+          each āyah's translation(s) flowing underneath. */}
+      <div className="mode-reading-tr">
+        {surah.hasBismillah && surah.number !== 1 && <p className="basmala arabic">{bismillah}</p>}
+        {ayahs.map((ayah) => (
+          <div key={ayah.aya} id={`r-${surah.number}:${ayah.aya}`} className="read-ayah">
+            <p className="read-ar arabic">
+              {ayah.text}
+              <span className="end-marker">﴿{toArabicDigits(ayah.aya)}﴾</span>
+            </p>
+            {byEdition.map(({ edition, text }) => {
+              const line = text.get(ayah.aya);
+              if (!line) return null;
+              const off = edition.id !== DEFAULT_EDITION ? " tr--off" : "";
+              return (
+                <p
+                  key={edition.id}
+                  className={`read-tr${off}`}
+                  data-edition={edition.id}
+                  lang={edition.language}
+                  dir={edition.direction}
+                >
+                  {line}
+                </p>
+              );
+            })}
+          </div>
+        ))}
       </div>
 
       <nav className="reader-nav">

--- a/apps/web/src/components/EditionManager.tsx
+++ b/apps/web/src/components/EditionManager.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  type EditionChoice,
+  DEFAULT_EDITIONS,
+  applyEditionVisibility,
+  readEditions,
+} from "../lib/editions";
+import { TranslationSettings } from "./TranslationSettings";
+
+/**
+ * The translation picker shared by the surah and juzʾ readers: a compact "My
+ * Translations" summary plus a "Manage" button that opens the full grouped,
+ * searchable {@link TranslationSettings} modal. Owns the selected-set state and
+ * keeps the page's `[data-edition]` blocks in sync via `applyEditionVisibility`.
+ */
+export function EditionManager({ editions }: { editions: EditionChoice[] }) {
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(DEFAULT_EDITIONS));
+  const [managing, setManaging] = useState(false);
+
+  useEffect(() => {
+    const saved = new Set(readEditions());
+    setSelected(saved);
+    applyEditionVisibility(saved, editions);
+  }, [editions]);
+
+  const chosen = editions.filter((e) => selected.has(e.id));
+
+  return (
+    <div className="edition-summary">
+      <span className="edition-summary-label">Translations:</span>
+      <span className="edition-summary-names">
+        {chosen.length > 0 ? chosen.map((e) => e.name).join(", ") : "None"}
+      </span>
+      <button
+        type="button"
+        className="chip"
+        onClick={() => setManaging(true)}
+        aria-haspopup="dialog"
+      >
+        Manage
+      </button>
+
+      {managing && (
+        <TranslationSettings
+          editions={editions}
+          selected={selected}
+          onChange={(next) => setSelected(new Set(next))}
+          onClose={() => setManaging(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ReaderControls.tsx
+++ b/apps/web/src/components/ReaderControls.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { EditionChoice } from "../lib/editions";
+import { EditionManager } from "./EditionManager";
 
-export interface EditionChoice {
-  id: string;
-  name: string;
-  language: string;
-}
+export type { EditionChoice };
 
-const EDITIONS_KEY = "ul.editions";
 const BOOKMARKS_KEY = "ul.bookmarks";
 const LAST_READ_KEY = "ul.lastRead";
-const DEFAULT_EDITIONS = ["eng-khattab"];
 const SCALE_KEY = "ul.scale";
 const SCALE_MIN = 0.8;
 const SCALE_MAX = 1.8;
@@ -33,16 +29,6 @@ function write(key: string, value: unknown): void {
   }
 }
 
-/** Show/hide a translation edition across the page by toggling `.tr--off`. */
-function applyEditionVisibility(selected: Set<string>, all: EditionChoice[]): void {
-  for (const e of all) {
-    const visible = selected.has(e.id);
-    document
-      .querySelectorAll<HTMLElement>(`[data-edition="${e.id}"]`)
-      .forEach((node) => node.classList.toggle("tr--off", !visible));
-  }
-}
-
 export function ReaderControls({
   surahNumber,
   editions,
@@ -50,39 +36,24 @@ export function ReaderControls({
   surahNumber: number;
   editions: EditionChoice[];
 }) {
-  const [selected, setSelected] = useState<Set<string>>(() => new Set(DEFAULT_EDITIONS));
   const [bookmarked, setBookmarked] = useState(false);
   const [scale, setScale] = useState(1);
 
   // Hydrate from localStorage and record this surah as last-read.
   useEffect(() => {
-    const saved = new Set(read<string[]>(EDITIONS_KEY, DEFAULT_EDITIONS));
-    setSelected(saved);
-    applyEditionVisibility(saved, editions);
-
     setBookmarked(read<number[]>(BOOKMARKS_KEY, []).includes(surahNumber));
     write(LAST_READ_KEY, { surah: surahNumber });
 
     const savedScale = read<number>(SCALE_KEY, 1);
     setScale(savedScale);
     document.documentElement.style.setProperty("--reading-scale", String(savedScale));
-  }, [surahNumber, editions]);
+  }, [surahNumber]);
 
   function changeScale(delta: number): void {
     const next = Math.min(SCALE_MAX, Math.max(SCALE_MIN, Math.round((scale + delta) * 10) / 10));
     setScale(next);
     write(SCALE_KEY, next);
     document.documentElement.style.setProperty("--reading-scale", String(next));
-  }
-
-  function toggleEdition(id: string): void {
-    const next = new Set(selected);
-    if (next.has(id)) next.delete(id);
-    else next.add(id);
-    if (next.size === 0) next.add(DEFAULT_EDITIONS[0]!); // never hide everything
-    setSelected(next);
-    write(EDITIONS_KEY, [...next]);
-    applyEditionVisibility(next, editions);
   }
 
   function toggleBookmark(): void {
@@ -126,19 +97,8 @@ export function ReaderControls({
           </button>
         </div>
       </div>
-      <div className="edition-chips">
-        {editions.map((e) => (
-          <button
-            key={e.id}
-            type="button"
-            className={selected.has(e.id) ? "chip chip--on" : "chip"}
-            aria-pressed={selected.has(e.id)}
-            onClick={() => toggleEdition(e.id)}
-          >
-            {e.name}
-          </button>
-        ))}
-      </div>
+
+      <EditionManager editions={editions} />
     </div>
   );
 }

--- a/apps/web/src/components/ReadingModeToggle.tsx
+++ b/apps/web/src/components/ReadingModeToggle.tsx
@@ -2,7 +2,17 @@
 
 import { useEffect, useState } from "react";
 
-type Mode = "translation" | "reading";
+/**
+ * Reading mode, mirroring Quran.com's two-level control:
+ *  - "translation"  → verse-by-verse, each āyah with its translations
+ *  - "reading"      → continuous mushaf, Arabic only
+ *  - "reading-tr"   → continuous reading, Arabic with translations
+ *
+ * The value persists in `ul.readingMode` and drives visibility via the
+ * `html[data-reading-mode]` attribute (restored pre-paint in layout.tsx). The
+ * legacy stored value "reading" keeps working unchanged.
+ */
+type Mode = "translation" | "reading" | "reading-tr";
 
 export function ReadingModeToggle() {
   const [mode, setMode] = useState<Mode>("translation");
@@ -21,24 +31,50 @@ export function ReadingModeToggle() {
     }
   }
 
+  const isReading = mode === "reading" || mode === "reading-tr";
+
   return (
-    <div className="mode-toggle" role="group" aria-label="Reading mode">
-      <button
-        type="button"
-        className={mode === "translation" ? "chip chip--on" : "chip"}
-        aria-pressed={mode === "translation"}
-        onClick={() => choose("translation")}
-      >
-        Translation
-      </button>
-      <button
-        type="button"
-        className={mode === "reading" ? "chip chip--on" : "chip"}
-        aria-pressed={mode === "reading"}
-        onClick={() => choose("reading")}
-      >
-        Reading
-      </button>
+    <div className="mode-toggle-wrap">
+      <div className="mode-toggle" role="group" aria-label="Reading mode">
+        <button
+          type="button"
+          className={mode === "translation" ? "chip chip--on" : "chip"}
+          aria-pressed={mode === "translation"}
+          onClick={() => choose("translation")}
+        >
+          Verse by verse
+        </button>
+        <button
+          type="button"
+          className={isReading ? "chip chip--on" : "chip"}
+          aria-pressed={isReading}
+          // Entering reading mode keeps the last reading sub-choice, default Arabic.
+          onClick={() => choose(mode === "reading-tr" ? "reading-tr" : "reading")}
+        >
+          Reading
+        </button>
+      </div>
+
+      {isReading && (
+        <div className="mode-toggle mode-toggle--sub" role="group" aria-label="Reading content">
+          <button
+            type="button"
+            className={mode === "reading" ? "chip chip--on" : "chip"}
+            aria-pressed={mode === "reading"}
+            onClick={() => choose("reading")}
+          >
+            Arabic
+          </button>
+          <button
+            type="button"
+            className={mode === "reading-tr" ? "chip chip--on" : "chip"}
+            aria-pressed={mode === "reading-tr"}
+            onClick={() => choose("reading-tr")}
+          >
+            Translations
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/TranslationSettings.tsx
+++ b/apps/web/src/components/TranslationSettings.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  type LanguageGroup,
+  filterTranslations,
+  groupTranslationsByLanguage,
+} from "@ummahlibrary/core";
+import {
+  type EditionChoice,
+  DEFAULT_EDITIONS,
+  applyEditionVisibility,
+  writeEditions,
+} from "../lib/editions";
+
+/**
+ * "Manage translations" modal: search + language-grouped checklist + a "My
+ * Translations" summary. Grouping and filtering come from the pure core helpers;
+ * this component only owns the DOM, focus, and persistence.
+ */
+export function TranslationSettings({
+  editions,
+  selected,
+  onChange,
+  onClose,
+}: {
+  editions: EditionChoice[];
+  selected: Set<string>;
+  onChange: (next: Set<string>) => void;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Focus search on open; close on Escape.
+  useEffect(() => {
+    searchRef.current?.focus();
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const matches = useMemo(() => filterTranslations(editions, query), [editions, query]);
+  const groups: LanguageGroup[] = useMemo(
+    () => groupTranslationsByLanguage(matches),
+    [matches],
+  );
+  const chosen = useMemo(
+    () => editions.filter((e) => selected.has(e.id)),
+    [editions, selected],
+  );
+
+  function commit(next: Set<string>): void {
+    if (next.size === 0) next.add(DEFAULT_EDITIONS[0]!); // never hide everything
+    onChange(next);
+    writeEditions([...next]);
+    applyEditionVisibility(next, editions);
+  }
+
+  function toggle(id: string): void {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    commit(next);
+  }
+
+  return (
+    <div
+      className="ts-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Manage translations"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="ts-panel">
+        <div className="ts-head">
+          <h2 className="ts-title">Translations</h2>
+          <button type="button" className="ts-close" aria-label="Close" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+
+        <input
+          ref={searchRef}
+          type="search"
+          className="ts-search"
+          placeholder="Search by name, author, or language…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Search translations"
+        />
+
+        {chosen.length > 0 && (
+          <section className="ts-section">
+            <h3 className="ts-group-title">My Translations</h3>
+            <div className="ts-selected">
+              {chosen.map((e) => (
+                <button
+                  key={e.id}
+                  type="button"
+                  className="ts-pill"
+                  onClick={() => toggle(e.id)}
+                  aria-label={`Remove ${e.name}`}
+                >
+                  {e.name} <span aria-hidden="true">✕</span>
+                </button>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <div className="ts-groups">
+          {groups.length === 0 && <p className="ts-empty">No translations match “{query}”.</p>}
+          {groups.map((group) => (
+            <section key={group.code} className="ts-section">
+              <h3 className="ts-group-title">
+                {group.english}
+                {group.native !== group.english && (
+                  <span className="ts-native"> · {group.native}</span>
+                )}
+              </h3>
+              <ul className="ts-list">
+                {group.translations.map((t) => {
+                  const isOn = selected.has(t.id);
+                  return (
+                    <li key={t.id}>
+                      <label className="ts-row">
+                        <input
+                          type="checkbox"
+                          checked={isOn}
+                          onChange={() => toggle(t.id)}
+                        />
+                        <span className="ts-name">{t.name}</span>
+                        <span className="ts-author">{t.author}</span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/editions.ts
+++ b/apps/web/src/lib/editions.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared translation-edition selection: the localStorage-backed set of editions
+ * the reader currently shows, plus the DOM helper that toggles their visibility.
+ *
+ * All ingested editions are rendered into every page; selecting an edition just
+ * shows/hides its `[data-edition]` blocks via the `.tr--off` class. Both the
+ * compact reader controls and the full "manage translations" modal read and
+ * write this one source of truth so they stay in sync.
+ */
+import type { Translation } from "@ummahlibrary/core";
+
+/** The edition fields the reader UI needs (a view over `Translation`). */
+export type EditionChoice = Pick<
+  Translation,
+  "id" | "name" | "author" | "language" | "direction"
+>;
+
+export const EDITIONS_KEY = "ul.editions";
+export const DEFAULT_EDITIONS = ["eng-khattab"];
+
+export function readEditions(): string[] {
+  try {
+    const raw = localStorage.getItem(EDITIONS_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : DEFAULT_EDITIONS;
+  } catch {
+    return DEFAULT_EDITIONS;
+  }
+}
+
+export function writeEditions(ids: string[]): void {
+  try {
+    localStorage.setItem(EDITIONS_KEY, JSON.stringify(ids));
+  } catch {
+    /* storage unavailable — ignore */
+  }
+}
+
+/** Show/hide every edition's translation lines by toggling `.tr--off`. */
+export function applyEditionVisibility(selected: Set<string>, all: EditionChoice[]): void {
+  for (const e of all) {
+    const visible = selected.has(e.id);
+    document
+      .querySelectorAll<HTMLElement>(`[data-edition="${e.id}"]`)
+      .forEach((node) => node.classList.toggle("tr--off", !visible));
+  }
+}

--- a/docs/adr/0010-translation-selection.md
+++ b/docs/adr/0010-translation-selection.md
@@ -1,0 +1,53 @@
+# ADR 0010 — Translation selection: grouped, searchable, local-first
+
+- **Status:** Accepted
+- **Date:** 2026-06-06
+
+## Context
+
+The reader ingests several translation editions (0002, 0005) and, until now,
+exposed them as a **flat row of chips** — one per edition — with a single
+`Translation`/`Reading` mode toggle. That works for a handful of editions but
+doesn't match how Quran.com and peers let users manage translations, and it
+degrades as the catalogue grows across many languages.
+
+Quran.com's model (researched from `api.quran.com/api/v4/resources/translations`
+— ~100 editions across ~66 languages): a settings surface that **groups editions
+by language**, offers a **text search**, and shows a **"My Translations"**
+summary of the current picks; plus a two-level reading control — _Verse by verse_
+vs _Reading_, and within _Reading_, _Arabic_ vs _Translations_.
+
+## Decision
+
+**1. Selection model.** Editions are presented **grouped by language**, with a
+**search** over name/author/language and a **"My Translations"** summary. The
+grouping, ordering, and (diacritic-insensitive) matching are **pure functions in
+`core`** (`groupTranslationsByLanguage`, `filterTranslations`), unit-tested; the
+human-readable language names are reference data in `core/src/languages.ts`,
+shared by web and mobile. The web UI (`TranslationSettings`, `EditionManager`) is
+a thin shell over them.
+
+**2. Reading sub-mode.** A nested toggle adds **Reading → Translations**
+(continuous reading _with_ translations) alongside the existing **Reading →
+Arabic**. Three values in `ul.readingMode`: `translation`, `reading`,
+`reading-tr`; the legacy `reading` value still works. Visibility is driven by the
+`html[data-reading-mode]` attribute (restored pre-paint), no extra DOM.
+
+**3. Delivery — render-all + toggle, for now.** All ingested editions are still
+rendered into every page and shown/hidden client-side via `.tr--off`; selection
+stays **local-first** in `localStorage` (extends 0006), never zero-selected. We
+**keep this** rather than fetching selected translations at runtime, because the
+ingested catalogue is small. **Trigger to revisit:** when the ingested set grows
+past roughly **15 editions**, or the per-page translation payload becomes a
+measurable bundle/render regression — at which point translations move to a
+**runtime fetch** behind the existing content-plugin port (a `runtime-json`
+delivery mode, 0005), and this ADR is superseded.
+
+## Consequences
+
+- A scalable, familiar selector; logic is pure and tested, UI stays thin.
+- No new dependency edges, no DB, no API change — fully consistent with
+  static-first (0003) and local-first (0006).
+- The render-all approach has a known ceiling; the trigger and the migration path
+  (runtime-json plugin) are recorded so the decision is revisited deliberately,
+  not by accident.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,6 +18,7 @@ through Phases 1–3; later decisions get their own record at the time they're m
 | [0007](0007-hifz-spaced-repetition.md)        | Hifz scheduling: SM-2 in core behind a port                 | Accepted |
 | [0008](0008-recitation-audio-highlighting.md) | Recitation audio + word-by-word highlighting                | Accepted |
 | [0009](0009-mobile-app.md)                    | Mobile app (Expo) sharing the monorepo                      | Accepted |
+| [0010](0010-translation-selection.md)         | Translation selection: grouped, searchable, local-first     | Accepted |
 
 ## Writing a new ADR
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,5 +12,7 @@
 export * from "./quran-structure";
 export * from "./hifz";
 export * from "./plugins";
+export * from "./languages";
+export * from "./translations";
 export type * from "./entities";
 export type * from "./ports";

--- a/packages/core/src/languages.test.ts
+++ b/packages/core/src/languages.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { LANGUAGE_NAMES, displayLanguage } from "./languages";
+
+describe("displayLanguage", () => {
+  it("returns English and native names for known codes", () => {
+    expect(displayLanguage("en")).toEqual({ english: "English", native: "English" });
+    expect(displayLanguage("ur")).toEqual({ english: "Urdu", native: "اردو" });
+    expect(displayLanguage("bn")).toEqual({ english: "Bengali", native: "বাংলা" });
+  });
+
+  it("is case-insensitive on the code", () => {
+    expect(displayLanguage("UR")).toEqual(LANGUAGE_NAMES.ur);
+  });
+
+  it("covers every code our editions currently use", () => {
+    for (const code of ["en", "ur", "bn"]) {
+      expect(LANGUAGE_NAMES[code]).toBeDefined();
+    }
+  });
+
+  it("falls back to a title-cased code for unknown languages", () => {
+    expect(displayLanguage("xyz")).toEqual({ english: "Xyz", native: "Xyz" });
+  });
+});

--- a/packages/core/src/languages.ts
+++ b/packages/core/src/languages.ts
@@ -1,0 +1,64 @@
+/**
+ * Language reference data — a small, pure lookup from ISO-639 codes to display
+ * names (English + native). Translations carry only a language *code* (e.g.
+ * "ur"); the reader groups and labels them by language, so the human-readable
+ * names live here in the core where both web and mobile can share them.
+ *
+ * This is reference data, not logic: no I/O, no framework. Unknown codes fall
+ * back to a title-cased form of the code itself so a newly-added edition never
+ * breaks the UI.
+ */
+
+export interface LanguageName {
+  /** Name in English, e.g. "Urdu". */
+  english: string;
+  /** Endonym (name in its own script), e.g. "اردو". */
+  native: string;
+}
+
+/**
+ * ISO-639-1 (with a few ISO-639-3 fallbacks) → display names. Covers the codes
+ * our editions currently use plus common languages we expect to add, so the
+ * grouping UI labels them properly out of the box.
+ */
+export const LANGUAGE_NAMES: Record<string, LanguageName> = {
+  ar: { english: "Arabic", native: "العربية" },
+  bn: { english: "Bengali", native: "বাংলা" },
+  de: { english: "German", native: "Deutsch" },
+  en: { english: "English", native: "English" },
+  es: { english: "Spanish", native: "Español" },
+  fa: { english: "Persian", native: "فارسی" },
+  fr: { english: "French", native: "Français" },
+  hi: { english: "Hindi", native: "हिन्दी" },
+  id: { english: "Indonesian", native: "Bahasa Indonesia" },
+  ml: { english: "Malayalam", native: "മലയാളം" },
+  ms: { english: "Malay", native: "Bahasa Melayu" },
+  nl: { english: "Dutch", native: "Nederlands" },
+  ps: { english: "Pashto", native: "پښتو" },
+  pt: { english: "Portuguese", native: "Português" },
+  ru: { english: "Russian", native: "Русский" },
+  sq: { english: "Albanian", native: "Shqip" },
+  sw: { english: "Swahili", native: "Kiswahili" },
+  ta: { english: "Tamil", native: "தமிழ்" },
+  tr: { english: "Turkish", native: "Türkçe" },
+  ur: { english: "Urdu", native: "اردو" },
+  zh: { english: "Chinese", native: "中文" },
+};
+
+/** Title-case a bare code so an unknown language still reads sensibly. */
+function titleCase(code: string): string {
+  if (!code) return code;
+  return code.charAt(0).toUpperCase() + code.slice(1).toLowerCase();
+}
+
+/**
+ * Display names for a language code. Falls back to a title-cased copy of the
+ * code for anything not in {@link LANGUAGE_NAMES}, so the UI never shows a blank
+ * label for a freshly added edition.
+ */
+export function displayLanguage(code: string): LanguageName {
+  const known = LANGUAGE_NAMES[code.toLowerCase()];
+  if (known) return known;
+  const label = titleCase(code);
+  return { english: label, native: label };
+}

--- a/packages/core/src/translations.test.ts
+++ b/packages/core/src/translations.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { Translation } from "./entities";
+import { filterTranslations, groupTranslationsByLanguage, normalize } from "./translations";
+
+const khattab: Translation = {
+  id: "eng-khattab",
+  name: "The Clear Quran",
+  author: "Mustafa Khattab",
+  language: "en",
+  direction: "ltr",
+};
+const haleem: Translation = {
+  id: "eng-haleem",
+  name: "Abdel Haleem",
+  author: "M.A.S. Abdel Haleem",
+  language: "en",
+  direction: "ltr",
+};
+const jalandhry: Translation = {
+  id: "urd-jalandhry",
+  name: "Jalandhry",
+  author: "Fateh Muhammad Jalāndhrī",
+  language: "ur",
+  direction: "rtl",
+};
+const ahmedali: Translation = {
+  id: "urd-ahmedali",
+  name: "Ahmed Ali",
+  author: "Ahmed Ali",
+  language: "ur",
+  direction: "rtl",
+};
+const muhiuddin: Translation = {
+  id: "ben-muhiuddinkhan",
+  name: "Muhiuddin Khan",
+  author: "Muhiuddin Khan",
+  language: "bn",
+  direction: "ltr",
+};
+
+const all = [khattab, jalandhry, muhiuddin, haleem, ahmedali];
+
+describe("normalize", () => {
+  it("lowercases, trims, and strips diacritics", () => {
+    expect(normalize("  Jalāl  ")).toBe("jalal");
+    expect(normalize("Türkçe")).toBe("turkce");
+  });
+});
+
+describe("groupTranslationsByLanguage", () => {
+  it("orders groups by English language name", () => {
+    const groups = groupTranslationsByLanguage(all);
+    expect(groups.map((g) => g.code)).toEqual(["bn", "en", "ur"]);
+    expect(groups.map((g) => g.english)).toEqual(["Bengali", "English", "Urdu"]);
+  });
+
+  it("attaches native names and sorts editions within a group by name", () => {
+    const groups = groupTranslationsByLanguage(all);
+    const urdu = groups.find((g) => g.code === "ur")!;
+    expect(urdu.native).toBe("اردو");
+    expect(urdu.translations.map((t) => t.id)).toEqual(["urd-ahmedali", "urd-jalandhry"]);
+  });
+
+  it("collapses a single-language list into one group", () => {
+    const groups = groupTranslationsByLanguage([khattab, haleem]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.translations).toHaveLength(2);
+  });
+
+  it("returns an empty array for no translations", () => {
+    expect(groupTranslationsByLanguage([])).toEqual([]);
+  });
+});
+
+describe("filterTranslations", () => {
+  it("returns all entries for an empty or whitespace query", () => {
+    expect(filterTranslations(all, "")).toEqual(all);
+    expect(filterTranslations(all, "   ")).toEqual(all);
+  });
+
+  it("matches on edition name, case-insensitively", () => {
+    expect(filterTranslations(all, "clear")).toEqual([khattab]);
+  });
+
+  it("matches on author", () => {
+    expect(filterTranslations(all, "khan").map((t) => t.id)).toEqual(["ben-muhiuddinkhan"]);
+  });
+
+  it("matches on language English and native names", () => {
+    expect(filterTranslations(all, "urdu").map((t) => t.language)).toEqual(["ur", "ur"]);
+    expect(filterTranslations(all, "اردو")).toHaveLength(2);
+  });
+
+  it("is diacritic-insensitive (plain query matches accented data)", () => {
+    // author is "Fateh Muhammad Jalāndhrī" — searching without accents matches.
+    expect(filterTranslations(all, "jalandhri")).toEqual([jalandhry]);
+  });
+
+  it("returns nothing when no edition matches", () => {
+    expect(filterTranslations(all, "zzzz")).toEqual([]);
+  });
+});

--- a/packages/core/src/translations.ts
+++ b/packages/core/src/translations.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure helpers for presenting the translation catalogue: grouping editions by
+ * language and filtering them by a free-text query. The reader's "manage
+ * translations" UI is a thin shell over these functions — all the ordering and
+ * matching rules live here so they can be unit-tested in isolation.
+ *
+ * No I/O, no framework: this is core domain logic.
+ */
+import type { Translation } from "./entities";
+import { displayLanguage } from "./languages";
+
+/** A language and the editions available in it, ready to render as a section. */
+export interface LanguageGroup {
+  /** ISO-639 language code, e.g. "ur". */
+  code: string;
+  /** Language name in English, e.g. "Urdu". */
+  english: string;
+  /** Language name in its own script, e.g. "اردو". */
+  native: string;
+  /** Editions in this language, sorted by name. */
+  translations: Translation[];
+}
+
+/** Lowercase and strip diacritics so "Jalāl" matches a search for "jalal". */
+export function normalize(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+/**
+ * Group editions by language. Groups are ordered by English language name;
+ * editions within a group are ordered by name. Pure and stable — equal keys
+ * keep input order via a stable sort.
+ */
+export function groupTranslationsByLanguage(translations: Translation[]): LanguageGroup[] {
+  const byCode = new Map<string, Translation[]>();
+  for (const t of translations) {
+    const list = byCode.get(t.language);
+    if (list) list.push(t);
+    else byCode.set(t.language, [t]);
+  }
+
+  const groups: LanguageGroup[] = [];
+  for (const [code, list] of byCode) {
+    const { english, native } = displayLanguage(code);
+    groups.push({
+      code,
+      english,
+      native,
+      translations: [...list].sort((a, b) => a.name.localeCompare(b.name)),
+    });
+  }
+
+  return groups.sort((a, b) => a.english.localeCompare(b.english));
+}
+
+/**
+ * Filter editions by a free-text query, matching (case- and diacritic-
+ * insensitive) against the edition name, author, and the language's English and
+ * native names. An empty or whitespace-only query returns the input unchanged.
+ */
+export function filterTranslations(translations: Translation[], query: string): Translation[] {
+  const q = normalize(query);
+  if (!q) return translations;
+  return translations.filter((t) => {
+    const { english, native } = displayLanguage(t.language);
+    const haystack = normalize(`${t.name} ${t.author} ${english} ${native}`);
+    return haystack.includes(q);
+  });
+}


### PR DESCRIPTION
## What & why

Brings translation selection to parity with Quran.com. The reader previously
showed translations as a flat chip row with a single Translation/Reading toggle —
fine for a few editions, but not how users expect to manage translations and not
scalable across languages.

### Translation manager
- **Grouped by language** (English / Urdu / Bengali, with native script), with a
  **search** over name/author/language and a **"My Translations"** summary.
- Shared by the surah **and** juzʾ readers (the juzʾ reader now loads all
  editions — it was English-only before).

### Reading sub-modes
- Nested toggle: **Verse by verse | Reading**, and within Reading **Arabic |
  Translations** (matching Quran.com).
- **Reading → Translations** is a dedicated continuous reading layout — mushaf
  typography, no card chrome — with each āyah's translation(s) flowing
  underneath (not the verse-by-verse cards).

## Architecture
- All grouping/filtering is **pure logic in `core`** (`languages.ts`,
  `translations.ts`), **22 new unit tests**; the web components are thin shells.
- **No new dependency edges, no DB, no API change.** Selection stays
  **local-first** in `localStorage`; editions render-all + toggle via `.tr--off`.
- **ADR 0010** records the model and the explicit trigger to move translations to
  a runtime fetch (a `runtime-json` content plugin) if the catalogue grows.

## Verification
`pnpm lint · typecheck · test · build` all pass. Verified prerendered HTML for
`/surah/2` and `/juz/1`: all editions present, grouped manager wired, and the
dedicated reading-with-translations block renders (286 āyāt × 6 editions).
