### PR TITLE
test: coverage gates for the logic libraries + a Playwright reader smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,27 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E smoke tests
+        run: pnpm test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ Thumbs.db
 .idea/
 .vscode/*
 !.vscode/extensions.json
+
+# Playwright
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache

--- a/e2e/reader.spec.ts
+++ b/e2e/reader.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Surah reader", () => {
+  test("offers every reciter and wires the selected one to playback", async ({ page }) => {
+    // Never hit a real CDN: stub the quran.com timing API and any audio file.
+    await page.route(/api\.quran\.com\/.*by_key/, (route) =>
+      route.fulfill({
+        json: { verse: { audio: { url: "Alafasy/mp3/001001.mp3", segments: [] } } },
+      }),
+    );
+    await page.route(/\.mp3(\?.*)?$/, (route) =>
+      route.fulfill({ status: 200, contentType: "audio/mpeg", body: "" }),
+    );
+
+    await page.goto("/surah/1");
+
+    // Reader chrome is present.
+    await expect(page.getByRole("button", { name: "Verse" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Mushaf" })).toBeVisible();
+
+    // The audio dock's reciter selector lists all 8 reciters. (A select's text
+    // content includes its option labels, so filter by one reciter's name.)
+    const reciter = page.locator("select").filter({ hasText: "Mishary Rashid Alafasy" });
+    await expect(reciter.locator("option")).toHaveCount(8);
+
+    // Selecting a reciter persists the choice...
+    await reciter.selectOption({ label: "Saud Al-Shuraim" });
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("ul.reciter")))
+      .toBe("shuraym");
+
+    // ...and playing an āyah fetches THAT reciter's recitation
+    // (quranComId 10 = Saud Al-Shuraim appears in the timing request).
+    const timingRequest = page.waitForRequest(/api\.quran\.com\/.*by_key.*audio=10/);
+    await page.locator("[data-play-one]").first().click();
+    await timingRequest;
+  });
+});

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,mjs,cjs,md,json,yml,yaml}\" --ignore-path .prettierignore",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mjs,cjs,md,json,yml,yaml}\" --ignore-path .prettierignore",
     "clean": "turbo run clean"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.49.1",
     "@vitest/coverage-v8": "^2.1.8",
     "eslint": "^9.17.0",
     "eslint-import-resolver-typescript": "^4.4.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * E2E smoke tests. The web dev server is started automatically (reused locally
+ * if one is already running on :3000). Tests stub external audio so they never
+ * depend on quran.com / everyayah being reachable.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  timeout: 60_000,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    navigationTimeout: 60_000,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "pnpm --filter @ummahlibrary/web dev",
+    url: "http://localhost:3000",
+    timeout: 180_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@eslint/js':
         specifier: ^9.17.0
         version: 9.39.4
+      '@playwright/test':
+        specifier: ^1.49.1
+        version: 1.60.0
       '@vitest/coverage-v8':
         specifier: ^2.1.8
         version: 2.1.9(vitest@2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0))
@@ -132,7 +135,7 @@ importers:
         version: link:../../packages/ui
       next:
         specifier: ^15.1.3
-        version: 15.5.19(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -1612,6 +1615,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@react-native-async-storage/async-storage@2.2.0':
     resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
@@ -3114,6 +3122,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4038,6 +4051,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
@@ -6443,6 +6466,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))':
     dependencies:
       merge-options: 3.0.4
@@ -8073,6 +8100,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9039,7 +9069,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@15.5.19(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
@@ -9057,6 +9087,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.19
       '@next/swc-win32-arm64-msvc': 15.5.19
       '@next/swc-win32-x64-msvc': 15.5.19
+      '@playwright/test': 1.60.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -9206,6 +9237,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.1:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,9 +2,10 @@ import { defineConfig } from "vitest/config";
 
 /**
  * Root config — supplies the coverage settings for the workspace run
- * (`pnpm test:coverage`). Coverage is scoped to the logic libraries
- * (core / data / adapters); the UI apps are covered by manual + e2e checks,
- * not unit tests. No failing thresholds yet — this just reports the numbers.
+ * (`pnpm test:coverage`). Coverage is reported for the logic libraries
+ * (core / data / adapters) and the web client logic. Per-library thresholds
+ * lock in the well-tested logic so it can't silently regress; the web UI is
+ * reported as a growing baseline (no gate yet).
  */
 export default defineConfig({
   test: {
@@ -32,6 +33,13 @@ export default defineConfig({
         "packages/core/src/entities.ts",
         "packages/core/src/ports.ts",
       ],
+      // Gate the logic libraries (set a little below current to absorb churn).
+      // No web/global threshold yet — that's a ratcheting baseline.
+      thresholds: {
+        "packages/core/src/**": { statements: 95, branches: 88, functions: 95, lines: 95 },
+        "packages/data/src/**": { statements: 85, branches: 78, functions: 72, lines: 85 },
+        "packages/adapters/src/**": { statements: 95, branches: 82, functions: 90, lines: 95 },
+      },
     },
   },
 });


### PR DESCRIPTION
## What

Two guardrails on top of the coverage tooling:

### 1. Coverage gates (verified locally)
Per-library thresholds so the well-tested logic can't silently regress:
- `core` — 95% statements / 88% branches / 95% functions
- `data` — 85% / 78% / 72%
- `adapters` — 95% / 82% / 90%

The web UI stays a **reported, ungated baseline** (we ratchet it up as component tests land). Enforcement is proven: an impossible threshold correctly fails (`statements (99.57%) does not meet ... threshold (100%)`), the real thresholds pass.

### 2. Playwright reader smoke test
`e2e/reader.spec.ts` opens the reader and asserts:
- the audio dock lists **all 8 reciters**
- **selecting** a reciter persists the choice (`localStorage`)
- **playing** an āyah fetches **that reciter's** recitation (the `audio=10` timing request for Saud Al-Shuraim)

External audio (quran.com / everyayah) is **stubbed via `page.route`**, so the test never depends on a CDN. A new parallel CI **`e2e`** job installs Chromium (`--with-deps`) and runs it.

## Verification

- ✅ `pnpm test:coverage` passes the new thresholds (and correctly fails when one is set impossibly high)
- ✅ `pnpm lint` · `typecheck` pass
- ⏳ **The e2e runs in CI** — Playwright's browser can't launch in my WSL dev env (missing system libs, no sudo), so the new `e2e` CI job is the source of truth for it. I'll confirm it's green on this PR.

## Follow-ups
More e2e flows (search, prayer-times geolocation), and ratcheting the web coverage threshold once it climbs.
