### PR TITLE
test(web): ratchet web coverage (lib helpers) + search & geolocation e2e flows

### DIFF
--- a/apps/web/src/lib/adhkar.test.ts
+++ b/apps/web/src/lib/adhkar.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { adhkarToday, readAdhkarCounts, writeAdhkarCounts } from "./adhkar";
+
+describe("adhkar daily counts", () => {
+  it("formats today as local YYYY-MM-DD", () => {
+    expect(adhkarToday(new Date(2026, 5, 3))).toBe("2026-06-03");
+  });
+
+  it("is empty by default", () => {
+    expect(readAdhkarCounts()).toEqual({});
+  });
+
+  it("round-trips today's tallies", () => {
+    writeAdhkarCounts({ a: 3, b: 1 });
+    expect(readAdhkarCounts()).toEqual({ a: 3, b: 1 });
+  });
+
+  it("resets when the stored day is not today", () => {
+    localStorage.setItem("ul.adhkar", JSON.stringify({ date: "2000-01-01", counts: { a: 5 } }));
+    expect(readAdhkarCounts()).toEqual({});
+  });
+});

--- a/apps/web/src/lib/collections.test.ts
+++ b/apps/web/src/lib/collections.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Collection } from "@ummahlibrary/core";
+import {
+  COLLECTIONS_EVENT,
+  newId,
+  readCollections,
+  readNote,
+  readNotes,
+  writeCollections,
+  writeNote,
+} from "./collections";
+
+describe("collections storage", () => {
+  it("starts empty", () => {
+    expect(readCollections()).toEqual([]);
+    expect(readNotes()).toEqual({});
+  });
+
+  it("round-trips collections and emits a change event", () => {
+    const handler = vi.fn();
+    window.addEventListener(COLLECTIONS_EVENT, handler);
+
+    const cols: Collection[] = [{ id: "c1", name: "Favourites", ayahs: [{ sura: 1, aya: 1 }] }];
+    writeCollections(cols);
+
+    expect(readCollections()).toEqual(cols);
+    expect(handler).toHaveBeenCalled();
+    window.removeEventListener(COLLECTIONS_EVENT, handler);
+  });
+
+  it("writes, reads, and clears a per-āyah note", () => {
+    const ref = { sura: 2, aya: 255 };
+    writeNote(ref, "Āyat al-Kursī");
+    expect(readNote(ref)).toBe("Āyat al-Kursī");
+
+    writeNote(ref, "   "); // blank clears it
+    expect(readNote(ref)).toBe("");
+  });
+
+  it("generates unique ids", () => {
+    expect(newId()).not.toBe(newId());
+  });
+});

--- a/apps/web/src/lib/hijri.test.ts
+++ b/apps/web/src/lib/hijri.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { HIJRI_ADJUST_KEY, readHijriAdjust, writeHijriAdjust } from "./hijri";
+
+describe("hijri adjustment", () => {
+  it("defaults to 0 when nothing is stored", () => {
+    expect(readHijriAdjust()).toBe(0);
+  });
+
+  it("round-trips a written value", () => {
+    writeHijriAdjust(1);
+    expect(readHijriAdjust()).toBe(1);
+    expect(localStorage.getItem(HIJRI_ADJUST_KEY)).toBe("1");
+  });
+
+  it("clamps to ±2 days", () => {
+    writeHijriAdjust(5);
+    expect(readHijriAdjust()).toBe(2);
+    writeHijriAdjust(-9);
+    expect(readHijriAdjust()).toBe(-2);
+  });
+
+  it("ignores a corrupt stored value", () => {
+    localStorage.setItem(HIJRI_ADJUST_KEY, "not-a-number");
+    expect(readHijriAdjust()).toBe(0);
+  });
+
+  it("broadcasts the change on write", () => {
+    const handler = vi.fn();
+    window.addEventListener(HIJRI_ADJUST_KEY, handler);
+    writeHijriAdjust(2);
+    expect(handler).toHaveBeenCalledOnce();
+    window.removeEventListener(HIJRI_ADJUST_KEY, handler);
+  });
+});

--- a/apps/web/src/lib/reading-goals.test.ts
+++ b/apps/web/src/lib/reading-goals.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_GOAL,
+  activeDates,
+  clearKhatma,
+  markActivity,
+  pagesToday,
+  readGoal,
+  readKhatma,
+  readingLog,
+  recordMushafPage,
+  today,
+  writeGoal,
+  writeKhatma,
+} from "./reading-goals";
+
+describe("reading-goals storage", () => {
+  it("formats today as local YYYY-MM-DD", () => {
+    expect(today(new Date(2026, 0, 9))).toBe("2026-01-09");
+  });
+
+  it("goal defaults to DEFAULT_GOAL and floors to >= 1", () => {
+    expect(readGoal()).toBe(DEFAULT_GOAL);
+    writeGoal(8);
+    expect(readGoal()).toBe(8);
+    writeGoal(0);
+    expect(readGoal()).toBe(DEFAULT_GOAL);
+  });
+
+  it("records today's activity exactly once", () => {
+    markActivity();
+    markActivity();
+    expect(activeDates()).toEqual([today()]);
+  });
+
+  it("logs distinct Mushaf pages read today and marks activity", () => {
+    recordMushafPage(3);
+    recordMushafPage(3); // duplicate — ignored
+    recordMushafPage(4);
+
+    expect(pagesToday()).toBe(2);
+    expect(readingLog()[today()]).toBe(2);
+    expect(activeDates()).toContain(today());
+  });
+
+  it("advances the khatma cursor as later pages are read, and clears", () => {
+    writeKhatma({ totalPages: 604, currentPage: 0, targetDate: "2030-01-01" });
+    recordMushafPage(10);
+    expect(readKhatma()?.currentPage).toBe(10);
+
+    clearKhatma();
+    expect(readKhatma()).toBeNull();
+  });
+});

--- a/apps/web/src/lib/tafsir.test.ts
+++ b/apps/web/src/lib/tafsir.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { TAFSIR_KEY, readTafsir, writeTafsir } from "./tafsir";
+
+describe("tafsir selection", () => {
+  it("returns the fallback when nothing is stored", () => {
+    expect(readTafsir("en-ibn-kathir")).toBe("en-ibn-kathir");
+  });
+
+  it("prefers the stored edition over the fallback", () => {
+    writeTafsir("ar-muyassar");
+    expect(readTafsir("en-ibn-kathir")).toBe("ar-muyassar");
+    expect(localStorage.getItem(TAFSIR_KEY)).toBe("ar-muyassar");
+  });
+
+  it("broadcasts the change on write", () => {
+    const handler = vi.fn();
+    window.addEventListener(TAFSIR_KEY, handler);
+    writeTafsir("x");
+    expect(handler).toHaveBeenCalledOnce();
+    window.removeEventListener(TAFSIR_KEY, handler);
+  });
+});

--- a/e2e/geolocation.spec.ts
+++ b/e2e/geolocation.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+// Central London — used as the mocked device location.
+const LONDON = { latitude: 51.5074, longitude: -0.1278 };
+
+test.describe("Location-aware tools", () => {
+  test("prayer times render after granting location", async ({ page, context }) => {
+    await context.grantPermissions(["geolocation"]);
+    await context.setGeolocation(LONDON);
+
+    await page.goto("/prayer-times");
+    await page.getByRole("button", { name: /Use my location/ }).click();
+
+    // The internal prayer-times API computes a schedule for the mocked location.
+    await expect(page.getByText("Next prayer")).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("qibla bearing renders after granting location", async ({ page, context }) => {
+    await context.grantPermissions(["geolocation"]);
+    await context.setGeolocation(LONDON);
+
+    await page.goto("/qibla");
+    await page.getByRole("button", { name: /Use my location/ }).click();
+
+    await expect(page.getByText("Qibla direction")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/\d+°/)).toBeVisible(); // e.g. "119° SE"
+  });
+});

--- a/e2e/geolocation.spec.ts
+++ b/e2e/geolocation.spec.ts
@@ -22,7 +22,8 @@ test.describe("Location-aware tools", () => {
     await page.goto("/qibla");
     await page.getByRole("button", { name: /Use my location/ }).click();
 
-    await expect(page.getByText("Qibla direction")).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText(/\d+°/)).toBeVisible(); // e.g. "119° SE"
+    // `exact` avoids also matching the <title> "Qibla direction · Ummah Library".
+    await expect(page.getByText("Qibla direction", { exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/\d+° [NESW]/).first()).toBeVisible(); // e.g. "119° SE"
   });
 });

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Search", () => {
+  test("loads suggestions and returns matching verses", async ({ page }) => {
+    // Stub the two index sources so the test owns the corpus (no external deps).
+    await page.route(/\/api\/v1\/search\/corpus/, (route) =>
+      route.fulfill({ json: { verses: [{ s: 112, a: 1, t: "قُلْ هُوَ اللَّهُ أَحَدٌ" }] } }),
+    );
+    await page.route(/eng-mustafakhattaba/, (route) =>
+      route.fulfill({
+        json: { quran: [{ chapter: 112, verse: 1, text: "Say, He is Allah, the One." }] },
+      }),
+    );
+
+    await page.goto("/search");
+
+    // Suggested pills appear once the index is ready.
+    await expect(page.getByRole("button", { name: "Mercy" })).toBeVisible();
+
+    // A query matching the fixture returns a result.
+    await page.getByRole("searchbox").fill("Allah");
+    await expect(page.getByText(/result/)).toBeVisible();
+    await expect(page.getByText(/He is Allah/)).toBeVisible();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,12 +33,15 @@ export default defineConfig({
         "packages/core/src/entities.ts",
         "packages/core/src/ports.ts",
       ],
-      // Gate the logic libraries (set a little below current to absorb churn).
-      // No web/global threshold yet — that's a ratcheting baseline.
+      // Thresholds are set a little below current so they absorb churn but can
+      // only be RAISED (a ratchet). Bump the web floors as more tests land.
       thresholds: {
         "packages/core/src/**": { statements: 95, branches: 88, functions: 95, lines: 95 },
         "packages/data/src/**": { statements: 85, branches: 78, functions: 72, lines: 85 },
         "packages/adapters/src/**": { statements: 95, branches: 82, functions: 90, lines: 95 },
+        // Web client — a growing baseline.
+        "apps/web/src/lib/**": { statements: 30, branches: 70, functions: 85, lines: 30 },
+        "apps/web/src/components/**": { statements: 2, branches: 25, functions: 8, lines: 2 },
       },
     },
   },


### PR DESCRIPTION
## What

Builds on the coverage gates + e2e harness:

### Web coverage ratchet
- Unit-test the local-first `lib/` helpers: **hijri, tafsir, adhkar, collections, reading-goals** (round-trips, daily reset, clamping, khatma-cursor advance, change events).
- `apps/web/src/lib` goes **0% → ~31% statements / ~74% branches / ~92% functions**.
- Add **web coverage thresholds as a ratchet floor** (`lib` 30/70/85, `components` 2/25/8) — set just below current so they can only be raised. Bump as more tests land.

### New e2e flows
- **Search** — stubs the index sources, then asserts suggested pills load and a query returns a matching verse.
- **Geolocation** — mocks the device location (`context.setGeolocation`) and asserts the **prayer-times** schedule renders (real internal API computes for the mocked spot) and the **qibla** bearing appears.

Now 3 e2e specs (reader, search, geolocation) in the CI `e2e` job.

## Verification

- ✅ `pnpm test:coverage` — **211 tests**, all thresholds pass (incl. the new web floors)
- ✅ `pnpm lint` · `typecheck` pass
- ⏳ e2e verified in CI (Playwright can't launch in my WSL env) — I'll confirm the `e2e` job is green on this PR.
