### PR TITLE
test(web): Zakat + shell + Logo/Btn coverage, reader-mode & home-nav e2e

### DIFF
--- a/apps/web/src/components/ZakatCalculator.test.tsx
+++ b/apps/web/src/components/ZakatCalculator.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ZakatCalculator } from "./ZakatCalculator";
+
+describe("ZakatCalculator", () => {
+  it("computes 2.5% on net wealth once prices set the niṣāb", async () => {
+    render(<ZakatCalculator />);
+
+    await userEvent.type(screen.getByPlaceholderText("e.g. 75"), "75"); // gold price / gram
+    await userEvent.type(screen.getByPlaceholderText("e.g. 0.85"), "0.85"); // silver price / gram
+    await userEvent.type(screen.getAllByPlaceholderText("0")[0]!, "10000"); // cash & bank
+
+    expect(screen.getByText("$250.00")).toBeInTheDocument(); // 2.5% of 10,000
+    // Total assets and Net zakatable both read $10,000.00 (no liabilities).
+    expect(screen.getAllByText("$10,000.00").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/noor/Btn.test.tsx
+++ b/apps/web/src/components/noor/Btn.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Btn } from "./Btn";
+
+describe("Btn", () => {
+  it("renders its children and fires onClick", async () => {
+    const onClick = vi.fn();
+    render(<Btn onClick={onClick}>Open the app</Btn>);
+
+    await userEvent.click(screen.getByRole("button", { name: /Open the app/ }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders an icon alongside the label when given one", () => {
+    render(
+      <Btn icon="book" variant="ghost">
+        Start reading
+      </Btn>,
+    );
+    const button = screen.getByRole("button", { name: /Start reading/ });
+    expect(button.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/noor/Logo.test.tsx
+++ b/apps/web/src/components/noor/Logo.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Logo } from "./Logo";
+
+describe("Logo", () => {
+  it("renders the wordmark and the Khatam star", () => {
+    const { container } = render(<Logo />);
+
+    // The wordmark splits "Ummah" + " Library" across nested spans.
+    expect(container.textContent).toContain("Ummah");
+    expect(container.textContent).toContain("Library");
+    // The Khatam motif is an inline SVG.
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("fires onClick when provided", async () => {
+    const onClick = vi.fn();
+    const { container } = render(<Logo onClick={onClick} />);
+
+    await userEvent.click(container.firstElementChild as Element);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/shell/Sidebar.test.tsx
+++ b/apps/web/src/components/shell/Sidebar.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({ usePathname: () => "/" }));
+
+import { Sidebar } from "./Sidebar";
+
+describe("Sidebar", () => {
+  it("renders the nav groups and items", () => {
+    render(<Sidebar />);
+
+    expect(screen.getByText("Read")).toBeInTheDocument();
+    expect(screen.getByText("Worship")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Quran/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Prayer Times/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /99 Names/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Settings/ })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shell/TabBar.test.tsx
+++ b/apps/web/src/components/shell/TabBar.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({ usePathname: () => "/" }));
+
+import { TabBar } from "./TabBar";
+
+describe("TabBar", () => {
+  it("renders all five tabs", () => {
+    render(<TabBar />);
+    for (const label of ["Home", "Read", "Tools", "Hifz", "More"]) {
+      expect(screen.getByRole("link", { name: new RegExp(label) })).toBeInTheDocument();
+    }
+  });
+});

--- a/e2e/home-nav.spec.ts
+++ b/e2e/home-nav.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Home navigation", () => {
+  test("opening a surah from the home list lands in the reader", async ({ page }) => {
+    await page.goto("/");
+
+    // The surah index lists Al-Fātiḥah ("The Opening").
+    const opening = page.getByRole("link", { name: /The Opening/ });
+    await expect(opening).toBeVisible();
+    await opening.click();
+
+    // We land on the surah-1 reader, with its mode chrome present.
+    await expect(page).toHaveURL(/\/surah\/1$/);
+    await expect(page.getByRole("button", { name: "Verse" })).toBeVisible();
+  });
+});

--- a/e2e/reader-modes.spec.ts
+++ b/e2e/reader-modes.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+const readingMode = (page: Page) =>
+  page.evaluate(() => document.documentElement.dataset.readingMode);
+
+test.describe("Reader display modes", () => {
+  test("switching Verse / Reading / Mushaf drives the document reading mode", async ({ page }) => {
+    await page.goto("/surah/1");
+
+    // Default view is verse-by-verse translation.
+    await expect(page.getByRole("button", { name: "Verse" })).toBeVisible();
+    await expect.poll(() => readingMode(page)).toBe("translation");
+
+    // Mushaf → continuous Arabic with inline translations.
+    await page.getByRole("button", { name: "Mushaf" }).click();
+    await expect.poll(() => readingMode(page)).toBe("reading-tr");
+
+    // Reading → continuous Arabic only.
+    await page.getByRole("button", { name: "Reading" }).click();
+    await expect.poll(() => readingMode(page)).toBe("reading");
+
+    // The choice survives a reload (persisted to localStorage).
+    await page.reload();
+    await expect.poll(() => readingMode(page)).toBe("reading");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
         "packages/adapters/src/**": { statements: 95, branches: 82, functions: 90, lines: 95 },
         // Web client — a growing baseline, ratcheted as tests land.
         "apps/web/src/lib/**": { statements: 55, branches: 73, functions: 95, lines: 55 },
-        "apps/web/src/components/**": { statements: 10, branches: 50, functions: 25, lines: 10 },
+        "apps/web/src/components/**": { statements: 16, branches: 65, functions: 34, lines: 16 },
       },
     },
   },


### PR DESCRIPTION
## What

Another ratchet round of web UI coverage + Playwright flows.

**Component tests (Vitest + Testing Library):**
- `ZakatCalculator` — 2.5% on net wealth once gold/silver prices set the niṣāb
- `Sidebar` — nav groups (Read / Worship) and key links render
- `TabBar` — all five mobile tabs render
- `Logo` — wordmark + Khatam star render; `onClick` fires
- `Btn` — children + `onClick`; icon variant emits an svg

**E2E (Playwright):**
- `reader-modes.spec.ts` — Verse/Reading/Mushaf drive `documentElement.dataset.readingMode` and the choice survives reload
- `home-nav.spec.ts` — opening "The Opening" from the home list lands on `/surah/1` with reader chrome present

**Coverage gate:** web component floor ratcheted `10/50/25/10` → `16/65/34/16`.

## Verification
- `pnpm lint` ✅ · `pnpm typecheck` ✅
- web tests: **53 pass / 20 files** ✅
- `pnpm test:coverage` exit 0 with the raised floor ✅
- Local `pnpm build` only fails on Google-Fonts fetch (sandbox egress); CI/Vercel build with network. E2E is verified in the CI `e2e` job (WSL can't run browsers locally).

No app/runtime code changed — tests, e2e specs, and one coverage-threshold bump only.