### PR TITLE
test(web): QiblaCompass + DataBackup unit tests, hifz & tasbih e2e

### DIFF
--- a/apps/web/src/components/DataBackup.test.tsx
+++ b/apps/web/src/components/DataBackup.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DataBackup } from "./DataBackup";
+
+describe("DataBackup", () => {
+  it("explains the merge strategy and switches copy when toggled", async () => {
+    render(<DataBackup />);
+
+    // Defaults to "replace".
+    expect(screen.getByText(/fully restores your data/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Keep mine on conflict" }));
+
+    expect(screen.getByText(/only fills in things you don/)).toBeInTheDocument();
+    expect(screen.queryByText(/fully restores your data/)).not.toBeInTheDocument();
+  });
+
+  it("counts only the ul.* items stored on this device", async () => {
+    localStorage.setItem("ul.alpha", "1");
+    localStorage.setItem("ul.beta", "2");
+    localStorage.setItem("other.key", "ignored"); // not ul.* — excluded from the count
+
+    render(<DataBackup />);
+
+    // The count is read after mount to avoid a hydration mismatch.
+    expect(await screen.findByText(/2 items stored on this device/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/QiblaCompass.test.tsx
+++ b/apps/web/src/components/QiblaCompass.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QiblaCompass } from "./QiblaCompass";
+
+const COORDS_KEY = "ul.prayerCoords";
+const london = { latitude: 51.5074, longitude: -0.1278 };
+
+afterEach(() => {
+  // Remove any geolocation stub a test installed.
+  delete (navigator as { geolocation?: unknown }).geolocation;
+});
+
+describe("QiblaCompass", () => {
+  it("prompts for a location when none is saved", () => {
+    render(<QiblaCompass />);
+
+    expect(screen.getByRole("button", { name: /Use my location/ })).toBeInTheDocument();
+    expect(screen.queryByText("Qibla direction")).not.toBeInTheDocument();
+  });
+
+  it("renders the qibla bearing from a saved location", () => {
+    localStorage.setItem(COORDS_KEY, JSON.stringify(london));
+    render(<QiblaCompass />);
+
+    expect(screen.getByText("Qibla direction")).toBeInTheDocument();
+    // Bearing renders as "<degrees>° <cardinal>", e.g. "119° ESE".
+    expect(screen.getByText(/^\d+° [NESW]+$/)).toBeInTheDocument();
+    // The Kaaba marker sits on the needle.
+    expect(screen.getByText("🕋")).toBeInTheDocument();
+  });
+
+  it("locates the user and persists the coordinates on demand", async () => {
+    const getCurrentPosition = vi.fn((success: PositionCallback) =>
+      success({ coords: london } as GeolocationPosition),
+    );
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      value: { getCurrentPosition },
+    });
+
+    render(<QiblaCompass />);
+    await userEvent.click(screen.getByRole("button", { name: /Use my location/ }));
+
+    expect(getCurrentPosition).toHaveBeenCalledOnce();
+    expect(screen.getByText("Qibla direction")).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem(COORDS_KEY)!)).toMatchObject(london);
+  });
+});

--- a/e2e/hifz.spec.ts
+++ b/e2e/hifz.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Hifz memorization", () => {
+  test("adding an āyah from the reader makes it due, and rating clears it", async ({ page }) => {
+    await page.goto("/surah/1");
+
+    // Track the first āyah for memorization; the button flips state.
+    const add = page.getByRole("button", { name: /Hifz/ }).first();
+    await add.click();
+    await expect(page.getByRole("button", { name: /Memorizing/ }).first()).toBeVisible();
+
+    // It now appears on the review page, due immediately (a fresh card is due now).
+    await page.goto("/hifz");
+    await expect(page.getByText(/Reviewing 1 \/ 1 due/)).toBeVisible();
+
+    // Reveal and rate it — the queue empties.
+    await page.getByRole("button", { name: /Reveal/ }).click();
+    await page.getByRole("button", { name: "Good" }).click();
+    await expect(page.getByText(/All caught up/)).toBeVisible();
+  });
+});

--- a/e2e/tasbih.spec.ts
+++ b/e2e/tasbih.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Tasbih counter", () => {
+  test("counts taps and remembers them across reloads", async ({ page }) => {
+    await page.goto("/tasbih");
+
+    // The dial is a button whose accessible name tracks the running count.
+    const dial = page.getByRole("button", { name: /Count/ });
+    await dial.click();
+    await dial.click();
+    await dial.click();
+    await expect(page.getByRole("button", { name: /Count.*3 of/ })).toBeVisible();
+
+    // The count survives a reload (persisted to localStorage).
+    await page.reload();
+    await expect(page.getByRole("button", { name: /Count.*3 of/ })).toBeVisible();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
         "packages/adapters/src/**": { statements: 95, branches: 82, functions: 90, lines: 95 },
         // Web client — a growing baseline, ratcheted as tests land.
         "apps/web/src/lib/**": { statements: 55, branches: 73, functions: 95, lines: 55 },
-        "apps/web/src/components/**": { statements: 16, branches: 65, functions: 34, lines: 16 },
+        "apps/web/src/components/**": { statements: 20, branches: 66, functions: 37, lines: 20 },
       },
     },
   },


### PR DESCRIPTION
## What

Round 4 of the coverage ratchet — components + e2e.

**Component tests (Vitest + Testing Library):**
- `QiblaCompass` — prompts when no location; renders the bearing from a saved location; `navigator.geolocation` locate path persists coords
- `DataBackup` — merge-strategy copy toggles (replace ↔ keep-mine); item count includes only `ul.*` keys

**E2E (Playwright):**
- `hifz.spec.ts` — add an āyah from the reader → it's due on /hifz → reveal → rate Good → queue clears
- `tasbih.spec.ts` — tap the dial 3× → count shows 3 and survives a reload

**Coverage gate:** web component floor ratcheted `16/65/34/16` → `20/66/37/20`.

## Verification
- `pnpm lint` ✅ · `pnpm typecheck` ✅
- web tests: **58 pass / 22 files** ✅
- `pnpm test:coverage` exit 0 with the raised floor ✅
- E2E runs in CI (WSL can't launch browsers locally). Local build only fails on the Google-Fonts fetch (sandbox egress); CI/Vercel build with network.

Tests, e2e specs, and one coverage-threshold bump only — no app/runtime code changed.