### PR TITLE
test(web): ThemeToggle/HifzButton/HijriToday/TopBar units + backup e2e

### DIFF
--- a/apps/web/src/components/HifzButton.test.tsx
+++ b/apps/web/src/components/HifzButton.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { isTracked } from "../lib/hifz-store";
+import { HifzButton } from "./HifzButton";
+
+describe("HifzButton", () => {
+  it("toggles memorization tracking for an āyah, persisting both ways", async () => {
+    render(<HifzButton surah={2} aya={255} />);
+    const btn = screen.getByRole("button");
+
+    // Starts untracked.
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+    expect(isTracked({ sura: 2, aya: 255 })).toBe(false);
+
+    // First tap tracks it.
+    await userEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+    expect(isTracked({ sura: 2, aya: 255 })).toBe(true);
+
+    // Second tap removes it.
+    await userEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+    expect(isTracked({ sura: 2, aya: 255 })).toBe(false);
+  });
+});

--- a/apps/web/src/components/HijriToday.test.tsx
+++ b/apps/web/src/components/HijriToday.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HijriToday } from "./HijriToday";
+
+describe("HijriToday", () => {
+  it("renders today's Hijri date as a link to the calendar", () => {
+    render(<HijriToday />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/calendar");
+    expect(link).toHaveTextContent("🌙");
+    // The formatted label carries a Hijri year (3–4 digits).
+    expect(link).toHaveTextContent(/\d{3,4}/);
+  });
+});

--- a/apps/web/src/components/ThemeToggle.test.tsx
+++ b/apps/web/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeToggle } from "./ThemeToggle";
+
+describe("ThemeToggle", () => {
+  it("toggles the document theme and persists the choice", async () => {
+    document.documentElement.dataset.theme = "dark";
+    render(<ThemeToggle />);
+
+    // Dark by default → the control offers to switch to light.
+    await userEvent.click(screen.getByRole("button", { name: /Switch to light theme/ }));
+
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(localStorage.getItem("ul.theme")).toBe("light");
+    expect(screen.getByRole("button", { name: /Switch to dark theme/ })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shell/TopBar.test.tsx
+++ b/apps/web/src/components/shell/TopBar.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Capture router.push; usePathname stays on the Hub so focus doesn't navigate.
+const { push } = vi.hoisted(() => ({ push: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => "/",
+}));
+
+import { SearchProvider } from "./SearchContext";
+import { TopBar } from "./TopBar";
+
+describe("TopBar", () => {
+  it("submitting the search navigates to the results page", async () => {
+    render(
+      <SearchProvider>
+        <TopBar />
+      </SearchProvider>,
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/Search the Quran/), "mercy{Enter}");
+
+    expect(push).toHaveBeenCalledWith("/search?q=mercy");
+  });
+});

--- a/e2e/settings-backup.spec.ts
+++ b/e2e/settings-backup.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Settings — data backup", () => {
+  test("exports a backup file and imports it back", async ({ page }) => {
+    // Seed some local-first data so there's something to back up.
+    await page.addInitScript(() => {
+      localStorage.setItem("ul.readingGoal", "5");
+      localStorage.setItem("ul.theme", "dark");
+    });
+
+    await page.goto("/settings");
+
+    // The card reports how many items are stored on this device.
+    await expect(page.getByText(/\d+ items? stored on this device/)).toBeVisible();
+
+    // Export → capture the downloaded JSON file.
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByRole("button", { name: /Export my data/ }).click(),
+    ]);
+    const path = await download.path();
+    expect(path).toBeTruthy();
+
+    // Re-import the same file via the (hidden) file input → success status.
+    await page.locator('input[type="file"]').setInputFiles(path);
+    await expect(page.getByText(/Restored \d+ items/)).toBeVisible();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
         "packages/adapters/src/**": { statements: 95, branches: 82, functions: 90, lines: 95 },
         // Web client — a growing baseline, ratcheted as tests land.
         "apps/web/src/lib/**": { statements: 55, branches: 73, functions: 95, lines: 55 },
-        "apps/web/src/components/**": { statements: 20, branches: 66, functions: 37, lines: 20 },
+        "apps/web/src/components/**": { statements: 21, branches: 69, functions: 43, lines: 21 },
       },
     },
   },


### PR DESCRIPTION
## What

Round 5 of the coverage ratchet — components + e2e.

**Component tests (Vitest + Testing Library):**
- `ThemeToggle` — toggles `documentElement.dataset.theme` and persists `ul.theme`
- `HifzButton` — per-āyah tracking toggles `aria-pressed` and the hifz store both ways
- `HijriToday` — renders today's Hijri date as a link to /calendar
- `TopBar` — submitting search routes to `/search?q=…` (wrapped in `SearchProvider`, navigation mocked)

**E2E (Playwright):**
- `settings-backup.spec.ts` — /settings shows the item count, **Export** downloads the backup JSON, and re-importing it via the hidden file input reports `Restored N items`

**Coverage gate:** web component floor ratcheted `20/66/37/20` → `21/69/43/21` (functions +6pts).

## Verification
- `pnpm lint` ✅ · `pnpm typecheck` ✅
- web tests: **62 pass / 26 files** ✅
- `pnpm test:coverage` exit 0 with the raised floor ✅
- E2E runs in CI (browsers can't launch in WSL locally). Local build only fails on the Google-Fonts fetch (sandbox egress); CI/Vercel build with network.

Tests, e2e specs, and one coverage-threshold bump only — no app/runtime code changed.