### PR TITLE
test(web): TafsirPicker/ReadingModeToggle/VerseOfDay units + calendar e2e

### DIFF
--- a/apps/web/src/components/ReadingModeToggle.test.tsx
+++ b/apps/web/src/components/ReadingModeToggle.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReadingModeToggle } from "./ReadingModeToggle";
+
+describe("ReadingModeToggle", () => {
+  it("switches reading mode, reflecting it on <html> and in storage", async () => {
+    document.documentElement.dataset.readingMode = "translation";
+    render(<ReadingModeToggle />);
+
+    // Defaults to verse-by-verse.
+    expect(screen.getByRole("button", { name: "Verse by verse" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // Switch to continuous reading (Arabic only).
+    await userEvent.click(screen.getByRole("button", { name: "Reading" }));
+    expect(document.documentElement.dataset.readingMode).toBe("reading");
+    expect(localStorage.getItem("ul.readingMode")).toBe("reading");
+
+    // The sub-control now offers Arabic + translations.
+    await userEvent.click(screen.getByRole("button", { name: "Translations" }));
+    expect(document.documentElement.dataset.readingMode).toBe("reading-tr");
+    expect(localStorage.getItem("ul.readingMode")).toBe("reading-tr");
+  });
+});

--- a/apps/web/src/components/TafsirPicker.test.tsx
+++ b/apps/web/src/components/TafsirPicker.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { readTafsir } from "../lib/tafsir";
+import { TafsirPicker } from "./TafsirPicker";
+
+const tafsirs = [
+  { id: "en-jalalayn", name: "Jalālayn" },
+  { id: "en-ibn-kathir", name: "Ibn Kathīr" },
+];
+
+describe("TafsirPicker", () => {
+  it("renders nothing when there's only one tafsir to choose", () => {
+    const { container } = render(<TafsirPicker tafsirs={[tafsirs[0]!]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("persists the chosen tafsir edition", async () => {
+    render(<TafsirPicker tafsirs={tafsirs} />);
+
+    const select = screen.getByLabelText("Tafsir edition") as HTMLSelectElement;
+    await userEvent.selectOptions(select, "en-ibn-kathir");
+
+    expect(select.value).toBe("en-ibn-kathir");
+    expect(readTafsir("")).toBe("en-ibn-kathir");
+  });
+});

--- a/apps/web/src/components/VerseOfDay.test.tsx
+++ b/apps/web/src/components/VerseOfDay.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { VerseOfDay } from "./VerseOfDay";
+
+describe("VerseOfDay", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("shows the label immediately, then the fetched āyah and a link", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          ayah: { text: "ٱلْحَمْدُ لِلَّٰهِ رَبِّ ٱلْعَٰلَمِينَ" },
+          translation: { text: "All praise is for Allah—Lord of all worlds." },
+        }),
+      })),
+    );
+
+    render(<VerseOfDay />);
+
+    // The label renders even while the verse is loading.
+    expect(screen.getByText("Verse of the day")).toBeInTheDocument();
+
+    // Once the fetch resolves, the āyah, its translation, and a deep link appear.
+    await waitFor(() =>
+      expect(
+        screen.getByText("All praise is for Allah—Lord of all worlds."),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/ٱلْحَمْدُ/)).toBeInTheDocument();
+    expect(screen.getByRole("link").getAttribute("href")).toMatch(/\/surah\/\d+#/);
+  });
+});

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Hijri calendar", () => {
+  test("renders the current month and navigates between months", async ({ page }) => {
+    await page.goto("/calendar");
+
+    // Scope to the nav row holding the Prev/Next buttons so we target the month
+    // heading — not the app header's (unchanging) "today" Hijri label.
+    const navRow = page
+      .locator("div")
+      .filter({ has: page.getByRole("button", { name: "Next month" }) })
+      .filter({ has: page.getByRole("button", { name: "Previous month" }) })
+      .last();
+    const heading = navRow.getByText(/\d{3,4} AH/);
+
+    await expect(heading).toBeVisible();
+    const before = (await heading.textContent())!;
+
+    // Stepping forward a month changes the heading.
+    await page.getByRole("button", { name: "Next month" }).click();
+    await expect.poll(async () => await heading.textContent()).not.toBe(before);
+
+    // Stepping back returns to where we started.
+    await page.getByRole("button", { name: "Previous month" }).click();
+    await expect.poll(async () => await heading.textContent()).toBe(before);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
         "packages/adapters/src/**": { statements: 95, branches: 82, functions: 90, lines: 95 },
         // Web client — a growing baseline, ratcheted as tests land.
         "apps/web/src/lib/**": { statements: 55, branches: 73, functions: 95, lines: 55 },
-        "apps/web/src/components/**": { statements: 21, branches: 69, functions: 43, lines: 21 },
+        "apps/web/src/components/**": { statements: 24, branches: 71, functions: 48, lines: 24 },
       },
     },
   },


### PR DESCRIPTION
## What

Round 6 of the coverage ratchet — components + e2e.

**Component tests (Vitest + Testing Library):**
- `TafsirPicker` — hidden with a single edition; persists the chosen edition via `writeTafsir`
- `ReadingModeToggle` — Verse/Reading/Translations drive `html[data-reading-mode]` and `ul.readingMode`
- `VerseOfDay` — renders the label immediately, then the fetched āyah + translation + deep link (fetch stubbed)

**E2E (Playwright):**
- `calendar.spec.ts` — /calendar shows the current Hijri month and Next/Previous month navigation round-trips the heading

**Coverage gate:** web component floor ratcheted `21/69/43/21` → `24/71/48/24` (functions now ~half).

## Verification
- `pnpm lint` ✅ · `pnpm typecheck` ✅
- web tests: **66 pass / 29 files** ✅
- `pnpm test:coverage` exit 0 with the raised floor ✅
- E2E runs in CI (browsers can't launch in WSL locally). Local build only fails on the Google-Fonts fetch (sandbox egress); CI/Vercel build with network.

Tests, e2e specs, and one coverage-threshold bump only — no app/runtime code changed.