### PR TITLE
test(web): AdhkarView/SurahIndex units + adhkar & save-collection e2e

### DIFF
--- a/apps/web/src/components/AdhkarView.test.tsx
+++ b/apps/web/src/components/AdhkarView.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Dhikr } from "@ummahlibrary/core";
+import { readAdhkarCounts } from "../lib/adhkar";
+import { AdhkarView } from "./AdhkarView";
+
+const dhikr: Dhikr[] = [
+  {
+    id: "ayat-al-kursi",
+    order: 1,
+    occasions: ["morning", "evening"],
+    arabic: "ٱللَّٰهُ لَآ إِلَٰهَ إِلَّا هُوَ",
+    translation: "Allah — there is no deity except Him.",
+    transliteration: "Ayat al-Kursi",
+    repeat: 1,
+    repeatLabel: "Once",
+    source: "Al-Baqarah 2:255",
+  },
+  {
+    id: "tasbih",
+    order: 2,
+    occasions: ["morning"],
+    arabic: "سُبْحَانَ ٱللَّٰهِ وَبِحَمْدِهِ",
+    translation: "Glory and praise be to Allah.",
+    transliteration: "Subhan Allah wa bihamdihi",
+    repeat: 3,
+    repeatLabel: "3×",
+  },
+  {
+    id: "evening-only",
+    order: 3,
+    occasions: ["evening"],
+    arabic: "أَمْسَيْنَا وَأَمْسَى ٱلْمُلْكُ لِلَّٰهِ",
+    translation: "We have reached the evening and so has the dominion of Allah.",
+    transliteration: "Amsayna wa amsa l-mulku lillah",
+    repeat: 1,
+    repeatLabel: "Once",
+  },
+];
+
+describe("AdhkarView", () => {
+  it("counts a dhikr to completion and persists the progress", async () => {
+    render(<AdhkarView dhikr={dhikr} />);
+
+    // Morning is the default set: two items, none done.
+    expect(screen.getByText("0 / 2 done")).toBeInTheDocument();
+
+    // Tapping the once-repeat dhikr completes it and bumps progress.
+    await userEvent.click(screen.getByRole("button", { name: /Ayat al-Kursi/ }));
+    expect(screen.getByText("1 / 2 done")).toBeInTheDocument();
+    expect(readAdhkarCounts()["ayat-al-kursi"]).toBe(1);
+  });
+
+  it("switches between the morning and evening sets", async () => {
+    render(<AdhkarView dhikr={dhikr} />);
+
+    // Morning contains the tasbīḥ; evening does not.
+    expect(screen.getByRole("button", { name: /Subhan Allah/ })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("tab", { name: /Evening/ }));
+
+    expect(screen.queryByRole("button", { name: /Subhan Allah/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Amsayna/ })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/SurahIndex.test.tsx
+++ b/apps/web/src/components/SurahIndex.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SurahIndex } from "./SurahIndex";
+
+const surahs = [
+  { number: 1, name: "الفاتحة", transliteration: "Al-Fātiḥah", englishName: "The Opening", ayahCount: 7 },
+  { number: 2, name: "البقرة", transliteration: "Al-Baqarah", englishName: "The Cow", ayahCount: 286 },
+  { number: 112, name: "الإخلاص", transliteration: "Al-Ikhlāṣ", englishName: "Sincerity", ayahCount: 4 },
+];
+
+describe("SurahIndex", () => {
+  it("filters by English meaning, number prefix, or name", async () => {
+    render(<SurahIndex surahs={surahs} />);
+    const search = screen.getByRole("searchbox", { name: "Search surahs" });
+
+    // By English meaning.
+    await userEvent.type(search, "cow");
+    expect(screen.getByRole("link", { name: /Al-Baqarah/ })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Al-Fātiḥah/ })).not.toBeInTheDocument();
+
+    // By surah number.
+    await userEvent.clear(search);
+    await userEvent.type(search, "112");
+    expect(screen.getByRole("link", { name: /Al-Ikhlāṣ/ })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Al-Baqarah/ })).not.toBeInTheDocument();
+
+    // No match → empty state.
+    await userEvent.clear(search);
+    await userEvent.type(search, "zzz");
+    expect(screen.getByText(/No surahs match/)).toBeInTheDocument();
+  });
+});

--- a/e2e/adhkar.spec.ts
+++ b/e2e/adhkar.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Adhkar counter", () => {
+  test("counts a dhikr, persists it across reload, and switches sets", async ({ page }) => {
+    await page.goto("/adhkar");
+
+    const firstCard = page.locator("button.adhkar-card").first();
+    await expect(firstCard).toContainText(/0 \/ \d+/);
+
+    // Tapping the card advances its tally.
+    await firstCard.click();
+    await expect(firstCard).toContainText(/1 \/ \d+/);
+
+    // The tally survives a reload (kept on-device).
+    await page.reload();
+    await expect(page.locator("button.adhkar-card").first()).toContainText(/1 \/ \d+/);
+
+    // The Evening tab selects the evening set.
+    const evening = page.getByRole("tab", { name: /Evening/ });
+    await evening.click();
+    await expect(evening).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/e2e/save-collection.spec.ts
+++ b/e2e/save-collection.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Saving an āyah", () => {
+  test("creating a collection from the reader shows it in bookmarks", async ({ page }) => {
+    await page.goto("/surah/1");
+
+    // Open the save panel on the first āyah.
+    await page.getByRole("button", { name: /☆ Save/ }).first().click();
+
+    // Create a new collection — this also saves the current āyah into it.
+    await page.getByPlaceholder(/New collection/).first().fill("Reflections");
+    await page.getByRole("button", { name: "Add", exact: true }).first().click();
+
+    // The action now reflects the saved state.
+    await expect(page.getByRole("button", { name: /★ Saved/ }).first()).toBeVisible();
+
+    // The collection and its āyah appear on the bookmarks page.
+    await page.goto("/bookmarks");
+    await expect(page.locator("input.collection-name")).toHaveValue("Reflections");
+    await expect(page.getByText("1:1")).toBeVisible();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
         "packages/adapters/src/**": { statements: 95, branches: 82, functions: 90, lines: 95 },
         // Web client — a growing baseline, ratcheted as tests land.
         "apps/web/src/lib/**": { statements: 55, branches: 73, functions: 95, lines: 55 },
-        "apps/web/src/components/**": { statements: 24, branches: 71, functions: 48, lines: 24 },
+        "apps/web/src/components/**": { statements: 27, branches: 73, functions: 52, lines: 27 },
       },
     },
   },


### PR DESCRIPTION
## What

Round 7 of the coverage ratchet — components + e2e.

**Component tests (Vitest + Testing Library):**
- `AdhkarView` — taps a dhikr to completion (progress + persistence), and switches morning ↔ evening sets
- `SurahIndex` — search filters by English meaning, number prefix, and shows the empty state

**E2E (Playwright):**
- `adhkar.spec.ts` — tap a dhikr → tally advances → survives reload → Evening tab selects the evening set
- `save-collection.spec.ts` — from the reader, ☆ Save → create a collection → it (and the āyah) appear on /bookmarks (new ground — the existing bookmarks spec only renames a *seeded* collection)

**Coverage gate:** web component floor ratcheted `24/71/48/24` → `27/73/52/27`.

## Verification
- `pnpm lint` ✅ · `pnpm typecheck` ✅
- web tests: **69 pass / 31 files** ✅
- `pnpm test:coverage` exit 0 with the raised floor ✅
- E2E runs in CI (browsers can't launch in WSL locally). Local build only fails on the Google-Fonts fetch (sandbox egress); CI/Vercel build with network.

Tests, e2e specs, and one coverage-threshold bump only — no app/runtime code changed.