### PR TITLE
fix(web): make home Juzʾ and Revelation tabs change content

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,6 +13,7 @@ export default async function HomePage() {
         englishName: s.englishName,
         ayahCount: s.ayahCount,
         revelationPlace: s.revelationPlace,
+        revelationOrder: s.revelationOrder,
       }))}
     />
   );

--- a/apps/web/src/components/NoorHomePage.test.tsx
+++ b/apps/web/src/components/NoorHomePage.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NoorHomePage } from "./NoorHomePage";
+
+type Surah = Parameters<typeof NoorHomePage>[0]["surahs"][number];
+
+// Listed in surah-number order (1, 2, 96), but a different order of revelation —
+// Al-ʿAlaq (96) was revealed first. This lets us prove the Revelation tab
+// actually re-sorts rather than just re-styling the active chip.
+const surahs: Surah[] = [
+  {
+    number: 1,
+    name: "الفاتحة",
+    transliteration: "Al-Fātiḥah",
+    englishName: "The Opening",
+    ayahCount: 7,
+    revelationPlace: "meccan",
+    revelationOrder: 5,
+  },
+  {
+    number: 2,
+    name: "البقرة",
+    transliteration: "Al-Baqarah",
+    englishName: "The Cow",
+    ayahCount: 286,
+    revelationPlace: "medinan",
+    revelationOrder: 87,
+  },
+  {
+    number: 96,
+    name: "العلق",
+    transliteration: "Al-ʿAlaq",
+    englishName: "The Clot",
+    ayahCount: 19,
+    revelationPlace: "meccan",
+    revelationOrder: 1,
+  },
+];
+
+const juzLinks = () =>
+  screen
+    .getAllByRole("link")
+    .filter((a) => /^\/juz\/\d+$/.test(a.getAttribute("href") ?? ""));
+
+const positionOf = (re: RegExp) =>
+  screen.getAllByRole("link").findIndex((a) => re.test(a.textContent ?? ""));
+
+describe("NoorHomePage tabs", () => {
+  it("Surah tab lists surahs in order and shows no juzʾ links", () => {
+    render(<NoorHomePage surahs={surahs} />);
+
+    expect(juzLinks()).toHaveLength(0);
+    // by-number order: Al-Fātiḥah (1) precedes Al-ʿAlaq (96)
+    expect(positionOf(/Al-Fātiḥah/)).toBeLessThan(positionOf(/Al-ʿAlaq/));
+  });
+
+  it("Juzʾ tab reveals all 30 ajzāʾ, each linking to its reader", async () => {
+    render(<NoorHomePage surahs={surahs} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Juzʾ" }));
+
+    const hrefs = juzLinks().map((a) => a.getAttribute("href"));
+    expect(hrefs).toHaveLength(30);
+    expect(hrefs).toContain("/juz/1");
+    expect(hrefs).toContain("/juz/30");
+  });
+
+  it("Revelation tab re-orders surahs by order of revelation", async () => {
+    render(<NoorHomePage surahs={surahs} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Revelation" }));
+
+    // Al-ʿAlaq (revealed #1) now precedes Al-Fātiḥah (revealed #5).
+    expect(positionOf(/Al-ʿAlaq/)).toBeLessThan(positionOf(/Al-Fātiḥah/));
+    expect(screen.getByText(/Revealed #1\b/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/NoorHomePage.tsx
+++ b/apps/web/src/components/NoorHomePage.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useState } from "react";
+import { JUZ_STARTS, TOTAL_JUZ } from "@ummahlibrary/core";
 import { N, Khatam } from "./noor";
 import { useSearch } from "./shell/SearchContext";
 
@@ -11,6 +12,7 @@ interface Surah {
   englishName: string;
   ayahCount: number;
   revelationPlace: "meccan" | "medinan";
+  revelationOrder: number;
 }
 
 interface Props {
@@ -38,6 +40,29 @@ export function NoorHomePage({ surahs }: Props) {
           s.name.includes(query),
       )
     : surahs;
+
+  // Surah list for the active tab: natural order, or by order of revelation.
+  const surahList =
+    tab === "rev" ? [...filtered].sort((a, b) => a.revelationOrder - b.revelationOrder) : filtered;
+
+  // Juzʾ index — each juzʾ spans one or more surahs (mirrors /juz).
+  const byNumber = new Map(surahs.map((s) => [s.number, s]));
+  const juzEndSura = (n: number): number => {
+    if (n >= TOTAL_JUZ) return 114;
+    const next = JUZ_STARTS[n]!;
+    return next.aya > 1 ? next.sura : next.sura - 1;
+  };
+  const juzList = JUZ_STARTS.map((start, i) => {
+    const n = i + 1;
+    const first = byNumber.get(start.sura);
+    const lastSura = juzEndSura(n);
+    const last = byNumber.get(lastSura);
+    const span =
+      lastSura === start.sura
+        ? (first?.transliteration ?? "")
+        : `${first?.transliteration ?? ""} – ${last?.transliteration ?? ""}`;
+    return { n, span, name: first?.name ?? "" };
+  });
 
   return (
     <div
@@ -328,87 +353,173 @@ export function NoorHomePage({ surahs }: Props) {
           </div>
         </div>
 
-        {q && (
+        {q && tab !== "juz" && (
           <div style={{ fontSize: 13, color: N.faint, marginBottom: 12, fontFamily: N.ui }}>
-            {filtered.length} result{filtered.length !== 1 ? "s" : ""} for &ldquo;{query}&rdquo;
+            {surahList.length} result{surahList.length !== 1 ? "s" : ""} for &ldquo;{query}&rdquo;
           </div>
         )}
 
-        {/* Surah grid */}
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
-            gap: 12,
-          }}
-        >
-          {filtered.map((s) => (
-            <Link
-              key={s.number}
-              href={`/surah/${s.number}`}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 14,
-                padding: "12px 14px",
-                borderRadius: 12,
-                background: N.card,
-                border: `1px solid ${N.border}`,
-                textDecoration: "none",
-                transition: "border-color .15s, transform .12s",
-              }}
-            >
-              {/* Number badge */}
-              <div
+        {/* Juzʾ grid */}
+        {tab === "juz" && (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+              gap: 12,
+            }}
+          >
+            {juzList.map((j) => (
+              <Link
+                key={j.n}
+                href={`/juz/${j.n}`}
                 style={{
-                  width: 40,
-                  height: 40,
-                  flexShrink: 0,
-                  position: "relative",
-                  display: "grid",
-                  placeItems: "center",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 14,
+                  padding: "12px 14px",
+                  borderRadius: 12,
+                  background: N.card,
+                  border: `1px solid ${N.border}`,
+                  textDecoration: "none",
+                  transition: "border-color .15s, transform .12s",
                 }}
               >
-                <Khatam size={40} color={N.goldDim} sw={1.2} />
-                <span
-                  style={{
-                    position: "absolute",
-                    fontSize: 12.5,
-                    fontWeight: 700,
-                    color: N.gold,
-                    fontFamily: N.ui,
-                  }}
-                >
-                  {s.number}
-                </span>
-              </div>
-              <div style={{ minWidth: 0, flex: 1 }}>
+                {/* Number badge */}
                 <div
                   style={{
-                    fontSize: 15,
-                    fontWeight: 700,
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    color: N.fg,
-                    fontFamily: N.ui,
+                    width: 40,
+                    height: 40,
+                    flexShrink: 0,
+                    position: "relative",
+                    display: "grid",
+                    placeItems: "center",
                   }}
                 >
-                  {s.transliteration}
+                  <Khatam size={40} color={N.goldDim} sw={1.2} />
+                  <span
+                    style={{
+                      position: "absolute",
+                      fontSize: 12.5,
+                      fontWeight: 700,
+                      color: N.gold,
+                      fontFamily: N.ui,
+                    }}
+                  >
+                    {j.n}
+                  </span>
                 </div>
-                <div style={{ fontSize: 12.5, color: N.faint, fontFamily: N.ui }}>
-                  {s.englishName} · {s.ayahCount} ayahs ·{" "}
-                  {s.revelationPlace === "meccan" ? "Meccan" : "Medinan"}
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div
+                    style={{
+                      fontSize: 15,
+                      fontWeight: 700,
+                      color: N.fg,
+                      fontFamily: N.ui,
+                    }}
+                  >
+                    Juzʾ {j.n}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 12.5,
+                      color: N.faint,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      fontFamily: N.ui,
+                    }}
+                  >
+                    {j.span}
+                  </div>
                 </div>
-              </div>
-              <div className="noor-ar" style={{ fontSize: 22, color: N.muted, flexShrink: 0 }}>
-                {s.name}
-              </div>
-            </Link>
-          ))}
-        </div>
+                <div className="noor-ar" style={{ fontSize: 22, color: N.muted, flexShrink: 0 }}>
+                  {j.name}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
 
-        {filtered.length === 0 && (
+        {/* Surah grid (Surah order, or order of revelation) */}
+        {tab !== "juz" && (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+              gap: 12,
+            }}
+          >
+            {surahList.map((s) => (
+              <Link
+                key={s.number}
+                href={`/surah/${s.number}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 14,
+                  padding: "12px 14px",
+                  borderRadius: 12,
+                  background: N.card,
+                  border: `1px solid ${N.border}`,
+                  textDecoration: "none",
+                  transition: "border-color .15s, transform .12s",
+                }}
+              >
+                {/* Number badge */}
+                <div
+                  style={{
+                    width: 40,
+                    height: 40,
+                    flexShrink: 0,
+                    position: "relative",
+                    display: "grid",
+                    placeItems: "center",
+                  }}
+                >
+                  <Khatam size={40} color={N.goldDim} sw={1.2} />
+                  <span
+                    style={{
+                      position: "absolute",
+                      fontSize: 12.5,
+                      fontWeight: 700,
+                      color: N.gold,
+                      fontFamily: N.ui,
+                    }}
+                  >
+                    {tab === "rev" ? s.revelationOrder : s.number}
+                  </span>
+                </div>
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div
+                    style={{
+                      fontSize: 15,
+                      fontWeight: 700,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      color: N.fg,
+                      fontFamily: N.ui,
+                    }}
+                  >
+                    {s.transliteration}
+                  </div>
+                  <div style={{ fontSize: 12.5, color: N.faint, fontFamily: N.ui }}>
+                    {tab === "rev"
+                      ? `Revealed #${s.revelationOrder} · ${s.englishName}`
+                      : `${s.englishName} · ${s.ayahCount} ayahs · ${
+                          s.revelationPlace === "meccan" ? "Meccan" : "Medinan"
+                        }`}
+                  </div>
+                </div>
+                <div className="noor-ar" style={{ fontSize: 22, color: N.muted, flexShrink: 0 }}>
+                  {s.name}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+
+        {tab !== "juz" && surahList.length === 0 && (
           <div
             style={{
               textAlign: "center",


### PR DESCRIPTION
The home page "Juzʾ" and "Revelation" tabs only restyled the active chip — `filtered` ignored the `tab` state, so clicking them did nothing (they looked like broken links).

- Juzʾ tab now lists the 30 ajzāʾ, each linking to /juz/N (mirrors /juz)
- Revelation tab orders surahs by revelationOrder, labelled "Revealed #N"
- Thread revelationOrder from the home route into NoorHomePage

Add NoorHomePage.test.tsx asserting each tab changes the rendered output; the two new cases fail against the previous behaviour.

## What & why

<!-- What does this change do, and why? Link the issue it closes. -->

Closes #

## Checklist

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] `pnpm build` passes
- [ ] No module-boundary violations (`apps → packages` only; `core` imports nothing)
- [ ] Any Islamic content is attributed and flagged `needs-scholar-review` if applicable
