### PR TITLE
test(web): fix CI on main — hifz coverage + e2e

### DIFF
--- a/apps/web/src/lib/hifz-store.test.ts
+++ b/apps/web/src/lib/hifz-store.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "vitest";
 import type { HifzCard } from "@ummahlibrary/core";
-import { allRecords, dueRecords, getCard, isTracked, removeCard, setCard } from "./hifz-store";
+import {
+  allRecords,
+  cardStrength,
+  dueRecords,
+  getCard,
+  isTracked,
+  removeCard,
+  setCard,
+  surahProgressMap,
+} from "./hifz-store";
 
-const card = (due: string): HifzCard => ({
+const card = (due: string, opts: Partial<HifzCard> = {}): HifzCard => ({
   repetitions: 1,
   easeFactor: 2.5,
   intervalDays: 1,
   due,
   lastReviewed: null,
+  ...opts,
 });
 
 describe("hifz store", () => {
@@ -32,5 +42,43 @@ describe("hifz store", () => {
 
     const due = dueRecords(new Date("2026-06-11T00:00:00.000Z"));
     expect(due.map((r) => `${r.ref.sura}:${r.ref.aya}`)).toEqual(["2:1"]);
+  });
+
+  it("scores card strength from interval, capped at 1", () => {
+    // Never reviewed → no strength yet.
+    expect(cardStrength(card("2030-01-01T00:00:00.000Z"))).toBe(0);
+    // Reviewed, mid-interval → proportional.
+    expect(
+      cardStrength(card("2030-01-01T00:00:00.000Z", { lastReviewed: "2026-06-01T00:00:00.000Z", intervalDays: 15 })),
+    ).toBe(0.5);
+    // Long interval → capped at 1.
+    expect(
+      cardStrength(card("2030-01-01T00:00:00.000Z", { lastReviewed: "2026-06-01T00:00:00.000Z", intervalDays: 60 })),
+    ).toBe(1);
+  });
+
+  it("aggregates per-surah progress, due counts, strength and earliest due", () => {
+    const now = new Date("2026-06-14T00:00:00.000Z");
+    // Surah 2: one due+memorized (strength 1), one not-due+fresh (strength 0).
+    setCard(
+      { sura: 2, aya: 1 },
+      card("2000-01-01T00:00:00.000Z", { lastReviewed: "2026-06-01T00:00:00.000Z", intervalDays: 30 }),
+    );
+    setCard({ sura: 2, aya: 2 }, card("2099-01-01T00:00:00.000Z"));
+    // Surah 1: a single due card.
+    setCard({ sura: 1, aya: 1 }, card("2000-06-01T00:00:00.000Z"));
+
+    const map = surahProgressMap(now);
+
+    const s2 = map.get(2)!;
+    expect(s2.trackedCount).toBe(2);
+    expect(s2.dueCount).toBe(1);
+    expect(s2.avgStrength).toBe(0.5);
+    expect(s2.nextDue).toBe("2000-01-01T00:00:00.000Z");
+
+    const s1 = map.get(1)!;
+    expect(s1.trackedCount).toBe(1);
+    expect(s1.dueCount).toBe(1);
+    expect(s1.avgStrength).toBe(0);
   });
 });

--- a/apps/web/src/lib/hifz-streak.test.ts
+++ b/apps/web/src/lib/hifz-streak.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getStreak, touchStreak } from "./hifz-streak";
+
+describe("hifz streak", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("starts empty", () => {
+    expect(getStreak()).toEqual({ count: 0, lastDate: "" });
+  });
+
+  it("counts the first review as a one-day streak", () => {
+    vi.setSystemTime(new Date("2026-06-14T12:00:00.000Z"));
+    expect(touchStreak()).toEqual({ count: 1, lastDate: "2026-06-14" });
+    expect(getStreak().count).toBe(1);
+  });
+
+  it("is idempotent within the same day", () => {
+    vi.setSystemTime(new Date("2026-06-14T12:00:00.000Z"));
+    touchStreak();
+    expect(touchStreak()).toEqual({ count: 1, lastDate: "2026-06-14" });
+  });
+
+  it("increments on a consecutive day, resets after a gap", () => {
+    vi.setSystemTime(new Date("2026-06-14T12:00:00.000Z"));
+    touchStreak();
+
+    vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"));
+    expect(touchStreak().count).toBe(2);
+
+    // Skip the 16th — a missed day breaks the streak back to 1.
+    vi.setSystemTime(new Date("2026-06-17T12:00:00.000Z"));
+    expect(touchStreak().count).toBe(1);
+  });
+
+  it("returns the default when stored data is corrupt", () => {
+    localStorage.setItem("ul.hifz.streak", "not json");
+    expect(getStreak()).toEqual({ count: 0, lastDate: "" });
+  });
+});

--- a/e2e/hifz.spec.ts
+++ b/e2e/hifz.spec.ts
@@ -12,9 +12,13 @@ test.describe("Hifz memorization", () => {
     await page.getByRole("button", { name: "More" }).first().click();
     await expect(page.getByRole("button", { name: "Stop memorizing" })).toBeVisible();
 
-    // It now appears on the review page, due immediately (a fresh card is due now).
+    // The Hifz dashboard now lists it as due, with a review CTA.
     await page.goto("/hifz");
-    await expect(page.getByText(/Reviewing 1 \/ 1 due/)).toBeVisible();
+    await expect(page.getByText(/1 āyah ready for review/)).toBeVisible();
+
+    // Start the review session — the fresh card is due now.
+    await page.getByRole("link", { name: /Start review/ }).click();
+    await expect(page.getByText(/0 \/ 1/)).toBeVisible();
 
     // Reveal and rate it — the queue empties.
     await page.getByRole("button", { name: /Reveal/ }).click();


### PR DESCRIPTION
## Why

`main` CI has been failing since the Hifz dashboard work (#3afc72f → 359d684). Two breakages:

1. **Coverage gate** — `apps/web/src/lib/**` function coverage fell to **92.5%** (< 95%). The new `hifz-streak.ts` and the added `surahProgressMap`/`cardStrength` in `hifz-store.ts` were untested.
2. **E2E** — `e2e/hifz.spec.ts` still asserted the old in-page review UI (`Reviewing 1 / 1 due` at `/hifz`). The review session moved to `/hifz/review` behind a dashboard CTA.

## What

- Add `hifz-streak.test.ts` (empty / first day / idempotent / consecutive / gap / corrupt storage).
- Cover `cardStrength` and `surahProgressMap` in `hifz-store.test.ts`.
- Realign `e2e/hifz.spec.ts` to the dashboard → **Start review** → `/hifz/review` flow.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test:coverage` all pass locally — lib function coverage back to **96.34%**.
- E2E is verified by CI (Playwright can't run in the dev sandbox).