### PR TITLE
fix(web): make the home Verse of the day change daily

### DIFF
--- a/apps/web/src/components/HomeVerseOfDay.test.tsx
+++ b/apps/web/src/components/HomeVerseOfDay.test.tsx
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { HomeVerseOfDay } from "./HomeVerseOfDay";
+
+describe("HomeVerseOfDay", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("shows the label immediately, then the fetched āyah, translation and a named deep link", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          ayah: { text: "ٱلْحَمْدُ لِلَّٰهِ رَبِّ ٱلْعَٰلَمِينَ" },
+          translation: { text: "All praise is for Allah—Lord of all worlds." },
+        }),
+      })),
+    );
+
+    render(<HomeVerseOfDay nameOf={() => "Al-Fātiḥah"} />);
+
+    // The label renders even while the verse is loading.
+    expect(screen.getByText("Verse of the day")).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByText("All praise is for Allah—Lord of all worlds.")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/ٱلْحَمْدُ/)).toBeInTheDocument();
+
+    // The reference is prefixed with the surah name and links into the surah.
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toMatch(/\/surah\/\d+#/);
+    expect(screen.getByText(/^Al-Fātiḥah \d+:\d+$/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/HomeVerseOfDay.tsx
+++ b/apps/web/src/components/HomeVerseOfDay.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ayahKey, verseOfDay } from "@ummahlibrary/core";
+import { N } from "@ummahlibrary/ui";
+
+interface Loaded {
+  sura: number;
+  aya: number;
+  arabic: string;
+  translation: string | null;
+}
+
+/** Local calendar date as YYYY-MM-DD — the seed for the deterministic daily verse. */
+function today(): string {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+const cardStyle = {
+  borderRadius: 16,
+  padding: "22px 26px",
+  background: N.card,
+  border: `1px solid ${N.border}`,
+  marginBottom: 16,
+  display: "flex",
+  gap: 28,
+  alignItems: "center",
+  flexWrap: "wrap",
+  textDecoration: "none",
+  transition: "border-color .15s",
+} as const;
+
+const labelStyle = {
+  fontSize: 11.5,
+  letterSpacing: 1.2,
+  textTransform: "uppercase",
+  color: N.gold,
+  fontWeight: 700,
+  marginBottom: 8,
+  fontFamily: N.ui,
+} as const;
+
+/**
+ * The day's ayah — deterministic per calendar date (`verseOfDay`), resolved on the
+ * client so it advances each day without a rebuild. Replaces the old hardcoded
+ * verse, which never changed.
+ */
+export function HomeVerseOfDay({ nameOf }: { nameOf: (sura: number) => string }) {
+  const [v, setV] = useState<Loaded | null>(null);
+
+  useEffect(() => {
+    const ref = verseOfDay(today());
+    let cancelled = false;
+    fetch(`/api/v1/surahs/${ref.sura}/ayahs/${ref.aya}?edition=eng-khattab`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { ayah?: { text?: string }; translation?: { text?: string } } | null) => {
+        if (cancelled || !data?.ayah?.text) return;
+        setV({
+          sura: ref.sura,
+          aya: ref.aya,
+          arabic: data.ayah.text,
+          translation: data.translation?.text ?? null,
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!v) {
+    return (
+      <div style={cardStyle} aria-busy="true">
+        <div style={{ flex: "1 1 280px", display: "flex", flexDirection: "column", gap: 14 }}>
+          <div className="skeleton-line" style={{ height: "1.8rem", borderRadius: 6 }} />
+          <div className="skeleton-line" style={{ height: "1.8rem", width: "68%", borderRadius: 6 }} />
+        </div>
+        <div style={{ flex: "1 1 260px" }}>
+          <div style={labelStyle}>Verse of the day</div>
+          <div className="skeleton-line" style={{ height: "1rem", marginBottom: 8 }} />
+          <div className="skeleton-line" style={{ height: "1rem", width: "82%" }} />
+        </div>
+      </div>
+    );
+  }
+
+  const key = ayahKey({ sura: v.sura, aya: v.aya });
+  const name = nameOf(v.sura);
+
+  return (
+    <Link href={`/surah/${v.sura}#${key}`} style={cardStyle}>
+      <div
+        className="noor-ar"
+        style={{ flex: "1 1 280px", fontSize: 28, lineHeight: 2.1, color: N.fg }}
+        dir="rtl"
+        lang="ar"
+      >
+        {v.arabic}
+      </div>
+      <div style={{ flex: "1 1 260px" }}>
+        <div style={labelStyle}>Verse of the day</div>
+        {v.translation && (
+          <div style={{ fontSize: 15.5, lineHeight: 1.65, color: N.muted, fontFamily: N.ui }}>
+            {v.translation}
+          </div>
+        )}
+        <div style={{ fontSize: 13.5, color: N.gold, marginTop: 10, fontWeight: 600, fontFamily: N.ui }}>
+          {name ? `${name} ${key}` : key}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/components/NoorHomePage.tsx
+++ b/apps/web/src/components/NoorHomePage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { JUZ_STARTS, TOTAL_JUZ } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
 import { HomeHeroCards } from "./HomeHeroCards";
+import { HomeVerseOfDay } from "./HomeVerseOfDay";
 import { useSearch } from "./shell/SearchContext";
 
 interface Surah {
@@ -478,58 +479,10 @@ export function NoorHomePage({ surahs }: Props) {
           </div>
         </Link>
 
-        {/* Verse of the day */}
-        <div
-          style={{
-            borderRadius: 16,
-            padding: "22px 26px",
-            background: N.card,
-            border: `1px solid ${N.border}`,
-            marginBottom: 16,
-            display: "flex",
-            gap: 28,
-            alignItems: "center",
-            flexWrap: "wrap",
-          }}
-        >
-          <div
-            className="noor-ar"
-            style={{ flex: "1 1 280px", fontSize: 28, lineHeight: 2.1, color: N.fg }}
-          >
-            ٱلَّذِينَ ءَامَنُوا۟ وَتَطْمَئِنُّ قُلُوبُهُم بِذِكْرِ ٱللَّهِ ۗ أَلَا بِذِكْرِ ٱللَّهِ
-            تَطْمَئِنُّ ٱلْقُلُوبُ
-          </div>
-          <div style={{ flex: "1 1 260px" }}>
-            <div
-              style={{
-                fontSize: 11.5,
-                letterSpacing: 1.2,
-                textTransform: "uppercase",
-                color: N.gold,
-                fontWeight: 700,
-                marginBottom: 8,
-                fontFamily: N.ui,
-              }}
-            >
-              Verse of the day
-            </div>
-            <div style={{ fontSize: 15.5, lineHeight: 1.65, color: N.muted, fontFamily: N.ui }}>
-              Those who believe and whose hearts find rest in the remembrance of Allah. Verily, in
-              the remembrance of Allah do hearts find rest.
-            </div>
-            <div
-              style={{
-                fontSize: 13.5,
-                color: N.gold,
-                marginTop: 10,
-                fontWeight: 600,
-                fontFamily: N.ui,
-              }}
-            >
-              Ar-Raʿd 13:28
-            </div>
-          </div>
-        </div>
+        {/* Verse of the day — deterministic per calendar date, resolved client-side */}
+        <HomeVerseOfDay
+          nameOf={(num) => surahs.find((s) => s.number === num)?.transliteration ?? ""}
+        />
 
         {/* Quick tools strip */}
         <div


### PR DESCRIPTION
## Problem
The Noor home page shipped the **Verse of the day hardcoded** into the JSX (Ar-Raʿd 13:28) — the Arabic, translation and reference were all static literals, so it never changed regardless of the date.

## Fix
Replace the hardcoded block with `HomeVerseOfDay`, a client component that seeds core's deterministic `verseOfDay()` with the **local calendar date** and fetches the āyah, so it advances each day with no rebuild. Styled to match the existing Noor card and links into the surah at the verse. (The old, unused `VerseOfDay` component already did this — the redesign had dropped it in favour of static text.)

## Verification
- New `HomeVerseOfDay.test.tsx` (mirrors the existing `VerseOfDay.test.tsx`) + existing suite pass.
- The deterministic index lands on a different āyah each day (e.g. `2026-06-14` → Al-Baqara 2:168).
- Confirmed live on a fresh dev server (the verse now matches the day).
