### PR TITLE
feat: reading-plans foundation — schedule engine + catalogue port

### DIFF
--- a/apps/mobile/src/plans.ts
+++ b/apps/mobile/src/plans.ts
@@ -1,42 +1,42 @@
 /**
- * Reading-plan persistence for mobile. The plan *definitions* and pure progress
- * helpers are shared in `@ummahlibrary/core`; this layer holds the local-first
- * progress in AsyncStorage (`ul.readingPlan`, ADR 0006). Only one plan is active.
+ * Reading-plan persistence for mobile. The plan catalogue and the pure schedule
+ * maths are shared in `@ummahlibrary/core`; this layer holds the started plan
+ * (an `ActivePlan` snapshot) in AsyncStorage (`ul.readingPlan`, ADR 0006). Only
+ * one plan is active at a time.
  */
-import { type PlanProgress, togglePlanDay } from "@ummahlibrary/core";
+import { type ActivePlan, activatePlan, templateById, toggleDayComplete } from "@ummahlibrary/core";
 import { KEYS, getJSON, setJSON } from "./storage";
 
 export {
-  PLANS,
-  planById,
-  planPercent,
+  PLAN_TEMPLATES,
+  computeTodayPortion,
+  currentDay,
+  isDayComplete,
+  percentComplete,
+  planDuration,
   planWeekWindow,
-  type DayTarget,
-  type PlanDay,
-  type PlanProgress,
-  type ReadingPlan,
 } from "@ummahlibrary/core";
-export { currentPlanDay as currentDay } from "@ummahlibrary/core";
+export type { ActivePlan, DayPortion, DayTarget, PlanTemplate } from "@ummahlibrary/core";
 
 export function todayStr(d = new Date()): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
-export function readPlanProgress(): Promise<PlanProgress | null> {
-  return getJSON<PlanProgress | null>(KEYS.readingPlan, null);
+export function readActivePlan(): Promise<ActivePlan | null> {
+  return getJSON<ActivePlan | null>(KEYS.readingPlan, null);
 }
 
-export async function startPlan(planId: string): Promise<void> {
-  const next: PlanProgress = { planId, startDate: todayStr(), completed: [] };
-  await setJSON(KEYS.readingPlan, next);
+export async function startPlan(templateId: string): Promise<void> {
+  const template = templateById(templateId);
+  if (template) await setJSON(KEYS.readingPlan, activatePlan(template, todayStr()));
 }
 
 export async function clearPlan(): Promise<void> {
   await setJSON(KEYS.readingPlan, null);
 }
 
-export async function toggleDay(dayIndex: number): Promise<void> {
-  const p = await readPlanProgress();
-  if (!p) return;
-  await setJSON(KEYS.readingPlan, togglePlanDay(p, dayIndex));
+/** Toggle a 1-based day's completion (advances/retreats the linear cursor). */
+export async function toggleDay(day: number): Promise<void> {
+  const plan = await readActivePlan();
+  if (plan) await setJSON(KEYS.readingPlan, toggleDayComplete(plan, day));
 }

--- a/apps/mobile/src/screens/PlansScreen.tsx
+++ b/apps/mobile/src/screens/PlansScreen.tsx
@@ -7,16 +7,19 @@ import { Icon, Khatam } from "@ummahlibrary/ui";
 import { useTheme, type Palette } from "../theme";
 import { FONT } from "../fonts";
 import {
-  PLANS,
-  type DayTarget,
-  type PlanProgress,
+  type ActivePlan,
+  type DayPortion,
+  PLAN_TEMPLATES,
   clearPlan,
+  computeTodayPortion,
   currentDay,
-  planById,
-  planPercent,
+  isDayComplete,
+  percentComplete,
+  planDuration,
   planWeekWindow,
-  readPlanProgress,
+  readActivePlan,
   startPlan,
+  todayStr,
   toggleDay,
 } from "../plans";
 import type { ReadStackParamList } from "../navigation/types";
@@ -24,29 +27,32 @@ import type { ReadStackParamList } from "../navigation/types";
 type Props = NativeStackScreenProps<ReadStackParamList, "Plans">;
 type Nav = Props["navigation"];
 
-function openTarget(navigation: Nav, target: DayTarget) {
-  if (target.kind === "juz") navigation.navigate("JuzReader", { juz: target.juz });
-  else navigation.navigate("SurahReader", { surah: target.surah });
+function openTarget(navigation: Nav, portion: DayPortion) {
+  const t = portion.target;
+  if (t.kind === "juz") navigation.navigate("JuzReader", { juz: t.juz });
+  else if (t.kind === "surah") navigation.navigate("SurahReader", { surah: t.surah });
+  else navigation.navigate("SurahReader", { surah: portion.startRef.sura });
 }
 
 export function PlansScreen({ navigation }: Props) {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
-  const [progress, setProgress] = useState<PlanProgress | null>(null);
+  const [plan, setPlan] = useState<ActivePlan | null>(null);
   const [ready, setReady] = useState(false);
 
   const refresh = useCallback(() => {
-    void readPlanProgress().then((p) => {
-      setProgress(p);
+    void readActivePlan().then((p) => {
+      setPlan(p);
       setReady(true);
     });
   }, []);
   useFocusEffect(refresh);
 
-  const active = progress ? planById(progress.planId) : undefined;
-  const day = active && progress ? currentDay(active, progress) : 0;
-  const todayDay = active ? active.days[day - 1] : undefined;
-  const pct = active && progress ? planPercent(active, progress) : 0;
+  const today = todayStr();
+  const totalDays = plan ? planDuration(plan) : 0;
+  const day = plan ? currentDay(plan, today) : 0;
+  const portion = plan ? computeTodayPortion(plan, today) : undefined;
+  const pct = plan ? percentComplete(plan) : 0;
 
   const R = 33;
   const C = 2 * Math.PI * R;
@@ -56,7 +62,7 @@ export function PlansScreen({ navigation }: Props) {
       <Text style={styles.h1}>Reading plans</Text>
       <Text style={styles.subtitle}>Structured journeys through the Book</Text>
 
-      {ready && active && progress && todayDay ? (
+      {ready && plan && portion ? (
         <>
           <View style={styles.activeCard}>
             <View style={styles.watermark} pointerEvents="none">
@@ -83,15 +89,15 @@ export function PlansScreen({ navigation }: Props) {
               </View>
               <View style={styles.activeMeta}>
                 <Text style={styles.activeKicker}>
-                  Active · Day {day} of {active.days.length}
+                  Active · Day {day} of {totalDays}
                 </Text>
-                <Text style={styles.activeName}>{active.name}</Text>
+                <Text style={styles.activeName}>{plan.template.name}</Text>
                 <Text style={styles.activeToday}>
-                  Today: <Text style={styles.activeTodayStrong}>{todayDay.label}</Text> · {todayDay.est}
+                  Today: <Text style={styles.activeTodayStrong}>{portion.label}</Text> · {portion.est}
                 </Text>
               </View>
             </View>
-            <Pressable style={styles.readBtn} onPress={() => openTarget(navigation, todayDay.target)}>
+            <Pressable style={styles.readBtn} onPress={() => openTarget(navigation, portion)}>
               <Icon name="book" size={15} color={colors.ink} sw={1.8} />
               <Text style={styles.readBtnText}>Read today</Text>
             </Pressable>
@@ -99,11 +105,11 @@ export function PlansScreen({ navigation }: Props) {
 
           <View style={styles.actions}>
             <Pressable
-              style={[styles.pill, progress.completed.includes(day - 1) && styles.pillOn]}
-              onPress={() => void toggleDay(day - 1).then(refresh)}
+              style={[styles.pill, isDayComplete(plan, day) && styles.pillOn]}
+              onPress={() => void toggleDay(day).then(refresh)}
             >
-              <Text style={[styles.pillText, progress.completed.includes(day - 1) && styles.pillTextOn]}>
-                {progress.completed.includes(day - 1) ? "✓ Day done" : `Mark Day ${day} done`}
+              <Text style={[styles.pillText, isDayComplete(plan, day) && styles.pillTextOn]}>
+                {isDayComplete(plan, day) ? "✓ Day done" : `Mark Day ${day} done`}
               </Text>
             </Pressable>
             <Pressable style={styles.pill} onPress={() => void clearPlan().then(refresh)}>
@@ -113,8 +119,8 @@ export function PlansScreen({ navigation }: Props) {
 
           <Text style={styles.sectionLabel}>Your days</Text>
           <View style={styles.week}>
-            {planWeekWindow(active, day).map((n) => {
-              const done = progress.completed.includes(n - 1);
+            {planWeekWindow(plan, day).map((n) => {
+              const done = isDayComplete(plan, n);
               const isToday = n === day;
               return (
                 <View
@@ -143,15 +149,15 @@ export function PlansScreen({ navigation }: Props) {
 
       <Text style={styles.sectionLabel}>Browse plans</Text>
       <View style={styles.library}>
-        {PLANS.map((pl) => {
-          const isActive = active?.id === pl.id;
+        {PLAN_TEMPLATES.map((pl) => {
+          const isActive = plan?.template.id === pl.id;
           const plPct = isActive ? pct : 0;
           return (
             <Pressable
               key={pl.id}
               style={styles.libCard}
               onPress={() => {
-                if (isActive && todayDay) openTarget(navigation, todayDay.target);
+                if (isActive && portion) openTarget(navigation, portion);
                 else void startPlan(pl.id).then(refresh);
               }}
             >

--- a/apps/web/src/components/PlansView.tsx
+++ b/apps/web/src/components/PlansView.tsx
@@ -3,22 +3,38 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
-  type DayTarget,
-  PLANS,
-  type PlanProgress,
-  currentPlanDay,
-  planById,
-  planPercent,
+  type ActivePlan,
+  type DayPortion,
+  PLAN_TEMPLATES,
+  computeTodayPortion,
+  currentDay,
+  isDayComplete,
+  percentComplete,
+  planDuration,
   planWeekWindow,
 } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
-import { READING_PLAN_EVENT, clearPlan, readPlanProgress, startPlan, toggleDay } from "../lib/reading-plan";
+import {
+  READING_PLAN_EVENT,
+  clearPlan,
+  readActivePlan,
+  startPlan,
+  todayStr,
+  toggleDay,
+} from "../lib/reading-plan";
 
 const R = 30;
 const C = 2 * Math.PI * R;
 
-function targetHref(t: DayTarget): string {
-  return t.kind === "juz" ? `/juz/${t.juz}` : `/surah/${t.surah}`;
+function targetHref(p: DayPortion): string {
+  switch (p.target.kind) {
+    case "juz":
+      return `/juz/${p.target.juz}`;
+    case "surah":
+      return `/surah/${p.target.surah}`;
+    default:
+      return `/surah/${p.startRef.sura}`;
+  }
 }
 
 const sectionLabel = {
@@ -32,29 +48,31 @@ const sectionLabel = {
 } as const;
 
 /** Reading plans — structured journeys, mirroring the mobile screen and the
- *  Noor design. Definitions + pure progress live in core; persistence is local. */
+ *  Noor design. The catalogue + pure schedule maths live in core; persistence
+ *  is local. */
 export function PlansView() {
-  const [progress, setProgress] = useState<PlanProgress | null>(null);
+  const [plan, setPlan] = useState<ActivePlan | null>(null);
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    const refresh = () => setProgress(readPlanProgress());
+    const refresh = () => setPlan(readActivePlan());
     refresh();
     setReady(true);
     window.addEventListener(READING_PLAN_EVENT, refresh);
     return () => window.removeEventListener(READING_PLAN_EVENT, refresh);
   }, []);
 
-  const active = progress ? planById(progress.planId) : undefined;
-  const day = active && progress ? currentPlanDay(active, progress) : 0;
-  const todayDay = active ? active.days[day - 1] : undefined;
-  const pct = active && progress ? planPercent(active, progress) : 0;
+  const today = todayStr();
+  const totalDays = plan ? planDuration(plan) : 0;
+  const day = plan ? currentDay(plan, today) : 0;
+  const portion = plan ? computeTodayPortion(plan, today) : undefined;
+  const pct = plan ? percentComplete(plan) : 0;
 
   if (!ready) return <div style={{ minHeight: 240 }} />;
 
   return (
     <div>
-      {active && progress && todayDay && (
+      {plan && portion && (
         <>
           {/* Active plan */}
           <div
@@ -121,18 +139,18 @@ export function PlansView() {
                       fontFamily: N.ui,
                     }}
                   >
-                    Active · Day {day} of {active.days.length}
+                    Active · Day {day} of {totalDays}
                   </div>
                   <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: -0.5, color: N.fg, fontFamily: N.ui }}>
-                    {active.name}
+                    {plan.template.name}
                   </div>
                   <div style={{ fontSize: 13.5, color: N.muted, marginTop: 3, fontFamily: N.ui }}>
-                    Today: <span style={{ color: N.fg, fontWeight: 600 }}>{todayDay.label}</span> · {todayDay.est}
+                    Today: <span style={{ color: N.fg, fontWeight: 600 }}>{portion.label}</span> · {portion.est}
                   </div>
                 </div>
               </div>
               <Link
-                href={targetHref(todayDay.target)}
+                href={targetHref(portion)}
                 style={{
                   display: "inline-flex",
                   alignItems: "center",
@@ -157,20 +175,20 @@ export function PlansView() {
           <div style={{ display: "flex", gap: 9, flexWrap: "wrap", marginTop: 14 }}>
             <button
               type="button"
-              onClick={() => toggleDay(day - 1)}
+              onClick={() => toggleDay(day)}
               className="noor-press"
               style={{
                 padding: "9px 16px",
                 borderRadius: 999,
-                border: `1px solid ${progress.completed.includes(day - 1) ? N.gold : N.border}`,
-                background: progress.completed.includes(day - 1) ? N.goldSoft : N.card,
-                color: progress.completed.includes(day - 1) ? N.gold : N.muted,
+                border: `1px solid ${isDayComplete(plan, day) ? N.gold : N.border}`,
+                background: isDayComplete(plan, day) ? N.goldSoft : N.card,
+                color: isDayComplete(plan, day) ? N.gold : N.muted,
                 fontSize: 13,
                 fontWeight: 600,
                 fontFamily: N.ui,
               }}
             >
-              {progress.completed.includes(day - 1) ? "✓ Day done" : `Mark Day ${day} done`}
+              {isDayComplete(plan, day) ? "✓ Day done" : `Mark Day ${day} done`}
             </button>
             <button
               type="button"
@@ -194,8 +212,8 @@ export function PlansView() {
           {/* This week */}
           <div style={sectionLabel}>This week</div>
           <div style={{ display: "flex", gap: 8 }}>
-            {planWeekWindow(active, day).map((n) => {
-              const done = progress.completed.includes(n - 1);
+            {planWeekWindow(plan, day).map((n) => {
+              const done = isDayComplete(plan, n);
               const isToday = n === day;
               return (
                 <div
@@ -238,7 +256,7 @@ export function PlansView() {
         </>
       )}
 
-      {ready && !active && (
+      {ready && !plan && (
         <div
           style={{
             display: "flex",
@@ -261,8 +279,8 @@ export function PlansView() {
       {/* Browse plans */}
       <div style={sectionLabel}>Browse plans</div>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: 12 }}>
-        {PLANS.map((pl) => {
-          const isActive = active?.id === pl.id;
+        {PLAN_TEMPLATES.map((pl) => {
+          const isActive = plan?.template.id === pl.id;
           const plPct = isActive ? pct : 0;
           const done = plPct >= 100;
           return (
@@ -270,7 +288,7 @@ export function PlansView() {
               key={pl.id}
               type="button"
               onClick={() => {
-                if (isActive && todayDay) window.location.href = targetHref(todayDay.target);
+                if (isActive && portion) window.location.href = targetHref(portion);
                 else startPlan(pl.id);
               }}
               className="noor-press"

--- a/apps/web/src/lib/reading-plan.ts
+++ b/apps/web/src/lib/reading-plan.ts
@@ -1,15 +1,17 @@
 /**
- * Local-first reading-plan progress (ADR 0006). The plan definitions and pure
- * progress helpers live in `@ummahlibrary/core`; this layer persists the active
- * plan + completed days in `localStorage` (`ul.readingPlan`) and broadcasts a
- * window event so the plans page re-renders. Mirrors the mobile persistence.
+ * Local-first reading-plan progress (ADR 0006). The plan catalogue and the pure
+ * schedule maths live in `@ummahlibrary/core`; this layer persists the *started*
+ * plan (an `ActivePlan` snapshot) in `localStorage` (`ul.readingPlan`) and
+ * broadcasts a window event so the plans page re-renders. Mirrors the mobile
+ * persistence.
  */
-import { type PlanProgress, togglePlanDay } from "@ummahlibrary/core";
+import { type ActivePlan, activatePlan, templateById, toggleDayComplete } from "@ummahlibrary/core";
 
 export const READING_PLAN_EVENT = "ul.readingPlan";
 const KEY = "ul.readingPlan";
 
-function todayStr(d = new Date()): string {
+/** Today as a local `YYYY-MM-DD` string — the clock the pure core is fed. */
+export function todayStr(d = new Date()): string {
   const p = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
@@ -22,26 +24,27 @@ function emit(): void {
   }
 }
 
-export function readPlanProgress(): PlanProgress | null {
+export function readActivePlan(): ActivePlan | null {
   try {
     const raw = localStorage.getItem(KEY);
-    return raw ? (JSON.parse(raw) as PlanProgress) : null;
+    return raw ? (JSON.parse(raw) as ActivePlan) : null;
   } catch {
     return null;
   }
 }
 
-function write(progress: PlanProgress): void {
+function write(plan: ActivePlan): void {
   try {
-    localStorage.setItem(KEY, JSON.stringify(progress));
+    localStorage.setItem(KEY, JSON.stringify(plan));
   } catch {
     /* storage unavailable */
   }
   emit();
 }
 
-export function startPlan(planId: string): void {
-  write({ planId, startDate: todayStr(), completed: [] });
+export function startPlan(templateId: string): void {
+  const template = templateById(templateId);
+  if (template) write(activatePlan(template, todayStr()));
 }
 
 export function clearPlan(): void {
@@ -53,7 +56,8 @@ export function clearPlan(): void {
   emit();
 }
 
-export function toggleDay(dayIndex: number): void {
-  const p = readPlanProgress();
-  if (p) write(togglePlanDay(p, dayIndex));
+/** Toggle a 1-based day's completion (advances/retreats the linear cursor). */
+export function toggleDay(day: number): void {
+  const plan = readActivePlan();
+  if (plan) write(toggleDayComplete(plan, day));
 }

--- a/packages/api/src/repositories.ts
+++ b/packages/api/src/repositories.ts
@@ -2,6 +2,7 @@ import type {
   AdhkarRepository,
   AsmaRepository,
   HadithRepository,
+  PlanCatalogPort,
   PluginRegistry,
   PrayerTimesCalculator,
   QuranRepository,
@@ -9,6 +10,7 @@ import type {
   TranslationRepository,
 } from "@ummahlibrary/core";
 import {
+  BundledPlanCatalog,
   FileAdhkarRepository,
   FileAsmaRepository,
   FileHadithRepository,
@@ -53,3 +55,6 @@ export const adhkarRepository: AdhkarRepository = new FileAdhkarRepository();
 
 /** The bundled 99 Names of Allah. */
 export const asmaRepository: AsmaRepository = new FileAsmaRepository();
+
+/** The reading-plan catalogue — bundled in core, served through the port for the API. */
+export const planCatalog: PlanCatalogPort = new BundledPlanCatalog();

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -18,6 +18,7 @@ import type {
 } from "./entities";
 import type { HifzCard } from "./hifz";
 import type { Coordinates, Madhab, PrayerTimings } from "./prayer";
+import type { PlanTemplate } from "./reading-plans";
 
 /** Access to the Arabic Quran text and surah structure. */
 export interface QuranRepository {
@@ -130,6 +131,18 @@ export interface AdhkarRepository {
   all(): Promise<readonly Dhikr[]>;
   /** The dhikrs said at a given occasion (morning/evening), in display order. */
   byOccasion(occasion: AdhkarOccasion): Promise<readonly Dhikr[]>;
+}
+
+/**
+ * Access to the reading-plan catalogue (templates a reader can start). The
+ * curated templates are bundled in `core` so both apps load them offline; this
+ * port lets the API serve them through the same seam as every other repository.
+ */
+export interface PlanCatalogPort {
+  /** Every template in the catalogue, in display order. */
+  all(): Promise<readonly PlanTemplate[]>;
+  /** A single template by id, or `null` if it isn't in the catalogue. */
+  byId(id: string): Promise<PlanTemplate | null>;
 }
 
 /** One tracked memorization item: which ayah, and its SM-2 state. */

--- a/packages/core/src/reading-plans.test.ts
+++ b/packages/core/src/reading-plans.test.ts
@@ -1,127 +1,395 @@
 import { describe, expect, it } from "vitest";
+import { ayahCountOf } from "./quran-structure";
+import { addDays, daysBetween } from "./reading-goals";
 import {
-  PLANS,
-  type PlanProgress,
-  currentPlanDay,
-  planById,
-  planPercent,
+  type ActivePlan,
+  type PlanTemplate,
+  PLAN_TEMPLATES,
+  activatePlan,
+  computeTodayPortion,
+  cumulativeUnits,
+  currentDay,
+  daysAheadBehind,
+  isDayComplete,
+  isValidDateString,
+  materializeDay,
+  percentComplete,
+  planDuration,
+  planEndDate,
   planWeekWindow,
-  togglePlanDay,
+  projectedFinish,
+  rangeOfJuz,
+  rangeOfPages,
+  rangeOfSurahs,
+  reschedule,
+  setUnitsRead,
+  surahList,
+  templateById,
+  toggleDayComplete,
+  totalUnits,
+  unitsRemaining,
+  validatePlanDraft,
 } from "./reading-plans";
 
-const progressFor = (planId: string, completed: number[]): PlanProgress => ({
-  planId,
-  startDate: "2026-01-01",
-  completed,
+const START = "2026-01-01";
+
+/** A fixed one-unit-a-day plan over juzʾ 1…30 (30 days), started on START. */
+const ramadan = (): ActivePlan => activatePlan(templateById("ramadan-khatm")!, START);
+
+/** A template helper for ad-hoc plans in tests. */
+const tpl = (range: PlanTemplate["range"], schedule: PlanTemplate["schedule"]): PlanTemplate => ({
+  id: "t",
+  name: "Test",
+  tag: "",
+  len: "",
+  desc: "",
+  range,
+  schedule,
 });
 
-describe("PLANS", () => {
-  it("ships well-formed plans with readable day targets", () => {
-    expect(PLANS.length).toBeGreaterThan(0);
-    for (const plan of PLANS) {
-      expect(plan.id.length).toBeGreaterThan(0);
-      expect(plan.days.length).toBeGreaterThan(0);
-      for (const day of plan.days) {
-        expect(day.label.length).toBeGreaterThan(0);
-        if (day.target.kind === "juz") {
-          expect(day.target.juz).toBeGreaterThanOrEqual(1);
-          expect(day.target.juz).toBeLessThanOrEqual(30);
-        } else {
-          expect(day.target.surah).toBeGreaterThanOrEqual(1);
-          expect(day.target.surah).toBeLessThanOrEqual(114);
-        }
-      }
+// ── Date helpers ─────────────────────────────────────────────────────────────
+
+describe("date helpers", () => {
+  it("counts whole days between dates, signed", () => {
+    expect(daysBetween("2026-01-01", "2026-01-08")).toBe(7);
+    expect(daysBetween("2026-01-08", "2026-01-01")).toBe(-7);
+    expect(daysBetween("2026-01-01", "2026-01-01")).toBe(0);
+  });
+
+  it("adds (and subtracts) days across month boundaries", () => {
+    expect(addDays("2026-01-30", 2)).toBe("2026-02-01");
+    expect(addDays("2026-03-01", -1)).toBe("2026-02-28");
+  });
+
+  it("validates YYYY-MM-DD strings", () => {
+    expect(isValidDateString("2026-06-15")).toBe(true);
+    expect(isValidDateString("2026-13-01")).toBe(false);
+    expect(isValidDateString("nope")).toBe(false);
+  });
+});
+
+// ── Catalogue + range builders ───────────────────────────────────────────────
+
+describe("range builders", () => {
+  it("builds contiguous and explicit ranges", () => {
+    expect(rangeOfJuz(1, 30).units).toHaveLength(30);
+    expect(rangeOfSurahs(78, 114).units).toHaveLength(37);
+    expect(rangeOfPages(1, 604).units).toHaveLength(604);
+    expect(surahList([1, 36, 55]).units).toEqual([1, 36, 55]);
+    expect(totalUnits(rangeOfJuz(1, 5))).toBe(5);
+  });
+});
+
+describe("PLAN_TEMPLATES", () => {
+  it("ships well-formed templates with valid unit indices", () => {
+    expect(PLAN_TEMPLATES.length).toBeGreaterThan(0);
+    for (const t of PLAN_TEMPLATES) {
+      expect(t.id.length).toBeGreaterThan(0);
+      expect(t.range.units.length).toBeGreaterThan(0);
+      for (const u of t.range.units) expect(u).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("looks up a known template and misses gracefully", () => {
+    expect(templateById("ramadan-khatm")?.name).toBe("Ramaḍān Khatm");
+    expect(templateById("nope")).toBeUndefined();
+  });
+});
+
+// ── Duration + end date ──────────────────────────────────────────────────────
+
+describe("planDuration", () => {
+  it("derives days from a fixed cadence (ceil)", () => {
+    expect(planDuration(ramadan())).toBe(30);
+    expect(planDuration(activatePlan(tpl(rangeOfJuz(1, 30), { kind: "fixed", unitsPerDay: 4 }), START))).toBe(8);
+  });
+
+  it("uses the inclusive span for a target date", () => {
+    const plan = activatePlan(tpl(rangeOfJuz(1, 30), { kind: "targetDate", endDate: "2026-01-07" }), START);
+    expect(planDuration(plan)).toBe(7);
+  });
+
+  it("rejects impossible plans", () => {
+    expect(() => planDuration(activatePlan(tpl({ unit: "juz", units: [] }, { kind: "fixed", unitsPerDay: 1 }), START))).toThrow(RangeError);
+    expect(() => planDuration(activatePlan(tpl(rangeOfJuz(1, 30), { kind: "fixed", unitsPerDay: 0 }), START))).toThrow(RangeError);
+    const past = activatePlan(tpl(rangeOfJuz(1, 30), { kind: "targetDate", endDate: "2025-12-01" }), START);
+    expect(() => planDuration(past)).toThrow(/before the start/);
+  });
+});
+
+describe("planEndDate", () => {
+  it("derives the end of a fixed plan", () => {
+    expect(planEndDate(ramadan())).toBe("2026-01-30");
+  });
+  it("returns the chosen date for a target-date plan", () => {
+    const plan = activatePlan(tpl(rangeOfJuz(1, 30), { kind: "targetDate", endDate: "2026-02-14" }), START);
+    expect(planEndDate(plan)).toBe("2026-02-14");
+  });
+});
+
+// ── Acceptance: target-date scheduling ───────────────────────────────────────
+
+describe("target-date scheduling (acceptance)", () => {
+  it("spreads the work so the plan finishes on or before the end date", () => {
+    const endDate = "2026-01-07"; // 7 days
+    const plan = activatePlan(tpl(rangeOfJuz(1, 30), { kind: "targetDate", endDate }), START);
+    const dur = planDuration(plan);
+
+    // The daily amounts sum to the whole range and never exceed the ceil pace.
+    const perDay = ceilPace(30, dur);
+    let sum = 0;
+    for (let d = 1; d <= dur; d++) {
+      const amount = cumulativeUnits(plan, d) - cumulativeUnits(plan, d - 1);
+      expect(amount).toBeLessThanOrEqual(perDay);
+      sum += amount;
+    }
+    expect(sum).toBe(30);
+
+    // Everything is scheduled by the final day, which is on/before the end date.
+    expect(cumulativeUnits(plan, dur)).toBe(30);
+    expect(daysBetween(planEndDate(plan), endDate)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("handles a range shorter than the number of days (idle days, still finishes)", () => {
+    const plan = activatePlan(tpl(rangeOfJuz(1, 5), { kind: "targetDate", endDate: "2026-01-10" }), START);
+    expect(planDuration(plan)).toBe(10);
+    expect(cumulativeUnits(plan, 10)).toBe(5);
+    expect(materializeDay(plan, 1).empty).toBe(true); // nothing due on day 1
+  });
+});
+
+function ceilPace(total: number, days: number): number {
+  return Math.ceil(total / days);
+}
+
+// ── Cumulative distribution + current day ────────────────────────────────────
+
+describe("cumulativeUnits", () => {
+  it("runs from 0 to the total, monotonically", () => {
+    const plan = ramadan();
+    expect(cumulativeUnits(plan, 0)).toBe(0);
+    expect(cumulativeUnits(plan, 30)).toBe(30);
+    expect(cumulativeUnits(plan, 31)).toBe(30); // clamps past the end
+    for (let d = 1; d <= 30; d++) {
+      expect(cumulativeUnits(plan, d)).toBeGreaterThanOrEqual(cumulativeUnits(plan, d - 1));
     }
   });
 });
 
-describe("planById", () => {
-  it("finds a known plan and returns undefined otherwise", () => {
-    expect(planById("ramadan-khatm")?.name).toBe("Ramaḍān Khatm");
-    expect(planById("does-not-exist")).toBeUndefined();
+describe("currentDay", () => {
+  const plan = ramadan();
+  it("clamps before the start, tracks the calendar, and clamps past the end", () => {
+    expect(currentDay(plan, "2025-12-20")).toBe(1);
+    expect(currentDay(plan, START)).toBe(1);
+    expect(currentDay(plan, "2026-01-10")).toBe(10);
+    expect(currentDay(plan, "2026-03-01")).toBe(30);
   });
 });
 
-describe("currentPlanDay", () => {
-  const plan = planById("juz-amma")!;
+// ── Progress metrics ─────────────────────────────────────────────────────────
 
-  it("is day 1 when nothing is completed", () => {
-    expect(currentPlanDay(plan, progressFor(plan.id, []))).toBe(1);
+describe("unitsRemaining + percentComplete", () => {
+  it("reflects the cursor", () => {
+    const plan = setUnitsRead(ramadan(), 12);
+    expect(unitsRemaining(plan)).toBe(18);
+    expect(percentComplete(plan)).toBe(40);
   });
-
-  it("returns the first uncompleted day", () => {
-    expect(currentPlanDay(plan, progressFor(plan.id, [0, 1]))).toBe(3);
-  });
-
-  it("skips completed days that are out of order", () => {
-    expect(currentPlanDay(plan, progressFor(plan.id, [0, 2]))).toBe(2);
-  });
-
-  it("caps at the plan length when every day is done", () => {
-    const all = plan.days.map((_, i) => i);
-    expect(currentPlanDay(plan, progressFor(plan.id, all))).toBe(plan.days.length);
+  it("is 0% fresh and 100% done", () => {
+    expect(percentComplete(ramadan())).toBe(0);
+    expect(percentComplete(setUnitsRead(ramadan(), 30))).toBe(100);
   });
 });
 
-describe("planPercent", () => {
-  const plan = planById("jewels")!;
-
-  it("is 0 when nothing is done", () => {
-    expect(planPercent(plan, progressFor(plan.id, []))).toBe(0);
-  });
-
-  it("rounds partial progress", () => {
-    // 2 of 5 days = 40%
-    expect(planPercent(plan, progressFor(plan.id, [0, 1]))).toBe(40);
-  });
-
-  it("is 100 when complete", () => {
-    const all = plan.days.map((_, i) => i);
-    expect(planPercent(plan, progressFor(plan.id, all))).toBe(100);
-  });
-
-  it("guards against an empty plan", () => {
-    const empty = { ...plan, days: [] };
-    expect(planPercent(empty, progressFor(plan.id, []))).toBe(0);
+describe("isDayComplete", () => {
+  it("is true once the cursor reaches the day's cumulative target", () => {
+    const plan = setUnitsRead(ramadan(), 3);
+    expect(isDayComplete(plan, 3)).toBe(true);
+    expect(isDayComplete(plan, 4)).toBe(false);
   });
 });
 
-describe("togglePlanDay", () => {
-  it("marks a day complete, keeping the list sorted", () => {
-    const next = togglePlanDay(progressFor("p", [2, 0]), 1);
-    expect(next.completed).toEqual([0, 1, 2]);
+describe("daysAheadBehind", () => {
+  const plan = ramadan();
+  it("is 0 when on track for today", () => {
+    expect(daysAheadBehind(plan, START)).toBe(0); // day 1, nothing read yet
+    expect(daysAheadBehind(setUnitsRead(plan, 1), "2026-01-02")).toBe(0); // day 2, 1 read
   });
-
-  it("unmarks an already-completed day", () => {
-    const next = togglePlanDay(progressFor("p", [0, 1, 2]), 1);
-    expect(next.completed).toEqual([0, 2]);
+  it("is negative when behind", () => {
+    expect(daysAheadBehind(setUnitsRead(plan, 1), "2026-01-03")).toBe(-1);
   });
-
-  it("preserves the rest of the progress object", () => {
-    const before = progressFor("p", []);
-    const after = togglePlanDay(before, 0);
-    expect(after.planId).toBe(before.planId);
-    expect(after.startDate).toBe(before.startDate);
+  it("is positive when ahead", () => {
+    expect(daysAheadBehind(setUnitsRead(plan, 2), START)).toBe(1);
   });
 });
+
+describe("projectedFinish", () => {
+  const plan = ramadan();
+  it("falls back to the planned end date before any progress", () => {
+    expect(projectedFinish(plan, START)).toBe("2026-01-30");
+  });
+  it("returns today once complete", () => {
+    expect(projectedFinish(setUnitsRead(plan, 30), "2026-01-15")).toBe("2026-01-15");
+  });
+  it("projects later than planned when behind pace", () => {
+    const behind = setUnitsRead(plan, 5);
+    expect(daysBetween("2026-01-30", projectedFinish(behind, "2026-01-11"))).toBeGreaterThan(0);
+  });
+  it("projects earlier than planned when ahead of pace", () => {
+    const ahead = setUnitsRead(plan, 6); // 6 juzʾ by day 3 → 2/day
+    expect(daysBetween(projectedFinish(ahead, "2026-01-03"), "2026-01-30")).toBeGreaterThan(0);
+  });
+});
+
+// ── Portions + labels (unit conversions) ─────────────────────────────────────
+
+describe("materializeDay", () => {
+  it("labels a single juzʾ and deep-links to it", () => {
+    const day = materializeDay(ramadan(), 1);
+    expect(day.label).toBe("Juzʾ 1");
+    expect(day.target).toEqual({ kind: "juz", juz: 1 });
+    expect(day.startRef).toEqual({ sura: 1, aya: 1 });
+    expect(day.endRef).toEqual({ sura: 2, aya: 141 }); // verse before juzʾ 2
+    expect(day.est).toMatch(/^~\d+ min$/);
+    expect(day.empty).toBe(false);
+  });
+
+  it("ends a juzʾ that closes on a sūrah boundary at that sūrah's last verse", () => {
+    // Juzʾ 13 ends where juzʾ 14 begins (15:1), i.e. the last verse of Sūrah Ibrāhīm (14).
+    const plan = activatePlan(tpl(rangeOfJuz(13, 13), { kind: "fixed", unitsPerDay: 1 }), START);
+    expect(materializeDay(plan, 1).endRef).toEqual({ sura: 14, aya: ayahCountOf(14) });
+  });
+
+  it("labels a single sūrah using the structure's ayah count", () => {
+    const plan = activatePlan(templateById("juz-amma")!, START);
+    const day = materializeDay(plan, 1);
+    expect(day.label).toBe("Sūrah 78");
+    expect(day.target).toEqual({ kind: "surah", surah: 78 });
+    expect(day.endRef).toEqual({ sura: 78, aya: ayahCountOf(78) });
+  });
+
+  it("labels a contiguous multi-unit portion as a range", () => {
+    const plan = activatePlan(tpl(rangeOfJuz(1, 6), { kind: "fixed", unitsPerDay: 3 }), START);
+    expect(materializeDay(plan, 1).label).toBe("Juzʾ 1–3");
+  });
+
+  it("lists a non-contiguous multi-unit portion", () => {
+    const plan = activatePlan(tpl(surahList([1, 36, 55]), { kind: "fixed", unitsPerDay: 3 }), START);
+    expect(materializeDay(plan, 1).label).toBe("Sūrah 1, Sūrah 36, Sūrah 55");
+  });
+
+  it("resolves page and ayah units", () => {
+    const pages = activatePlan(tpl(rangeOfPages(1, 3), { kind: "fixed", unitsPerDay: 1 }), START);
+    const p1 = materializeDay(pages, 1);
+    expect(p1.label).toBe("Page 1");
+    expect(p1.startRef).toEqual({ sura: 1, aya: 1 });
+
+    const ayat = activatePlan(tpl({ unit: "ayah", units: [1, 2, 3] }, { kind: "fixed", unitsPerDay: 1 }), START);
+    const a1 = materializeDay(ayat, 1);
+    expect(a1.label).toBe("Ayah 1:1");
+    expect(a1.target).toEqual({ kind: "ayah", ref: { sura: 1, aya: 1 } });
+
+    const hizb = activatePlan(tpl({ unit: "hizb", units: [1, 2] }, { kind: "fixed", unitsPerDay: 1 }), START);
+    const h1 = materializeDay(hizb, 1);
+    expect(h1.label).toBe("Ḥizb 1");
+    expect(h1.target).toEqual({ kind: "hizb", hizb: 1 });
+  });
+
+  it("returns an empty portion when nothing is scheduled", () => {
+    const plan = activatePlan(tpl(rangeOfJuz(1, 5), { kind: "targetDate", endDate: "2026-01-10" }), START);
+    const day = materializeDay(plan, 1);
+    expect(day.empty).toBe(true);
+    expect(day.count).toBe(0);
+    expect(day.label).toBe("Nothing scheduled");
+  });
+});
+
+describe("computeTodayPortion", () => {
+  it("returns the calendar day's portion", () => {
+    expect(computeTodayPortion(ramadan(), "2026-01-05").label).toBe("Juzʾ 5");
+  });
+});
+
+// ── Week window ──────────────────────────────────────────────────────────────
 
 describe("planWeekWindow", () => {
-  const ramadan = planById("ramadan-khatm")!; // 30 days
-  const jewels = planById("jewels")!; // 5 days
-
-  it("centres a seven-day window around the current day", () => {
-    expect(planWeekWindow(ramadan, 10)).toEqual([7, 8, 9, 10, 11, 12, 13]);
+  const plan = ramadan();
+  it("centres a seven-day window", () => {
+    expect(planWeekWindow(plan, 10)).toEqual([7, 8, 9, 10, 11, 12, 13]);
   });
-
-  it("clamps to the start of the plan", () => {
-    expect(planWeekWindow(ramadan, 1)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  it("clamps to the start and the end", () => {
+    expect(planWeekWindow(plan, 1)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(planWeekWindow(plan, 30)).toEqual([24, 25, 26, 27, 28, 29, 30]);
   });
-
-  it("clamps to the end of the plan", () => {
-    expect(planWeekWindow(ramadan, 30)).toEqual([24, 25, 26, 27, 28, 29, 30]);
-  });
-
-  it("shrinks the window for short plans", () => {
+  it("shrinks for short plans", () => {
+    const jewels = activatePlan(templateById("jewels")!, START);
     expect(planWeekWindow(jewels, 1)).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+// ── Lifecycle ────────────────────────────────────────────────────────────────
+
+describe("activatePlan + setUnitsRead", () => {
+  it("starts fresh and clamps the cursor", () => {
+    const plan = ramadan();
+    expect(plan.unitsRead).toBe(0);
+    expect(setUnitsRead(plan, -5).unitsRead).toBe(0);
+    expect(setUnitsRead(plan, 999).unitsRead).toBe(30);
+    expect(setUnitsRead(plan, 3.7).unitsRead).toBe(3);
+  });
+});
+
+describe("toggleDayComplete", () => {
+  it("marks a day done, completing earlier days, and un-marks it", () => {
+    const done = toggleDayComplete(ramadan(), 3);
+    expect(done.unitsRead).toBe(3);
+    expect(toggleDayComplete(done, 3).unitsRead).toBe(2); // back to end of day 2
+  });
+});
+
+describe("reschedule", () => {
+  it("changes the cadence while keeping progress and start date", () => {
+    const plan = setUnitsRead(ramadan(), 4);
+    const faster = reschedule(plan, { kind: "fixed", unitsPerDay: 2 });
+    expect(planDuration(faster)).toBe(15);
+    expect(faster.unitsRead).toBe(4);
+    expect(faster.startDate).toBe(START);
+  });
+  it("moves to a target date", () => {
+    const plan = reschedule(ramadan(), { kind: "targetDate", endDate: "2026-01-15" });
+    expect(planEndDate(plan)).toBe("2026-01-15");
+  });
+  it("rejects impossible changes", () => {
+    expect(() => reschedule(ramadan(), { kind: "targetDate", endDate: "2025-01-01" })).toThrow(RangeError);
+    expect(() => reschedule(ramadan(), { kind: "fixed", unitsPerDay: 0 })).toThrow(RangeError);
+  });
+});
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+describe("validatePlanDraft", () => {
+  it("accepts a sound draft", () => {
+    expect(validatePlanDraft({ range: rangeOfJuz(1, 30), schedule: { kind: "fixed", unitsPerDay: 1 }, startDate: START })).toEqual([]);
+    expect(validatePlanDraft({ range: rangeOfJuz(1, 30), schedule: { kind: "targetDate", endDate: "2026-06-01" }, startDate: START })).toEqual([]);
+  });
+
+  it("flags an empty range", () => {
+    expect(validatePlanDraft({ range: { unit: "juz", units: [] }, schedule: { kind: "fixed", unitsPerDay: 1 }, startDate: START })).toContain(
+      "Choose at least one portion to read.",
+    );
+  });
+
+  it("flags a non-positive cadence", () => {
+    expect(validatePlanDraft({ range: rangeOfJuz(1, 30), schedule: { kind: "fixed", unitsPerDay: 0 }, startDate: START })).toContain(
+      "Read at least one unit per day.",
+    );
+  });
+
+  it("flags a malformed or past end date", () => {
+    expect(validatePlanDraft({ range: rangeOfJuz(1, 30), schedule: { kind: "targetDate", endDate: "nope" }, startDate: START })).toContain(
+      "Pick a valid end date.",
+    );
+    expect(validatePlanDraft({ range: rangeOfJuz(1, 30), schedule: { kind: "targetDate", endDate: "2025-12-01" }, startDate: START })).toContain(
+      "The end date can’t be before the start date.",
+    );
   });
 });

--- a/packages/core/src/reading-plans.test.ts
+++ b/packages/core/src/reading-plans.test.ts
@@ -94,6 +94,25 @@ describe("PLAN_TEMPLATES", () => {
     expect(templateById("ramadan-khatm")?.name).toBe("Ramaḍān Khatm");
     expect(templateById("nope")).toBeUndefined();
   });
+
+  it("ships the launch catalogue with the expected pacing", () => {
+    const dur = (id: string) => planDuration(activatePlan(templateById(id)!, START));
+    expect(dur("ramadan-khatm")).toBe(30);
+    expect(dur("juz-sprint")).toBe(30);
+    expect(dur("quran-60")).toBe(60); // 60 aḥzāb, one a day
+    expect(dur("quran-year")).toBe(302); // 604 pages, two a day
+    expect(dur("juz-amma")).toBe(37); // 37 sūrahs of Juzʾ ʿAmma
+  });
+
+  it("validates every template against the core types (acceptance)", () => {
+    for (const t of PLAN_TEMPLATES) {
+      expect(validatePlanDraft({ range: t.range, schedule: t.schedule, startDate: START })).toEqual([]);
+      const plan = activatePlan(t, START);
+      expect(planDuration(plan)).toBeGreaterThan(0);
+      expect(totalUnits(t.range)).toBeGreaterThan(0);
+      expect(computeTodayPortion(plan, START).empty).toBe(false);
+    }
+  });
 });
 
 // ── Duration + end date ──────────────────────────────────────────────────────

--- a/packages/core/src/reading-plans.ts
+++ b/packages/core/src/reading-plans.ts
@@ -1,70 +1,281 @@
 /**
- * Reading plans — structured journeys through the Book. Plan *definitions* are
- * static and pure (no I/O); a reader's progress is local-first state persisted
- * by each app (`ul.readingPlan`, ADR 0006). Only one plan is active at a time.
+ * Reading plans — structured journeys through the Book.
  *
- * Each plan day points at something readable (a juzʾ or a sūrah) so "Read today"
- * can deep-link straight into the reader on either platform.
+ * The domain is pure and deterministic (ADR 0001/0003): no I/O, no framework,
+ * no `Date.now()`. Anything time-dependent takes an injected `today`
+ * (`YYYY-MM-DD`) so the maths is fully testable. A reader's progress is
+ * local-first state persisted by each app (`ul.readingPlan`, ADR 0006); only
+ * one plan is active at a time.
+ *
+ * A plan covers an ordered list of *units* (juzʾ / ḥizb / page / sūrah / ayah)
+ * drawn from the invariant Quran structure in `./quran-structure`. Two
+ * scheduling strategies decide the pace:
+ *
+ * - `fixed`      — a set cadence (e.g. one juzʾ a day); the end date is derived.
+ * - `targetDate` — a chosen finish date; the daily amount is derived so the plan
+ *                  completes on or before that date.
+ *
+ * Days are spread with an even cumulative distribution
+ * (`cum(d) = ⌊d·total / days⌋`) so `cum(0) = 0`, `cum(days) = total`, and every
+ * day differs by at most one unit.
  */
+import type { VerseKey } from "./entities";
+import {
+  AYAH_COUNTS,
+  HIZB_STARTS,
+  JUZ_STARTS,
+  PAGE_STARTS,
+  TOTAL_HIZB,
+  TOTAL_JUZ,
+  ayahCountOf,
+  ordinalToRef,
+  pageRange,
+} from "./quran-structure";
+// UTC `YYYY-MM-DD` date maths is shared with the reading-goals domain, where
+// `addDays`/`daysBetween` already live (prayer-tracker reuses them the same way).
+import { addDays, daysBetween } from "./reading-goals";
 
-export type DayTarget = { kind: "juz"; juz: number } | { kind: "surah"; surah: number };
+// ── Types ──────────────────────────────────────────────────────────────────
 
-export interface PlanDay {
-  label: string;
-  est: string;
-  target: DayTarget;
+/** The atomic readable unit a plan counts in. */
+export type PlanUnit = "juz" | "hizb" | "page" | "surah" | "ayah";
+
+/** Where "Read today" should deep-link for the start of a day's portion. */
+export type DayTarget =
+  | { kind: "juz"; juz: number }
+  | { kind: "hizb"; hizb: number }
+  | { kind: "page"; page: number }
+  | { kind: "surah"; surah: number }
+  | { kind: "ayah"; ref: VerseKey };
+
+/** The slice of the Book a plan covers: an ordered list of 1-based unit indices. */
+export interface PlanRange {
+  unit: PlanUnit;
+  /** e.g. `[1..30]` for the whole Quran by juzʾ, or `[1, 36, 55, 67, 18]`. */
+  units: number[];
 }
 
-export interface ReadingPlan {
+/** How a plan paces itself across the days. */
+export type ScheduleStrategy =
+  | { kind: "fixed"; unitsPerDay: number }
+  | { kind: "targetDate"; endDate: string };
+
+/** A reusable catalogue entry — no start date, no progress. */
+export interface PlanTemplate {
   id: string;
   name: string;
   /** Short badge, e.g. "30 days". */
   tag: string;
-  /** Cadence, e.g. "Juzʾ a day". */
+  /** Cadence label, e.g. "Juzʾ a day". */
   len: string;
   desc: string;
-  days: PlanDay[];
+  range: PlanRange;
+  schedule: ScheduleStrategy;
 }
 
-export interface PlanProgress {
-  planId: string;
-  /** YYYY-MM-DD the plan was started. */
+/** A template a reader has started: a self-contained snapshot + progress. */
+export interface ActivePlan {
+  /** Denormalised so an in-flight plan survives catalogue changes (offline). */
+  template: PlanTemplate;
+  /** `YYYY-MM-DD` the plan was started. */
   startDate: string;
-  /** 0-based day indices completed. */
-  completed: number[];
+  /** Atomic units completed so far (a linear cursor, 0…total). */
+  unitsRead: number;
 }
 
-const ramadanDays: PlanDay[] = Array.from({ length: 30 }, (_, i) => ({
-  label: `Juzʾ ${i + 1}`,
-  est: "~22 min",
-  target: { kind: "juz", juz: i + 1 },
-}));
+/** What to read on a given day, resolved to deep-linkable Quran references. */
+export interface DayPortion {
+  /** 1-based day number. */
+  day: number;
+  unit: PlanUnit;
+  /** Number of units scheduled this day (0 if the plan has already ended). */
+  count: number;
+  /** First / last unit index of the day (1-based; 0 when `empty`). */
+  fromUnit: number;
+  toUnit: number;
+  startRef: VerseKey;
+  endRef: VerseKey;
+  target: DayTarget;
+  /** e.g. "Juzʾ 5", "Sūrahs 78–80", "Pages 21–22". */
+  label: string;
+  /** Rough reading estimate, e.g. "~22 min". */
+  est: string;
+  /** True when there is nothing left to read on this day. */
+  empty: boolean;
+}
 
-/** The built-in plan library, shared by web and mobile. */
-export const PLANS: readonly ReadingPlan[] = [
+/** A not-yet-started plan, for validating the custom-plan creator. */
+export interface PlanDraft {
+  range: PlanRange;
+  schedule: ScheduleStrategy;
+  startDate: string;
+}
+
+/** A change applied by {@link reschedule}. */
+export type RescheduleChange =
+  | { kind: "fixed"; unitsPerDay: number }
+  | { kind: "targetDate"; endDate: string };
+
+// ── Local helpers ───────────────────────────────────────────────────────────
+
+const LAST_VERSE: VerseKey = { sura: 114, aya: 6 };
+
+/** Whether a string is a real `YYYY-MM-DD` calendar date. */
+export function isValidDateString(date: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) && !Number.isNaN(Date.parse(`${date}T00:00:00Z`));
+}
+
+// ── Unit ↔ Quran-structure conversions (reuse ./quran-structure) ────────────
+
+/** The verse immediately before `ref` in mushaf order. */
+function verseBefore(ref: VerseKey): VerseKey {
+  return ref.aya > 1
+    ? { sura: ref.sura, aya: ref.aya - 1 }
+    : { sura: ref.sura - 1, aya: ayahCountOf(ref.sura - 1) };
+}
+
+/** The first verse of unit index `i` for `unit`. */
+function unitStartRef(unit: PlanUnit, i: number): VerseKey {
+  switch (unit) {
+    case "surah":
+      return { sura: i, aya: 1 };
+    case "juz":
+      return JUZ_STARTS[i - 1]!;
+    case "hizb":
+      return HIZB_STARTS[i - 1]!;
+    case "page":
+      return PAGE_STARTS[i - 1]!;
+    case "ayah":
+      return ordinalToRef(i);
+  }
+}
+
+/** The last verse of unit index `i` for `unit`. */
+function unitEndRef(unit: PlanUnit, i: number): VerseKey {
+  switch (unit) {
+    case "surah":
+      return { sura: i, aya: ayahCountOf(i) };
+    case "juz":
+      return i >= TOTAL_JUZ ? LAST_VERSE : verseBefore(JUZ_STARTS[i]!);
+    case "hizb":
+      return i >= TOTAL_HIZB ? LAST_VERSE : verseBefore(HIZB_STARTS[i]!);
+    case "page":
+      return pageRange(i).end;
+    case "ayah":
+      return ordinalToRef(i);
+  }
+}
+
+/** A deep-link target for the start of unit index `i`. */
+function unitTarget(unit: PlanUnit, i: number): DayTarget {
+  switch (unit) {
+    case "juz":
+      return { kind: "juz", juz: i };
+    case "hizb":
+      return { kind: "hizb", hizb: i };
+    case "page":
+      return { kind: "page", page: i };
+    case "surah":
+      return { kind: "surah", surah: i };
+    case "ayah":
+      return { kind: "ayah", ref: ordinalToRef(i) };
+  }
+}
+
+const UNIT_SINGULAR: Record<PlanUnit, string> = {
+  juz: "Juzʾ",
+  hizb: "Ḥizb",
+  page: "Page",
+  surah: "Sūrah",
+  ayah: "Ayah",
+};
+
+const UNIT_PLURAL: Record<PlanUnit, string> = {
+  juz: "Juzʾ",
+  hizb: "Aḥzāb",
+  page: "Pages",
+  surah: "Sūrahs",
+  ayah: "Ayahs",
+};
+
+function unitLabel(unit: PlanUnit, i: number): string {
+  if (unit === "ayah") {
+    const r = ordinalToRef(i);
+    return `Ayah ${r.sura}:${r.aya}`;
+  }
+  return `${UNIT_SINGULAR[unit]} ${i}`;
+}
+
+/** A human label for a day's slice of units (handles single/contiguous/listed). */
+function portionLabel(unit: PlanUnit, slice: number[]): string {
+  if (slice.length === 1) return unitLabel(unit, slice[0]!);
+  const from = slice[0]!;
+  const to = slice[slice.length - 1]!;
+  const contiguous = slice.every((u, idx) => u === from + idx);
+  if (contiguous) return `${UNIT_PLURAL[unit]} ${from}–${to}`;
+  return slice.map((u) => unitLabel(unit, u)).join(", ");
+}
+
+/** The 1-based ordinal (1…6236) of a verse in mushaf order. */
+function refToOrdinal(ref: VerseKey): number {
+  let n = ref.aya;
+  for (let s = 1; s < ref.sura; s++) n += AYAH_COUNTS[s - 1]!;
+  return n;
+}
+
+/** A rough reading estimate in minutes for a verse span (~6.3s per ayah). */
+function estimateMinutes(start: VerseKey, end: VerseKey): number {
+  const ayahs = refToOrdinal(end) - refToOrdinal(start) + 1;
+  return Math.max(1, Math.round((ayahs * 6.3) / 60));
+}
+
+// ── Range builders + the launch catalogue ───────────────────────────────────
+
+function seq(from: number, to: number): number[] {
+  const out: number[] = [];
+  for (let i = from; i <= to; i++) out.push(i);
+  return out;
+}
+
+/** A contiguous juzʾ range, e.g. `rangeOfJuz(1, 30)` for the whole Quran. */
+export function rangeOfJuz(from: number, to: number): PlanRange {
+  return { unit: "juz", units: seq(from, to) };
+}
+
+/** A contiguous sūrah range, e.g. `rangeOfSurahs(78, 114)` for Juzʾ ʿAmma. */
+export function rangeOfSurahs(from: number, to: number): PlanRange {
+  return { unit: "surah", units: seq(from, to) };
+}
+
+/** A contiguous page range. */
+export function rangeOfPages(from: number, to: number): PlanRange {
+  return { unit: "page", units: seq(from, to) };
+}
+
+/** An explicit, possibly non-contiguous list of sūrahs. */
+export function surahList(units: number[]): PlanRange {
+  return { unit: "surah", units: [...units] };
+}
+
+/** The built-in catalogue, shared by web and mobile. */
+export const PLAN_TEMPLATES: readonly PlanTemplate[] = [
   {
     id: "ramadan-khatm",
     name: "Ramaḍān Khatm",
     tag: "30 days",
     len: "Juzʾ a day",
     desc: "Complete the Quran in a month, one juzʾ each day.",
-    days: ramadanDays,
+    range: rangeOfJuz(1, 30),
+    schedule: { kind: "fixed", unitsPerDay: 1 },
   },
   {
     id: "juz-amma",
-    name: "The Last Juzʾ",
-    tag: "7 days",
+    name: "A Sūrah a Day",
+    tag: "37 days",
     len: "Juzʾ ʿAmma",
-    desc: "Read and reflect on Juzʾ ʿAmma — the short sūrahs most of us recite in ṣalāh.",
-    days: [
-      { label: "An-Naba → ʿAbasa", est: "~12 min", target: { kind: "surah", surah: 78 } },
-      { label: "At-Takwīr → Al-Inshiqāq", est: "~10 min", target: { kind: "surah", surah: 81 } },
-      { label: "Al-Burūj → Al-Ghāshiyah", est: "~10 min", target: { kind: "surah", surah: 85 } },
-      { label: "Al-Fajr → Al-Layl", est: "~11 min", target: { kind: "surah", surah: 89 } },
-      { label: "Aḍ-Ḍuḥā → Al-ʿĀdiyāt", est: "~9 min", target: { kind: "surah", surah: 93 } },
-      { label: "Al-Qāriʿah → Al-Masad", est: "~8 min", target: { kind: "surah", surah: 101 } },
-      { label: "Al-Ikhlāṣ → An-Nās", est: "~4 min", target: { kind: "surah", surah: 112 } },
-    ],
+    desc: "Read a sūrah of Juzʾ ʿAmma each day — the short sūrahs most of us recite in ṣalāh.",
+    range: rangeOfSurahs(78, 114),
+    schedule: { kind: "fixed", unitsPerDay: 1 },
   },
   {
     id: "jewels",
@@ -72,47 +283,227 @@ export const PLANS: readonly ReadingPlan[] = [
     tag: "5 days",
     len: "A sūrah a day",
     desc: "Five beloved sūrahs to read slowly with their meanings.",
-    days: [
-      { label: "Al-Fātiḥah", est: "~3 min", target: { kind: "surah", surah: 1 } },
-      { label: "Yā-Sīn", est: "~15 min", target: { kind: "surah", surah: 36 } },
-      { label: "Ar-Raḥmān", est: "~12 min", target: { kind: "surah", surah: 55 } },
-      { label: "Al-Mulk", est: "~9 min", target: { kind: "surah", surah: 67 } },
-      { label: "Al-Kahf", est: "~25 min", target: { kind: "surah", surah: 18 } },
-    ],
+    range: surahList([1, 36, 55, 67, 18]),
+    schedule: { kind: "fixed", unitsPerDay: 1 },
   },
 ];
 
-export function planById(id: string): ReadingPlan | undefined {
-  return PLANS.find((p) => p.id === id);
+export function templateById(id: string): PlanTemplate | undefined {
+  return PLAN_TEMPLATES.find((t) => t.id === id);
 }
 
-/** The 1-based day the reader is on: the first uncompleted day, capped to the plan length. */
-export function currentPlanDay(plan: ReadingPlan, progress: PlanProgress): number {
-  for (let i = 0; i < plan.days.length; i++) {
-    if (!progress.completed.includes(i)) return i + 1;
+// ── Schedule maths ──────────────────────────────────────────────────────────
+
+/** Total atomic units in a range. */
+export function totalUnits(range: PlanRange): number {
+  return range.units.length;
+}
+
+function planTotal(plan: ActivePlan): number {
+  return plan.template.range.units.length;
+}
+
+/**
+ * The number of days the plan runs over. For `fixed`, derived from the cadence;
+ * for `targetDate`, the inclusive span to the end date. Throws a `RangeError`
+ * for an impossible plan (no units, a non-positive cadence, or an end date
+ * before the start).
+ */
+export function planDuration(plan: ActivePlan): number {
+  const total = planTotal(plan);
+  if (total <= 0) throw new RangeError("A plan must cover at least one unit.");
+  const s = plan.template.schedule;
+  if (s.kind === "fixed") {
+    if (!Number.isInteger(s.unitsPerDay) || s.unitsPerDay < 1) {
+      throw new RangeError("A fixed plan must read at least one unit per day.");
+    }
+    return Math.ceil(total / s.unitsPerDay);
   }
-  return plan.days.length;
+  const span = daysBetween(plan.startDate, s.endDate);
+  if (span < 0) throw new RangeError("The end date is before the start date.");
+  return span + 1;
 }
 
-export function planPercent(plan: ReadingPlan, progress: PlanProgress): number {
-  if (plan.days.length === 0) return 0;
-  return Math.round((progress.completed.length / plan.days.length) * 100);
+/** The date the plan is scheduled to finish (`YYYY-MM-DD`). */
+export function planEndDate(plan: ActivePlan): string {
+  const s = plan.template.schedule;
+  return s.kind === "targetDate" ? s.endDate : addDays(plan.startDate, planDuration(plan) - 1);
 }
 
-/** Toggle a 0-based day's completion, returning the next progress (pure). */
-export function togglePlanDay(progress: PlanProgress, dayIndex: number): PlanProgress {
-  const set = new Set(progress.completed);
-  if (set.has(dayIndex)) set.delete(dayIndex);
-  else set.add(dayIndex);
-  return { ...progress, completed: [...set].sort((a, b) => a - b) };
+/** Units that should be read by the end of day `day` (even distribution). */
+export function cumulativeUnits(plan: ActivePlan, day: number): number {
+  const total = planTotal(plan);
+  const dur = planDuration(plan);
+  if (day <= 0) return 0;
+  if (day >= dur) return total;
+  return Math.floor((day * total) / dur);
 }
 
-/** A window of up to seven plan days centred on the current day (1-based day numbers). */
-export function planWeekWindow(plan: ReadingPlan, day: number): number[] {
-  const len = plan.days.length;
+/** The calendar day the reader is on (1-based), clamped to the plan length. */
+export function currentDay(plan: ActivePlan, today: string): number {
+  const dur = planDuration(plan);
+  const d = daysBetween(plan.startDate, today) + 1;
+  return Math.min(Math.max(d, 1), dur);
+}
+
+/** Units still to read (never negative). */
+export function unitsRemaining(plan: ActivePlan): number {
+  return Math.max(0, planTotal(plan) - plan.unitsRead);
+}
+
+/** Completion as a 0–100 integer percentage. */
+export function percentComplete(plan: ActivePlan): number {
+  const total = planTotal(plan);
+  if (total === 0) return 0;
+  return Math.round((Math.min(plan.unitsRead, total) / total) * 100);
+}
+
+/** Whether everything scheduled through day `day` has been read. */
+export function isDayComplete(plan: ActivePlan, day: number): boolean {
+  return plan.unitsRead >= cumulativeUnits(plan, day);
+}
+
+/**
+ * How far ahead (+) or behind (−) schedule the reader is, in whole days. `0`
+ * means on track: you have finished every day before today and are working on
+ * today (or beyond is counted as ahead).
+ */
+export function daysAheadBehind(plan: ActivePlan, today: string): number {
+  const dur = planDuration(plan);
+  const cal = currentDay(plan, today);
+  let completed = 0;
+  for (let d = 1; d <= dur; d++) {
+    if (cumulativeUnits(plan, d) <= plan.unitsRead) completed = d;
+    else break;
+  }
+  if (completed >= cal) return completed - cal; // ahead
+  if (completed < cal - 1) return completed - (cal - 1); // behind
+  return 0;
+}
+
+/**
+ * The date the reader will actually finish at their current pace
+ * (`YYYY-MM-DD`). Falls back to the planned end date before any progress, and
+ * returns `today` once the plan is complete.
+ */
+export function projectedFinish(plan: ActivePlan, today: string): string {
+  const total = planTotal(plan);
+  if (plan.unitsRead >= total) return today;
+  const daysSoFar = daysBetween(plan.startDate, today) + 1;
+  if (daysSoFar < 1 || plan.unitsRead <= 0) return planEndDate(plan);
+  const pace = plan.unitsRead / daysSoFar;
+  const need = Math.ceil((total - plan.unitsRead) / pace);
+  return addDays(today, need);
+}
+
+/** What to read on day `day`, resolved to references and a label. */
+export function materializeDay(plan: ActivePlan, day: number): DayPortion {
+  const { unit, units } = plan.template.range;
+  const from = cumulativeUnits(plan, day - 1);
+  const to = cumulativeUnits(plan, day);
+  if (to <= from) {
+    return {
+      day,
+      unit,
+      count: 0,
+      fromUnit: 0,
+      toUnit: 0,
+      startRef: { sura: 1, aya: 1 },
+      endRef: { sura: 1, aya: 1 },
+      target: { kind: "surah", surah: 1 },
+      label: "Nothing scheduled",
+      est: "—",
+      empty: true,
+    };
+  }
+  const slice = units.slice(from, to);
+  const fromUnit = slice[0]!;
+  const toUnit = slice[slice.length - 1]!;
+  const startRef = unitStartRef(unit, fromUnit);
+  const endRef = unitEndRef(unit, toUnit);
+  return {
+    day,
+    unit,
+    count: slice.length,
+    fromUnit,
+    toUnit,
+    startRef,
+    endRef,
+    target: unitTarget(unit, fromUnit),
+    label: portionLabel(unit, slice),
+    est: `~${estimateMinutes(startRef, endRef)} min`,
+    empty: false,
+  };
+}
+
+/** Today's portion — what to read now to stay on schedule. */
+export function computeTodayPortion(plan: ActivePlan, today: string): DayPortion {
+  return materializeDay(plan, currentDay(plan, today));
+}
+
+/** A window of up to seven day numbers centred on `day` (for a week strip). */
+export function planWeekWindow(plan: ActivePlan, day: number): number[] {
+  const len = planDuration(plan);
   const size = Math.min(7, len);
   let start = day - 3;
   if (start < 1) start = 1;
   if (start + size - 1 > len) start = len - size + 1;
   return Array.from({ length: size }, (_, i) => start + i);
+}
+
+// ── Lifecycle (all pure; return the next state) ─────────────────────────────
+
+/** Begin a template on `startDate` with no progress yet. */
+export function activatePlan(template: PlanTemplate, startDate: string): ActivePlan {
+  return { template, startDate, unitsRead: 0 };
+}
+
+/** Set the linear cursor, clamped to `[0, total]`. */
+export function setUnitsRead(plan: ActivePlan, units: number): ActivePlan {
+  const total = planTotal(plan);
+  return { ...plan, unitsRead: Math.min(Math.max(0, Math.floor(units)), total) };
+}
+
+/**
+ * Toggle a day's completion: if it is already done, retreat the cursor to the
+ * end of the previous day; otherwise advance to the end of `day` (completing
+ * every earlier day too, since reading is linear).
+ */
+export function toggleDayComplete(plan: ActivePlan, day: number): ActivePlan {
+  const target = cumulativeUnits(plan, day);
+  const prev = cumulativeUnits(plan, day - 1);
+  return setUnitsRead(plan, plan.unitsRead >= target ? prev : target);
+}
+
+/**
+ * Re-pace a plan, keeping its progress and start date. Used by catch-up flows:
+ * "rebalance" passes the same end date (recomputing the daily amount), "extend"
+ * passes a later one. Throws for an impossible change.
+ */
+export function reschedule(plan: ActivePlan, change: RescheduleChange): ActivePlan {
+  if (change.kind === "targetDate" && daysBetween(plan.startDate, change.endDate) < 0) {
+    throw new RangeError("The end date is before the start date.");
+  }
+  if (change.kind === "fixed" && (!Number.isInteger(change.unitsPerDay) || change.unitsPerDay < 1)) {
+    throw new RangeError("A fixed plan must read at least one unit per day.");
+  }
+  return { ...plan, template: { ...plan.template, schedule: change } };
+}
+
+// ── Validation (for the custom-plan creator) ────────────────────────────────
+
+/** Human-readable problems with a draft plan ( `[]` when it is valid). */
+export function validatePlanDraft(draft: PlanDraft): string[] {
+  const errors: string[] = [];
+  if (draft.range.units.length === 0) errors.push("Choose at least one portion to read.");
+  if (draft.schedule.kind === "fixed") {
+    if (!Number.isInteger(draft.schedule.unitsPerDay) || draft.schedule.unitsPerDay < 1) {
+      errors.push("Read at least one unit per day.");
+    }
+  } else if (!isValidDateString(draft.schedule.endDate)) {
+    errors.push("Pick a valid end date.");
+  } else if (daysBetween(draft.startDate, draft.schedule.endDate) < 0) {
+    errors.push("The end date can’t be before the start date.");
+  }
+  return errors;
 }

--- a/packages/core/src/reading-plans.ts
+++ b/packages/core/src/reading-plans.ts
@@ -247,6 +247,11 @@ export function rangeOfSurahs(from: number, to: number): PlanRange {
   return { unit: "surah", units: seq(from, to) };
 }
 
+/** A contiguous ḥizb range, e.g. `rangeOfHizb(1, 60)` for the whole Quran. */
+export function rangeOfHizb(from: number, to: number): PlanRange {
+  return { unit: "hizb", units: seq(from, to) };
+}
+
 /** A contiguous page range. */
 export function rangeOfPages(from: number, to: number): PlanRange {
   return { unit: "page", units: seq(from, to) };
@@ -257,7 +262,11 @@ export function surahList(units: number[]): PlanRange {
   return { unit: "surah", units: [...units] };
 }
 
-/** The built-in catalogue, shared by web and mobile. */
+/**
+ * The built-in catalogue, bundled in core so it loads offline on web *and*
+ * mobile (the same "shared via core" approach as the Duʿās). `packages/data`
+ * re-serves it through `PlanCatalogPort` for the API; see the reading-plans ADR.
+ */
 export const PLAN_TEMPLATES: readonly PlanTemplate[] = [
   {
     id: "ramadan-khatm",
@@ -267,6 +276,33 @@ export const PLAN_TEMPLATES: readonly PlanTemplate[] = [
     desc: "Complete the Quran in a month, one juzʾ each day.",
     range: rangeOfJuz(1, 30),
     schedule: { kind: "fixed", unitsPerDay: 1 },
+  },
+  {
+    id: "juz-sprint",
+    name: "30-Day Juzʾ Sprint",
+    tag: "30 days",
+    len: "Juzʾ a day",
+    desc: "Finish the whole Quran in a month — one juzʾ a day, any time of year.",
+    range: rangeOfJuz(1, 30),
+    schedule: { kind: "fixed", unitsPerDay: 1 },
+  },
+  {
+    id: "quran-60",
+    name: "Quran in 60 Days",
+    tag: "60 days",
+    len: "Ḥizb a day",
+    desc: "A gentler pace — one ḥizb (half a juzʾ) each day completes the Quran in two months.",
+    range: rangeOfHizb(1, 60),
+    schedule: { kind: "fixed", unitsPerDay: 1 },
+  },
+  {
+    id: "quran-year",
+    name: "Quran in a Year",
+    tag: "≈ 10 months",
+    len: "2 pages a day",
+    desc: "Two pages a day — a sustainable habit that completes the Quran in under a year.",
+    range: rangeOfPages(1, 604),
+    schedule: { kind: "fixed", unitsPerDay: 2 },
   },
   {
     id: "juz-amma",

--- a/packages/data/src/index.test.ts
+++ b/packages/data/src/index.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@ummahlibrary/core";
 import { describe, expect, it } from "vitest";
 import {
+  BundledPlanCatalog,
   FileHadithRepository,
   FileQuranRepository,
   FileTranslationRepository,
@@ -20,6 +21,7 @@ import surahsData from "../datasets/surahs.json";
 const quran = new FileQuranRepository();
 const translations = new FileTranslationRepository();
 const hadith = new FileHadithRepository();
+const planCatalog = new BundledPlanCatalog();
 
 describe("FileQuranRepository", () => {
   it("lists all 114 surahs with full metadata", async () => {
@@ -133,6 +135,21 @@ describe("FileHadithRepository", () => {
     expect(await hadith.getCollection("nope")).toBeNull();
     expect(await hadith.getCollection("../secrets")).toBeNull();
     expect(await hadith.getSection("../secrets", 1)).toBeNull();
+  });
+});
+
+describe("BundledPlanCatalog", () => {
+  it("serves the catalogue bundled in core (loads offline)", async () => {
+    const all = await planCatalog.all();
+    expect(all.length).toBeGreaterThanOrEqual(5);
+    expect(all.map((t) => t.id)).toEqual(
+      expect.arrayContaining(["ramadan-khatm", "juz-sprint", "quran-60", "quran-year", "juz-amma"]),
+    );
+  });
+
+  it("finds a template by id and misses gracefully", async () => {
+    expect((await planCatalog.byId("ramadan-khatm"))?.name).toBe("Ramaḍān Khatm");
+    expect(await planCatalog.byId("nope")).toBeNull();
   });
 });
 

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -25,6 +25,8 @@ import type {
   HadithCollection,
   HadithRepository,
   HadithSection,
+  PlanCatalogPort,
+  PlanTemplate,
   QuranRepository,
   Surah,
   TranslatedAyah,
@@ -34,6 +36,7 @@ import type {
 } from "@ummahlibrary/core";
 import type { ContentPlugin } from "@ummahlibrary/core";
 import {
+  PLAN_TEMPLATES,
   PluginRegistry,
   filterByOccasion,
   isValidSurahNumber,
@@ -185,6 +188,21 @@ const ASMA = asmaData.names as readonly DivineName[];
 export class FileAsmaRepository implements AsmaRepository {
   all(): Promise<readonly DivineName[]> {
     return Promise.resolve(ASMA);
+  }
+}
+
+/**
+ * Serves the reading-plan catalogue. The curated templates are bundled in
+ * `core` (so both apps load them offline, like the Duʿās); this adapter
+ * re-serves them through `PlanCatalogPort` so the API and any future remote
+ * catalogue depend only on the port, never on where the templates live.
+ */
+export class BundledPlanCatalog implements PlanCatalogPort {
+  all(): Promise<readonly PlanTemplate[]> {
+    return Promise.resolve(PLAN_TEMPLATES);
+  }
+  byId(id: string): Promise<PlanTemplate | null> {
+    return Promise.resolve(PLAN_TEMPLATES.find((t) => t.id === id) ?? null);
   }
 }
 


### PR DESCRIPTION
Foundation for the Reading Plans cluster, built core-up.

## #59 — Core schedule engine
- Pure, deterministic domain in `packages/core/src/reading-plans.ts`: plan **templates** vs. **active plans**; juzʾ/ḥizb/page/sūrah/ayah units; `fixed` and `targetDate` strategies spread by an even cumulative distribution, so a target-date plan finishes on or before its end date.
- `computeTodayPortion`, `unitsRemaining`, `daysAheadBehind`, `percentComplete`, `projectedFinish`, `reschedule` (+ supporting maths), reusing `quran-structure` conversions and `reading-goals` date helpers.
- Web + mobile plan screens migrated onto `ActivePlan`; UI and behaviour unchanged.

## #60 — Catalogue as data, served via a port
- Catalogue expanded to the launch set — Ramaḍān Khatm, 30-Day Juzʾ Sprint, Quran in 60 Days, Quran in a Year, A Sūrah a Day, Jewels — bundled in core so **both apps load it offline**.
- `PlanCatalogPort` (core) + `BundledPlanCatalog` (data) re-serving core's list through the port; wired as `planCatalog` in the API.
- Catalogue stays in core (not a `packages/data` JSON) because mobile can't import `packages/data` (`node:fs`); to be recorded in the reading-plans ADR (#65).

## Checks
lint clean · typecheck 7/7 · 373 unit tests · coverage thresholds met (`reading-plans.ts` 100% lines / 97% branches). `build` + e2e validated by CI.

Closes #59. Closes #60.