### PR TITLE
feat(core): persist reading plans behind a PlanStore port (ADR 0024)

### DIFF
--- a/apps/mobile/src/plan-store.ts
+++ b/apps/mobile/src/plan-store.ts
@@ -1,0 +1,14 @@
+/**
+ * Mobile `PlanStore` adapter (ADR 0024): the reader's active plan in
+ * AsyncStorage under `ul.readingPlan`. Persistence only — the plan logic lives
+ * in `@ummahlibrary/core` — so a synced adapter (#25) can replace it without
+ * touching the feature. Mirrors the web adapter.
+ */
+import type { ActivePlan, PlanStore } from "@ummahlibrary/core";
+import { KEYS, getJSON, setJSON } from "./storage";
+
+export const mobilePlanStore: PlanStore = {
+  read: () => getJSON<ActivePlan | null>(KEYS.readingPlan, null),
+  write: (plan) => setJSON(KEYS.readingPlan, plan),
+  clear: () => setJSON(KEYS.readingPlan, null),
+};

--- a/apps/mobile/src/plans.ts
+++ b/apps/mobile/src/plans.ts
@@ -1,11 +1,10 @@
 /**
- * Reading-plan persistence for mobile. The plan catalogue and the pure schedule
- * maths are shared in `@ummahlibrary/core`; this layer holds the started plan
- * (an `ActivePlan` snapshot) in AsyncStorage (`ul.readingPlan`, ADR 0006). Only
- * one plan is active at a time.
+ * Reading-plan glue for mobile. The plan catalogue and pure schedule maths are
+ * shared in `@ummahlibrary/core`; persistence goes through the `PlanStore` port
+ * (mobile adapter `mobilePlanStore`, ADR 0024). Only one plan is active.
  */
 import { type ActivePlan, activatePlan, templateById, toggleDayComplete } from "@ummahlibrary/core";
-import { KEYS, getJSON, setJSON } from "./storage";
+import { mobilePlanStore as store } from "./plan-store";
 
 export {
   PLAN_TEMPLATES,
@@ -23,20 +22,20 @@ export function todayStr(d = new Date()): string {
 }
 
 export function readActivePlan(): Promise<ActivePlan | null> {
-  return getJSON<ActivePlan | null>(KEYS.readingPlan, null);
+  return store.read();
 }
 
 export async function startPlan(templateId: string): Promise<void> {
   const template = templateById(templateId);
-  if (template) await setJSON(KEYS.readingPlan, activatePlan(template, todayStr()));
+  if (template) await store.write(activatePlan(template, todayStr()));
 }
 
 export async function clearPlan(): Promise<void> {
-  await setJSON(KEYS.readingPlan, null);
+  await store.clear();
 }
 
 /** Toggle a 1-based day's completion (advances/retreats the linear cursor). */
 export async function toggleDay(day: number): Promise<void> {
-  const plan = await readActivePlan();
-  if (plan) await setJSON(KEYS.readingPlan, toggleDayComplete(plan, day));
+  const plan = await store.read();
+  if (plan) await store.write(toggleDayComplete(plan, day));
 }

--- a/apps/web/src/components/PlansView.tsx
+++ b/apps/web/src/components/PlansView.tsx
@@ -55,9 +55,13 @@ export function PlansView() {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    const refresh = () => setPlan(readActivePlan());
+    const refresh = () => {
+      void readActivePlan().then((p) => {
+        setPlan(p);
+        setReady(true);
+      });
+    };
     refresh();
-    setReady(true);
     window.addEventListener(READING_PLAN_EVENT, refresh);
     return () => window.removeEventListener(READING_PLAN_EVENT, refresh);
   }, []);
@@ -175,7 +179,7 @@ export function PlansView() {
           <div style={{ display: "flex", gap: 9, flexWrap: "wrap", marginTop: 14 }}>
             <button
               type="button"
-              onClick={() => toggleDay(day)}
+              onClick={() => void toggleDay(day)}
               className="noor-press"
               style={{
                 padding: "9px 16px",
@@ -192,7 +196,7 @@ export function PlansView() {
             </button>
             <button
               type="button"
-              onClick={() => clearPlan()}
+              onClick={() => void clearPlan()}
               className="noor-press"
               style={{
                 padding: "9px 16px",
@@ -289,7 +293,7 @@ export function PlansView() {
               type="button"
               onClick={() => {
                 if (isActive && portion) window.location.href = targetHref(portion);
-                else startPlan(pl.id);
+                else void startPlan(pl.id);
               }}
               className="noor-press"
               style={{

--- a/apps/web/src/lib/plan-store.test.ts
+++ b/apps/web/src/lib/plan-store.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { activatePlan, buildBackup, templateById, toggleDayComplete } from "@ummahlibrary/core";
+import { webPlanStore } from "./plan-store";
+import {
+  READING_PLAN_EVENT,
+  clearPlan,
+  readActivePlan,
+  startPlan,
+  todayStr,
+  toggleDay,
+} from "./reading-plan";
+import { clearAllData, collectLocalData, importBackup } from "./backup";
+
+/** An active plan with a little progress, for round-trip checks. */
+const samplePlan = () => toggleDayComplete(activatePlan(templateById("ramadan-khatm")!, "2026-03-01"), 3);
+
+describe("webPlanStore (PlanStore adapter)", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("round-trips an active plan through storage (survives reload)", async () => {
+    expect(await webPlanStore.read()).toBeNull();
+    const plan = samplePlan();
+    await webPlanStore.write(plan);
+    expect(await webPlanStore.read()).toEqual(plan);
+    await webPlanStore.clear();
+    expect(await webPlanStore.read()).toBeNull();
+  });
+
+  it("reads null when storage holds garbage", async () => {
+    localStorage.setItem("ul.readingPlan", "{not json");
+    expect(await webPlanStore.read()).toBeNull();
+  });
+});
+
+describe("reading-plan glue", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("starts, toggles and clears the active plan, emitting refresh events", async () => {
+    let events = 0;
+    const onEvt = () => {
+      events++;
+    };
+    window.addEventListener(READING_PLAN_EVENT, onEvt);
+
+    expect(await readActivePlan()).toBeNull();
+    await startPlan("ramadan-khatm");
+    expect((await readActivePlan())?.template.id).toBe("ramadan-khatm");
+
+    await toggleDay(1);
+    expect((await readActivePlan())?.unitsRead).toBe(1);
+
+    await clearPlan();
+    expect(await readActivePlan()).toBeNull();
+
+    window.removeEventListener(READING_PLAN_EVENT, onEvt);
+    expect(events).toBeGreaterThanOrEqual(3); // start + toggle + clear
+  });
+
+  it("ignores an unknown template and formats today as YYYY-MM-DD", async () => {
+    await startPlan("does-not-exist");
+    expect(await readActivePlan()).toBeNull();
+    expect(todayStr(new Date(2026, 2, 5))).toBe("2026-03-05");
+  });
+});
+
+describe("plan state through export/import (acceptance #61)", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("survives an export → wipe → import round-trip", async () => {
+    const plan = samplePlan();
+    await webPlanStore.write(plan);
+
+    // Export everything, then simulate a fresh device.
+    const fileText = JSON.stringify(buildBackup(collectLocalData(), new Date()));
+    clearAllData();
+    expect(await webPlanStore.read()).toBeNull();
+
+    // Import the backup → the plan comes back intact.
+    const result = importBackup(fileText, "replace");
+    expect(result.ok).toBe(true);
+    expect(await webPlanStore.read()).toEqual(plan);
+  });
+});

--- a/apps/web/src/lib/plan-store.ts
+++ b/apps/web/src/lib/plan-store.ts
@@ -1,0 +1,34 @@
+/**
+ * Web `PlanStore` adapter (ADR 0024): the reader's active plan in `localStorage`
+ * under `ul.readingPlan`. Persistence is the only thing this layer does — the
+ * plan logic lives in `@ummahlibrary/core` — so a synced adapter (#25) can
+ * replace it without touching the feature. Mirrors the mobile adapter.
+ */
+import type { ActivePlan, PlanStore } from "@ummahlibrary/core";
+
+const KEY = "ul.readingPlan";
+
+export const webPlanStore: PlanStore = {
+  read: async () => {
+    try {
+      const raw = localStorage.getItem(KEY);
+      return raw ? (JSON.parse(raw) as ActivePlan) : null;
+    } catch {
+      return null;
+    }
+  },
+  write: async (plan) => {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(plan));
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  clear: async () => {
+    try {
+      localStorage.removeItem(KEY);
+    } catch {
+      /* ignore */
+    }
+  },
+};

--- a/apps/web/src/lib/reading-plan.ts
+++ b/apps/web/src/lib/reading-plan.ts
@@ -1,14 +1,12 @@
 /**
- * Local-first reading-plan progress (ADR 0006). The plan catalogue and the pure
- * schedule maths live in `@ummahlibrary/core`; this layer persists the *started*
- * plan (an `ActivePlan` snapshot) in `localStorage` (`ul.readingPlan`) and
- * broadcasts a window event so the plans page re-renders. Mirrors the mobile
- * persistence.
+ * Local-first reading-plan glue. Persistence goes through the `PlanStore` port
+ * (web adapter `webPlanStore`, ADR 0024); this layer adds the business helpers
+ * and broadcasts a window event so the plans page re-renders. Mirrors mobile.
  */
 import { type ActivePlan, activatePlan, templateById, toggleDayComplete } from "@ummahlibrary/core";
+import { webPlanStore as store } from "./plan-store";
 
 export const READING_PLAN_EVENT = "ul.readingPlan";
-const KEY = "ul.readingPlan";
 
 /** Today as a local `YYYY-MM-DD` string — the clock the pure core is fed. */
 export function todayStr(d = new Date()): string {
@@ -24,40 +22,26 @@ function emit(): void {
   }
 }
 
-export function readActivePlan(): ActivePlan | null {
-  try {
-    const raw = localStorage.getItem(KEY);
-    return raw ? (JSON.parse(raw) as ActivePlan) : null;
-  } catch {
-    return null;
-  }
+export function readActivePlan(): Promise<ActivePlan | null> {
+  return store.read();
 }
 
-function write(plan: ActivePlan): void {
-  try {
-    localStorage.setItem(KEY, JSON.stringify(plan));
-  } catch {
-    /* storage unavailable */
-  }
+export async function startPlan(templateId: string): Promise<void> {
+  const template = templateById(templateId);
+  if (!template) return;
+  await store.write(activatePlan(template, todayStr()));
   emit();
 }
 
-export function startPlan(templateId: string): void {
-  const template = templateById(templateId);
-  if (template) write(activatePlan(template, todayStr()));
-}
-
-export function clearPlan(): void {
-  try {
-    localStorage.removeItem(KEY);
-  } catch {
-    /* ignore */
-  }
+export async function clearPlan(): Promise<void> {
+  await store.clear();
   emit();
 }
 
 /** Toggle a 1-based day's completion (advances/retreats the linear cursor). */
-export function toggleDay(day: number): void {
-  const plan = readActivePlan();
-  if (plan) write(toggleDayComplete(plan, day));
+export async function toggleDay(day: number): Promise<void> {
+  const plan = await store.read();
+  if (!plan) return;
+  await store.write(toggleDayComplete(plan, day));
+  emit();
 }

--- a/docs/adr/0024-local-storage-ports.md
+++ b/docs/adr/0024-local-storage-ports.md
@@ -1,0 +1,56 @@
+# ADR 0024 — Typed storage ports for local-first state
+
+- **Status:** Accepted
+- **Date:** 2026-06-15
+
+## Context
+
+Local-first state (ADR 0006) — reading plans, goals/streaks, bookmarks, notes,
+tasbih, the prayer tracker — is read and written by touching `localStorage`
+(web) or `AsyncStorage` (mobile) **directly** in each app's glue. The pure logic
+lives in `core`, but the persistence boundary is implicit and duplicated per
+platform.
+
+Cross-device **sync** is now on the roadmap (Phase 4, #25). It will add a
+backend implementation of persistence, and we don't want to rewrite every
+feature's reads and writes when it lands. Hifz already anticipates this: its
+state sits behind `HifzRepository` (ADR 0007), so a SQLite/Postgres adapter can
+replace the local one without touching the SM-2 logic or the UI. The local-data
+backup (ADR 0018) is the manual substitute today and is deliberately
+key-agnostic.
+
+## Decision
+
+**Persist each local-first feature behind its own typed port in `core`** — the
+same shape as `HifzRepository`: a `PlanStore` (`read`/`write`/`clear`), then a
+`ReadingGoalsStore`, a `BookmarksStore`, and so on. Each port has a **web
+adapter** (`localStorage`) and a **mobile adapter** (`AsyncStorage`) in the app
+layer; feature glue and UI depend only on the port. Values stay under the same
+`ul.*` keys, so the backup (ADR 0018) keeps working unchanged.
+
+We chose **typed per-feature ports over a single generic key-value store**: it
+matches the `HifzRepository` precedent, gives each feature an explicit,
+type-checked contract (no string keys or `JSON.parse` casts at the call sites),
+and reads clearly. When sync lands (#25), the per-platform adapters will share
+**one** synced engine underneath, so there is a single sync seam without a
+bespoke sync implementation per feature.
+
+This is the **seam** for #25: swapping local persistence for synced persistence
+becomes "provide a different adapter," with zero changes to feature logic or UI.
+
+## Consequences
+
+- **Good:** every feature's persistence is explicit, typed and swappable; the
+  future sync work (#25) is an adapter, not a rewrite; tests inject an in-memory
+  fake instead of stubbing `localStorage`; web and mobile share one contract
+  instead of two drifting glue files.
+- **Cost:** more surface than direct storage — one port plus two small adapters
+  per feature. Mitigated by keeping adapters tiny and migrating one feature per
+  PR (#73 tracks the rollout; #61 — reading plans — is the first).
+- **Async reads:** the ports return `Promise`s (web `localStorage` is sync, but
+  the contract is uniform), so a couple of web call sites that read
+  synchronously today become `await`/`.then` — already the norm on mobile.
+- **Backup unchanged:** values still live under `ul.*` and the backup stays
+  key-agnostic (ADR 0018); a port does not impose a per-key schema.
+- **Scope:** this records the *pattern*; the actual sync backend (accounts,
+  server, conflict resolution) remains the Phase 4 decision in #25.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ through Phases 1–3; later decisions get their own record at the time they're m
 | [0021](0021-global-search.md)                 | Global search: one client index over several sources        | Accepted |
 | [0022](0022-hadith-ingested-search.md)        | Hadith ingested at build time, searched on the client       | Accepted |
 | [0023](0023-noor-design-system.md)            | Noor design system: single source of truth across web and mobile | Accepted |
+| [0024](0024-local-storage-ports.md)           | Typed storage ports for local-first state (the sync seam)   | Accepted |
 
 ## Writing a new ADR
 

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -18,7 +18,7 @@ import type {
 } from "./entities";
 import type { HifzCard } from "./hifz";
 import type { Coordinates, Madhab, PrayerTimings } from "./prayer";
-import type { PlanTemplate } from "./reading-plans";
+import type { ActivePlan, PlanTemplate } from "./reading-plans";
 
 /** Access to the Arabic Quran text and surah structure. */
 export interface QuranRepository {
@@ -166,4 +166,18 @@ export interface HifzRepository {
   due(now: Date): Promise<readonly HifzRecord[]>;
   /** Every tracked card, in mushaf order. */
   all(): Promise<readonly HifzRecord[]>;
+}
+
+/**
+ * Persists the reader's single active reading plan on-device (ADR 0024). The web
+ * adapter uses `localStorage`, mobile uses `AsyncStorage`; a synced adapter can
+ * replace either without touching the plan logic or UI — the seam for #25.
+ */
+export interface PlanStore {
+  /** The active plan, or `null` if none is in progress. */
+  read(): Promise<ActivePlan | null>;
+  /** Save (or replace) the active plan. */
+  write(plan: ActivePlan): Promise<void>;
+  /** Stop the active plan. */
+  clear(): Promise<void>;
 }


### PR DESCRIPTION
The first slice of the storage-port rollout (#73) and the **seam** for cross-device sync (#25).

## What
- **ADR 0024** — typed per-feature storage ports (the `HifzRepository` pattern), chosen over a generic key-value store; the seam for Phase 4 sync.
- **`PlanStore` port** in `core` (`read`/`write`/`clear`).
- **Adapters:** `webPlanStore` (localStorage) + `mobilePlanStore` (AsyncStorage) — persistence only.
- **Migration:** the web glue + `PlansView` (reads become async) and the mobile glue move onto the port; UI and behaviour unchanged.

## Acceptance (#61)
- ✅ Plan state survives reload / works offline.
- ✅ **Round-trips through export/import** — test writes a plan → exports → wipes the "device" → imports → intact.
- ✅ No plan data leaves the device.

Deliberately did **not** bump `BACKUP_VERSION`: the backup is key-agnostic (ADR 0018) and the format is unchanged — recorded in ADR 0024.

## Checks
lint clean · typecheck 7/7 · 378 unit tests · coverage thresholds met. `build` + e2e via CI.

Closes #61. Part of #73.