### PR TITLE
feat(api): expose the reading-plan catalogue (REST + tRPC + OpenAPI)

### DIFF
--- a/apps/web/src/app/api/v1/openapi.json/route.ts
+++ b/apps/web/src/app/api/v1/openapi.json/route.ts
@@ -90,6 +90,27 @@ const spec = {
         },
       },
     },
+    "/plans/catalogue": {
+      get: {
+        summary: "List the reading-plan catalogue (templates a reader can start)",
+        responses: {
+          "200": {
+            description: "Plan templates",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    count: { type: "integer" },
+                    plans: { type: "array", items: { $ref: "#/components/schemas/PlanTemplate" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
   components: {
     schemas: {
@@ -132,6 +153,32 @@ const spec = {
           aya: { type: "integer" },
           translationId: { type: "string" },
           text: { type: "string" },
+        },
+      },
+      PlanTemplate: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          tag: { type: "string", description: 'Short badge, e.g. "30 days"' },
+          len: { type: "string", description: 'Cadence label, e.g. "Juzʾ a day"' },
+          desc: { type: "string" },
+          range: {
+            type: "object",
+            properties: {
+              unit: { type: "string", enum: ["juz", "hizb", "page", "surah", "ayah"] },
+              units: { type: "array", items: { type: "integer" }, description: "Ordered 1-based unit indices" },
+            },
+          },
+          schedule: {
+            type: "object",
+            description: "A fixed cadence or a target date",
+            properties: {
+              kind: { type: "string", enum: ["fixed", "targetDate"] },
+              unitsPerDay: { type: "integer" },
+              endDate: { type: "string", format: "date" },
+            },
+          },
         },
       },
     },

--- a/apps/web/src/app/api/v1/plans/catalogue/route.ts
+++ b/apps/web/src/app/api/v1/plans/catalogue/route.ts
@@ -1,0 +1,11 @@
+import { planCatalog } from "@ummahlibrary/api";
+import { apiJson } from "../../../../../lib/api-response";
+
+export const dynamic = "force-static";
+
+// The reading-plan catalogue (templates only). Progress is local-first device
+// state (ADR 0006), so it is never served here — there are no plan mutations.
+export async function GET() {
+  const plans = await planCatalog.all();
+  return apiJson({ count: plans.length, plans });
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,12 +23,18 @@ OpenAPI spec: [`/api/v1/openapi.json`](https://app.ummahlibrary.org/api/v1/opena
 | `GET /api/v1/surahs/{number}`                        | `{ surah: Surah, ayahs: Ayah[] }` (Arabic)    |
 | `GET /api/v1/editions`                               | `{ count, editions: Translation[] }`          |
 | `GET /api/v1/surahs/{number}/translations/{edition}` | `{ surah, edition, ayahs: TranslatedAyah[] }` |
+| `GET /api/v1/plans/catalogue`                        | `{ count, plans: PlanTemplate[] }`            |
 | `GET /api/v1/search/corpus`                          | `{ count, verses: { s, a, t }[] }` (full Arabic corpus, powers client-side search) |
 | `GET /api/v1/openapi.json`                           | OpenAPI 3 document                            |
 
 Tafsir, the runtime translation catalogue, and Hadith sections are also served
 under `/api/v1` (fetched on demand by the reader); see the OpenAPI document for
 the complete list.
+
+Reading **plans** expose only the catalogue (`/plans/catalogue`). A reader's
+progress is local-first device state (ADR 0006) that never leaves the device, so
+there are no plan-progress endpoints — starting, advancing and re-pacing a plan
+all happen client-side.
 
 `{number}` is `1`–`114`; `{edition}` is a translation id from `/editions`
 (e.g. `eng-khattab`, `urd-jalandhry`, `ben-muhiuddinkhan`).
@@ -62,6 +68,15 @@ type Translation = {
   direction: "rtl" | "ltr";
 };
 type TranslatedAyah = Ayah & { translationId: string };
+type PlanTemplate = {
+  id: string;
+  name: string;
+  tag: string; // short badge, e.g. "30 days"
+  len: string; // cadence, e.g. "Juzʾ a day"
+  desc: string;
+  range: { unit: "juz" | "hizb" | "page" | "surah" | "ayah"; units: number[] };
+  schedule: { kind: "fixed"; unitsPerDay: number } | { kind: "targetDate"; endDate: string };
+};
 ```
 
 ---
@@ -76,6 +91,7 @@ Endpoint: `/api/trpc`. Procedures (all queries):
 | `getSurah`       | `{ number }`          | `{ surah, ayahs } \| null` |
 | `listEditions`   | —                     | `Translation[]`            |
 | `getTranslation` | `{ edition, number }` | `TranslatedAyah[]`         |
+| `listPlanTemplates` | —                  | `PlanTemplate[]`           |
 
 The `AppRouter` type is exported from `@ummahlibrary/api` for end-to-end type
 safety in TypeScript clients:

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -8,6 +8,7 @@ import { initTRPC } from "@trpc/server";
 import { z } from "zod";
 import {
   hadithRepository,
+  planCatalog,
   pluginRegistry,
   quranRepository,
   tafsirRepository,
@@ -57,6 +58,13 @@ export const appRouter = t.router({
   getHadithSection: t.procedure
     .input(z.object({ collection: z.string(), section: z.number().int().min(1) }))
     .query(({ input }) => hadithRepository.getSection(input.collection, input.section)),
+
+  /**
+   * The reading-plan catalogue (templates a reader can start). Read-only — a
+   * reader's *progress* is local-first device state (ADR 0006), never on the
+   * server, so there are no plan mutations here.
+   */
+  listPlanTemplates: t.procedure.query(() => planCatalog.all()),
 });
 
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
Exposes the reading-plan catalogue through the public API — the read-only piece of #62's "tRPC plan router + REST mirror".

## What
- **`listPlanTemplates`** — read-only tRPC query over the `planCatalog` port (on `main` from #60).
- **`GET /api/v1/plans/catalogue`** — static (`force-static`) REST mirror, exactly like `/adhkar` and `/names`.
- **OpenAPI:** `/plans/catalogue` path + a `PlanTemplate` schema.
- **`docs/API.md`:** REST + tRPC rows, the `PlanTemplate` type, and a note on local-first progress.

## Scope decision
The issue also listed progress mutations (`start`/`recordProgress`/`repace`/`pause`/`abandon`). These are **not** server endpoints: the tRPC API is read-only over the core ports and there is no user state on the server (local-first, no accounts — ADR 0006). Those mutations already exist as the client-side `PlanStore` glue from #61, so the acceptance line *"mutations operate on local state in the client build"* is already satisfied. Documented in `docs/API.md`; flagged for the reading-plans ADR (#65).

## Acceptance (#62)
- ✅ `GET /api/v1/plans/catalogue` exposed + documented in `docs/API.md` and OpenAPI.
- ✅ Mutations operate on local state in the client build (the #61 `PlanStore` glue).

## Checks
lint clean · typecheck 7/7 · 378 tests. Route is `force-static`; build + e2e via CI.

Closes #62.