### PR TITLE
docs(adr): record the reading-plans architecture (ADR 0025)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,18 +31,19 @@ the operational checklist.
 
 ## Where does it go?
 
-| You're adding…                                   | Put it in                                                    |
-| ------------------------------------------------ | ------------------------------------------------------------ |
-| Domain type / pure logic / structural invariant  | `packages/core`                                              |
-| A new capability boundary (an interface)         | `packages/core/src/ports.ts`                                 |
-| Quran text/structure handling, ingestion         | `packages/data`                                              |
-| An adapter for something external (DB, HTTP, AI) | `packages/adapters` (implements a core port)                 |
-| Wiring repositories / a tRPC procedure / REST    | `packages/api` (router) or `apps/web/src/app/api`            |
-| Web UI                                           | `apps/web`                                                   |
-| Mobile UI                                        | `apps/mobile`                                                |
-| Shared, framework-light UI                       | `packages/ui`                                                |
-| **Design token / colour / Noor primitive**        | `packages/ui/src/` — _never in apps_                        |
-| **A translation / reciter / tafsir / hadith**    | a **JSON manifest** in `packages/data/plugins/` — _not code_ |
+| You're adding…                                   | Put it in                                                                                                  |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| Domain type / pure logic / structural invariant  | `packages/core`                                                                                            |
+| A new capability boundary (an interface)         | `packages/core/src/ports.ts`                                                                               |
+| Quran text/structure handling, ingestion         | `packages/data`                                                                                            |
+| An adapter for something external (DB, HTTP, AI) | `packages/adapters` (implements a core port)                                                               |
+| Wiring repositories / a tRPC procedure / REST    | `packages/api` (router) or `apps/web/src/app/api`                                                          |
+| Web UI                                           | `apps/web`                                                                                                 |
+| Mobile UI                                        | `apps/mobile`                                                                                              |
+| Shared, framework-light UI                       | `packages/ui`                                                                                              |
+| **Design token / colour / Noor primitive**       | `packages/ui/src/` — _never in apps_                                                                       |
+| **A translation / reciter / tafsir / hadith**    | a **JSON manifest** in `packages/data/plugins/` — _not code_                                               |
+| **A reading-plan template / schedule rule**      | `packages/core` (`reading-plans.ts`) — bundled, _not_ `data` (ADR 0025); progress via the `PlanStore` port |
 
 If an app needs data, it goes through **`api`**, not `data`/`adapters` directly.
 

--- a/docs/adr/0025-reading-plans.md
+++ b/docs/adr/0025-reading-plans.md
@@ -1,0 +1,54 @@
+# ADR 0025 — Reading plans: a pure schedule engine, catalogue bundled in core
+
+- **Status:** Accepted
+- **Date:** 2026-06-15
+
+## Context
+
+Readers want structured journeys through the Quran — finish in Ramaḍān, read
+Juzʾ ʿAmma, complete the whole muṣḥaf by a date they pick. This spans two needs:
+**preset** plans (a fixed cadence, e.g. a juzʾ a day) and **custom** plans (pick
+an end date, or N pages a day, and have the app compute the pace). It must work
+**offline on web and mobile** and, like everything else, stay local-first with no
+accounts (ADR 0006).
+
+## Decision
+
+**A pure schedule engine in `core` (`reading-plans.ts`).** Plan _templates_ (a
+reusable catalogue entry) are separated from a reader's _active plan_ (a started
+template + start date + a linear `unitsRead` cursor). A plan covers an ordered
+list of units — juzʾ / ḥizb / page / sūrah / ayah, converted via the existing
+`quran-structure` invariants — paced by one of two strategies: `fixed` (a set
+cadence) or `targetDate` (a chosen finish date). Both are spread by an even
+cumulative distribution (`cum(d) = ⌊d·total / days⌋`) so a target-date plan
+finishes on or before its date. Everything is deterministic and unit-tested; the
+clock is injected (a `today` string), never read inside `core`.
+
+**The catalogue is bundled in `core`, not `packages/data`.** The small curated
+templates are shared offline by both apps the same way the Duʿās are — straight
+from `core` — because **mobile cannot import `packages/data`** (it pulls in
+`node:fs`, which Metro can't bundle). A `PlanCatalogPort` plus a thin
+`BundledPlanCatalog` adapter in `packages/data` re-serve the list so the API (and
+any future remote catalogue) depend only on the port. This is a deliberate
+exception to "content lives in `data`", justified by the offline-on-mobile
+constraint.
+
+**Progress is local-first device state behind the `PlanStore` port** (ADR 0024):
+one active plan at a time, persisted under `ul.readingPlan` and carried by the
+key-agnostic backup (ADR 0018). The public API therefore exposes **only the
+catalogue** (read-only `listPlanTemplates` / `GET /api/v1/plans/catalogue`);
+there are no server plan mutations, because there is no server-side user state —
+starting, advancing and re-pacing all happen client-side.
+
+## Consequences
+
+- **Good:** one engine drives presets, custom target-date plans, and the
+  re-pace/catch-up maths (`reschedule`, `daysAheadBehind`, `projectedFinish`); it
+  works offline on both platforms; catalogue and progress are each swappable
+  behind a port, so cross-device sync (Phase 4, #25) becomes an adapter swap.
+- **Cost:** the catalogue sits in `core` rather than `data` (the documented
+  exception above); and `core` labels are number-based ("Sūrah 78") because
+  `core` can't import the names dataset — apps prettify them.
+- **Scope:** this records the model. The catalogue / custom-plan UI, the progress
+  detail view, reader auto-advance, the re-pace UX, reminders and the share card
+  are follow-ups (#67–#71); mobile parity is #64.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,32 +7,33 @@ record is short: the problem, the decision, and what it costs us.
 ADRs 0002–0009 were written together to document decisions already made and shipped
 through Phases 1–3; later decisions get their own record at the time they're made.
 
-| #                                             | Decision                                                    | Status   |
-| --------------------------------------------- | ----------------------------------------------------------- | -------- |
-| [0001](0001-modular-monolith.md)              | Modular monolith with lint-enforced boundaries              | Accepted |
-| [0002](0002-quran-data-sourcing.md)           | Quran data: sourcing, reproducible ingestion, licensing     | Accepted |
-| [0003](0003-static-first-delivery.md)         | Static-first delivery on Next.js / Vercel (no database)     | Accepted |
-| [0004](0004-public-api.md)                    | Public API: static REST/OpenAPI + typed tRPC                | Accepted |
-| [0005](0005-content-plugin-system.md)         | Content plugin system (translations/reciters/tafsir/hadith) | Accepted |
-| [0006](0006-local-first-persistence.md)       | Local-first persistence — no accounts                       | Accepted |
-| [0007](0007-hifz-spaced-repetition.md)        | Hifz scheduling: SM-2 in core behind a port                 | Accepted |
-| [0008](0008-recitation-audio-highlighting.md) | Recitation audio + word-by-word highlighting                | Accepted |
-| [0009](0009-mobile-app.md)                    | Mobile app (Expo) sharing the monorepo                      | Accepted |
-| [0010](0010-translation-selection.md)         | Translation selection: grouped, searchable, local-first     | Accepted |
-| [0011](0011-translation-catalog-runtime.md)   | Full translation catalogue + multi-tafsir, runtime-fetched  | Accepted |
-| [0012](0012-prayer-times.md)                  | Prayer times: adhan behind a port, computed on demand       | Accepted |
-| [0013](0013-qibla.md)                         | Qibla: a pure great-circle bearing in `core`, no port       | Accepted |
-| [0014](0014-hijri-calendar.md)                | Hijri calendar: tabular arithmetic in `core` + adjustment   | Accepted |
-| [0015](0015-zakat.md)                         | Zakat: agreed monetary core in `core`, choice-points exposed | Accepted |
-| [0016](0016-adhkar.md)                        | Adhkar: bundled Ḥiṣn al-Muslim content + a pure counter      | Accepted |
-| [0017](0017-adhkar-reminders.md)              | Adhkar reminders: pure windows off prayer times, in-app reach | Accepted |
-| [0018](0018-local-data-backup.md)             | Local data backup: file export/import as the sync substitute | Accepted |
-| [0019](0019-prayer-reminders.md)              | Per-prayer reminders behind a `Notifier` port               | Accepted |
-| [0020](0020-prayer-tracker.md)                | Prayer tracker: a pure local prayer log, no port            | Accepted |
-| [0021](0021-global-search.md)                 | Global search: one client index over several sources        | Accepted |
-| [0022](0022-hadith-ingested-search.md)        | Hadith ingested at build time, searched on the client       | Accepted |
+| #                                             | Decision                                                         | Status   |
+| --------------------------------------------- | ---------------------------------------------------------------- | -------- |
+| [0001](0001-modular-monolith.md)              | Modular monolith with lint-enforced boundaries                   | Accepted |
+| [0002](0002-quran-data-sourcing.md)           | Quran data: sourcing, reproducible ingestion, licensing          | Accepted |
+| [0003](0003-static-first-delivery.md)         | Static-first delivery on Next.js / Vercel (no database)          | Accepted |
+| [0004](0004-public-api.md)                    | Public API: static REST/OpenAPI + typed tRPC                     | Accepted |
+| [0005](0005-content-plugin-system.md)         | Content plugin system (translations/reciters/tafsir/hadith)      | Accepted |
+| [0006](0006-local-first-persistence.md)       | Local-first persistence — no accounts                            | Accepted |
+| [0007](0007-hifz-spaced-repetition.md)        | Hifz scheduling: SM-2 in core behind a port                      | Accepted |
+| [0008](0008-recitation-audio-highlighting.md) | Recitation audio + word-by-word highlighting                     | Accepted |
+| [0009](0009-mobile-app.md)                    | Mobile app (Expo) sharing the monorepo                           | Accepted |
+| [0010](0010-translation-selection.md)         | Translation selection: grouped, searchable, local-first          | Accepted |
+| [0011](0011-translation-catalog-runtime.md)   | Full translation catalogue + multi-tafsir, runtime-fetched       | Accepted |
+| [0012](0012-prayer-times.md)                  | Prayer times: adhan behind a port, computed on demand            | Accepted |
+| [0013](0013-qibla.md)                         | Qibla: a pure great-circle bearing in `core`, no port            | Accepted |
+| [0014](0014-hijri-calendar.md)                | Hijri calendar: tabular arithmetic in `core` + adjustment        | Accepted |
+| [0015](0015-zakat.md)                         | Zakat: agreed monetary core in `core`, choice-points exposed     | Accepted |
+| [0016](0016-adhkar.md)                        | Adhkar: bundled Ḥiṣn al-Muslim content + a pure counter          | Accepted |
+| [0017](0017-adhkar-reminders.md)              | Adhkar reminders: pure windows off prayer times, in-app reach    | Accepted |
+| [0018](0018-local-data-backup.md)             | Local data backup: file export/import as the sync substitute     | Accepted |
+| [0019](0019-prayer-reminders.md)              | Per-prayer reminders behind a `Notifier` port                    | Accepted |
+| [0020](0020-prayer-tracker.md)                | Prayer tracker: a pure local prayer log, no port                 | Accepted |
+| [0021](0021-global-search.md)                 | Global search: one client index over several sources             | Accepted |
+| [0022](0022-hadith-ingested-search.md)        | Hadith ingested at build time, searched on the client            | Accepted |
 | [0023](0023-noor-design-system.md)            | Noor design system: single source of truth across web and mobile | Accepted |
-| [0024](0024-local-storage-ports.md)           | Typed storage ports for local-first state (the sync seam)   | Accepted |
+| [0024](0024-local-storage-ports.md)           | Typed storage ports for local-first state (the sync seam)        | Accepted |
+| [0025](0025-reading-plans.md)                 | Reading plans: pure schedule engine, catalogue bundled in core   | Accepted |
 
 ## Writing a new ADR
 


### PR DESCRIPTION
Consolidates the reading-plans decisions from #59–#62 into an ADR, and points contributors at where plan code lives.

## What
- **ADR 0025** — the pure schedule engine (templates vs active plans; juzʾ/ḥizb/page/sūrah/ayah units; `fixed` + `targetDate` strategies, even cumulative distribution); the catalogue **bundled in core** (not `packages/data`, because mobile can't import `node:fs`); progress behind the `PlanStore` port (ADR 0024); and a read-only catalogue API with **no server mutations** (local-first, ADR 0006).
- **AGENTS.md** — a "where does it go?" row: reading-plan templates / schedule rules live in `core` (`reading-plans.ts`), not `data`; progress via `PlanStore`.

## Acceptance (#65)
- ✅ ADR capturing the schedule model + offline-first decision (matches existing ADR style).
- ✅ AGENTS.md updated with where plan code lives.
- ✅ Plan endpoints documented in `docs/API.md` + OpenAPI — done in #62.

Docs-only; lint + prettier clean (typecheck/test unaffected).

Closes #65.