### PR TITLE
feat(web): custom reading-plan creation (by date or pace)

### DIFF
--- a/apps/web/src/components/PlansView.tsx
+++ b/apps/web/src/components/PlansView.tsx
@@ -5,19 +5,26 @@ import Link from "next/link";
 import {
   type ActivePlan,
   type DayPortion,
+  type PlanTemplate,
+  type ScheduleStrategy,
   PLAN_TEMPLATES,
+  activatePlan,
   computeTodayPortion,
   currentDay,
   isDayComplete,
   percentComplete,
   planDuration,
+  planEndDate,
   planWeekWindow,
+  rangeOfPages,
+  validatePlanDraft,
 } from "@ummahlibrary/core";
-import { N, Khatam, Icon } from "@ummahlibrary/ui";
+import { N, Khatam, Icon, Seg } from "@ummahlibrary/ui";
 import {
   READING_PLAN_EVENT,
   clearPlan,
   readActivePlan,
+  startCustomPlan,
   startPlan,
   todayStr,
   toggleDay,
@@ -53,6 +60,10 @@ const sectionLabel = {
 export function PlansView() {
   const [plan, setPlan] = useState<ActivePlan | null>(null);
   const [ready, setReady] = useState(false);
+  const [customOpen, setCustomOpen] = useState(false);
+  const [mode, setMode] = useState<"date" | "pace">("date");
+  const [endDate, setEndDate] = useState("");
+  const [perDay, setPerDay] = useState("2");
 
   useEffect(() => {
     const refresh = () => {
@@ -71,6 +82,43 @@ export function PlansView() {
   const day = plan ? currentDay(plan, today) : 0;
   const portion = plan ? computeTodayPortion(plan, today) : undefined;
   const pct = plan ? percentComplete(plan) : 0;
+
+  // Custom plan draft — whole Quran by pages; validate + preview the pace live.
+  const customRange = rangeOfPages(1, 604);
+  const customSchedule: ScheduleStrategy =
+    mode === "date"
+      ? { kind: "targetDate", endDate }
+      : { kind: "fixed", unitsPerDay: Number(perDay) || 0 };
+  const customErrors = validatePlanDraft({ range: customRange, schedule: customSchedule, startDate: today });
+  const customPreview =
+    customErrors.length === 0
+      ? (() => {
+          const draft = activatePlan(
+            { id: "custom", name: "", tag: "", len: "", desc: "", range: customRange, schedule: customSchedule },
+            today,
+          );
+          const days = planDuration(draft);
+          return { days, end: planEndDate(draft), perDay: Math.ceil(customRange.units.length / days) };
+        })()
+      : null;
+
+  function createCustom() {
+    if (!customPreview) return;
+    const template: PlanTemplate = {
+      id: "custom",
+      name: "Your plan",
+      tag: `${customPreview.days} days`,
+      len: mode === "date" ? `≈ ${customPreview.perDay} pages a day` : `${perDay} pages a day`,
+      desc:
+        mode === "date"
+          ? `Finish the Quran by ${customPreview.end}.`
+          : `${perDay} pages a day through the whole Quran.`,
+      range: customRange,
+      schedule: customSchedule,
+    };
+    void startCustomPlan(template);
+    setCustomOpen(false);
+  }
 
   if (!ready) return <div style={{ minHeight: 240 }} />;
 
@@ -350,6 +398,142 @@ export function PlansView() {
           );
         })}
       </div>
+
+      {/* Create your own */}
+      <div style={sectionLabel}>Create your own</div>
+      {!customOpen ? (
+        <button
+          type="button"
+          onClick={() => setCustomOpen(true)}
+          className="noor-press"
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+            padding: 16,
+            borderRadius: 14,
+            border: `1px dashed ${N.border}`,
+            background: N.card,
+            color: N.gold,
+            fontSize: 14,
+            fontWeight: 600,
+            fontFamily: N.ui,
+            cursor: "pointer",
+          }}
+        >
+          <Icon name="plus" size={16} color={N.gold} sw={2} /> Create a custom plan
+        </button>
+      ) : (
+        <div style={{ border: `1px solid ${N.border}`, borderRadius: 14, padding: 18, background: N.card }}>
+          <Seg
+            options={[
+              { value: "date", label: "By date" },
+              { value: "pace", label: "Pages a day" },
+            ]}
+            value={mode}
+            onChange={(v) => setMode(v as "date" | "pace")}
+            size="sm"
+          />
+          <label style={{ display: "block", marginTop: 14 }}>
+            <span style={{ fontSize: 13, color: N.muted, fontFamily: N.ui }}>
+              {mode === "date" ? "Finish the Quran by" : "Pages a day"}
+            </span>
+            {mode === "date" ? (
+              <input
+                type="date"
+                min={today}
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                style={inputStyle}
+              />
+            ) : (
+              <input
+                type="number"
+                min={1}
+                inputMode="numeric"
+                value={perDay}
+                onChange={(e) => setPerDay(e.target.value)}
+                style={inputStyle}
+              />
+            )}
+          </label>
+
+          <div style={{ marginTop: 12, minHeight: 20, fontSize: 13, fontFamily: N.ui }}>
+            {customPreview ? (
+              <span style={{ color: N.muted }}>
+                {mode === "date" ? (
+                  <>
+                    ≈ <span style={{ color: N.fg, fontWeight: 600 }}>{customPreview.perDay} pages a day</span> ·{" "}
+                    {customPreview.days} days
+                  </>
+                ) : (
+                  <>
+                    <span style={{ color: N.fg, fontWeight: 600 }}>{customPreview.days} days</span> · finishes{" "}
+                    {customPreview.end}
+                  </>
+                )}
+              </span>
+            ) : (
+              <span style={{ color: N.goldDim }}>{customErrors[0]}</span>
+            )}
+          </div>
+
+          <div style={{ display: "flex", gap: 9, marginTop: 14 }}>
+            <button
+              type="button"
+              disabled={!customPreview}
+              onClick={createCustom}
+              className="noor-press"
+              style={{
+                padding: "10px 18px",
+                borderRadius: 11,
+                background: customPreview ? N.goldGrad : N.card,
+                color: customPreview ? N.ink : N.faint,
+                border: `1px solid ${customPreview ? "transparent" : N.border}`,
+                fontWeight: 700,
+                fontSize: 14,
+                fontFamily: N.ui,
+                cursor: customPreview ? "pointer" : "not-allowed",
+              }}
+            >
+              Start plan
+            </button>
+            <button
+              type="button"
+              onClick={() => setCustomOpen(false)}
+              className="noor-press"
+              style={{
+                padding: "10px 16px",
+                borderRadius: 11,
+                background: N.card,
+                color: N.muted,
+                border: `1px solid ${N.border}`,
+                fontWeight: 600,
+                fontSize: 14,
+                fontFamily: N.ui,
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
+
+const inputStyle = {
+  display: "block",
+  width: "100%",
+  marginTop: 6,
+  padding: "11px 14px",
+  borderRadius: 10,
+  border: `1px solid ${N.border}`,
+  background: N.cardHi,
+  color: N.fg,
+  fontFamily: N.ui,
+  fontSize: 15,
+  boxSizing: "border-box",
+} as const;

--- a/apps/web/src/lib/plan-store.test.ts
+++ b/apps/web/src/lib/plan-store.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { activatePlan, buildBackup, templateById, toggleDayComplete } from "@ummahlibrary/core";
+import {
+  type PlanTemplate,
+  activatePlan,
+  buildBackup,
+  rangeOfPages,
+  templateById,
+  toggleDayComplete,
+} from "@ummahlibrary/core";
 import { webPlanStore } from "./plan-store";
 import {
   READING_PLAN_EVENT,
   clearPlan,
   readActivePlan,
+  startCustomPlan,
   startPlan,
   todayStr,
   toggleDay,
@@ -60,6 +68,23 @@ describe("reading-plan glue", () => {
     await startPlan("does-not-exist");
     expect(await readActivePlan()).toBeNull();
     expect(todayStr(new Date(2026, 2, 5))).toBe("2026-03-05");
+  });
+
+  it("starts a one-off custom plan from a synthesized template", async () => {
+    const template: PlanTemplate = {
+      id: "custom",
+      name: "Your plan",
+      tag: "302 days",
+      len: "2 pages a day",
+      desc: "Two pages a day.",
+      range: rangeOfPages(1, 604),
+      schedule: { kind: "fixed", unitsPerDay: 2 },
+    };
+    await startCustomPlan(template);
+    const active = await readActivePlan();
+    expect(active?.template.id).toBe("custom");
+    expect(active?.template.schedule).toEqual({ kind: "fixed", unitsPerDay: 2 });
+    expect(active?.unitsRead).toBe(0);
   });
 });
 

--- a/apps/web/src/lib/reading-plan.ts
+++ b/apps/web/src/lib/reading-plan.ts
@@ -3,7 +3,13 @@
  * (web adapter `webPlanStore`, ADR 0024); this layer adds the business helpers
  * and broadcasts a window event so the plans page re-renders. Mirrors mobile.
  */
-import { type ActivePlan, activatePlan, templateById, toggleDayComplete } from "@ummahlibrary/core";
+import {
+  type ActivePlan,
+  type PlanTemplate,
+  activatePlan,
+  templateById,
+  toggleDayComplete,
+} from "@ummahlibrary/core";
 import { webPlanStore as store } from "./plan-store";
 
 export const READING_PLAN_EVENT = "ul.readingPlan";
@@ -26,11 +32,19 @@ export function readActivePlan(): Promise<ActivePlan | null> {
   return store.read();
 }
 
-export async function startPlan(templateId: string): Promise<void> {
-  const template = templateById(templateId);
-  if (!template) return;
+async function activate(template: PlanTemplate): Promise<void> {
   await store.write(activatePlan(template, todayStr()));
   emit();
+}
+
+export async function startPlan(templateId: string): Promise<void> {
+  const template = templateById(templateId);
+  if (template) await activate(template);
+}
+
+/** Start a one-off custom plan built in the UI (not from the catalogue). */
+export function startCustomPlan(template: PlanTemplate): Promise<void> {
+  return activate(template);
 }
 
 export async function clearPlan(): Promise<void> {


### PR DESCRIPTION
Surfaces the target-date scheduling the core has supported since #59 — readers can now **create** a custom plan, not just pick a preset.

## What
- A collapsible **"Create your own"** card on `/plans` with a **By date** / **Pages a day** toggle (whole Quran, by pages).
  - *By date* → `targetDate` schedule; *Pages a day* → `fixed` schedule.
- **Live preview + validation** via core's `validatePlanDraft` — a past date shows an error; valid input previews "≈ N pages a day · D days · finishes <date>".
- New `startCustomPlan` glue persists the synthesized template through the `PlanStore` (ADR 0024).

The catalogue cards, pinned active banner, and single-active-plan behaviour were already in place (#59/#61), so this is purely additive — the form is collapsed by default.

## Acceptance (#67)
- ✅ `/plans`: template cards + "Create custom plan" (by target date or N pages/day).
- ✅ Pinned "Today" banner when active · only one active plan at a time.
- ✅ Start a template plan in two taps; today's portion correct from the start date.

## Checks
lint clean · typecheck 7/7 · 379 tests · coverage thresholds met. build + e2e via CI; the form renders on the Vercel preview.

Closes #67.