### PR TITLE
feat(core): reading-plan catch-up & re-pace (behind-state recovery)

### DIFF
--- a/apps/web/src/components/PlansView.tsx
+++ b/apps/web/src/components/PlansView.tsx
@@ -9,8 +9,10 @@ import {
   type ScheduleStrategy,
   PLAN_TEMPLATES,
   activatePlan,
+  catchUpPortion,
   computeTodayPortion,
   currentDay,
+  daysAheadBehind,
   isDayComplete,
   percentComplete,
   planDuration,
@@ -23,7 +25,9 @@ import { N, Khatam, Icon, Seg } from "@ummahlibrary/ui";
 import {
   READING_PLAN_EVENT,
   clearPlan,
+  extendPlanBy,
   readActivePlan,
+  rebalancePlan,
   startCustomPlan,
   startPlan,
   todayStr,
@@ -82,6 +86,8 @@ export function PlansView() {
   const day = plan ? currentDay(plan, today) : 0;
   const portion = plan ? computeTodayPortion(plan, today) : undefined;
   const pct = plan ? percentComplete(plan) : 0;
+  const behind = plan ? daysAheadBehind(plan, today) : 0;
+  const catchUp = plan ? catchUpPortion(plan, today) : undefined;
 
   // Custom plan draft — whole Quran by pages; validate + preview the pace live.
   const customRange = rangeOfPages(1, 604);
@@ -260,6 +266,52 @@ export function PlansView() {
               Leave plan
             </button>
           </div>
+
+          {/* Behind-state + recovery (#70) */}
+          {behind < 0 && catchUp && (
+            <div
+              style={{
+                marginTop: 14,
+                padding: 16,
+                borderRadius: 14,
+                border: `1px solid ${N.gold}`,
+                background: N.goldSoft,
+              }}
+            >
+              <div style={{ fontSize: 14, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>
+                You’re {Math.abs(behind)} {Math.abs(behind) === 1 ? "day" : "days"} behind
+              </div>
+              <div style={{ fontSize: 13, color: N.muted, fontFamily: N.ui, margin: "4px 0 12px" }}>
+                Catch up on the backlog, re-pace to keep your finish date, or give yourself more time.
+              </div>
+              <div style={{ display: "flex", gap: 9, flexWrap: "wrap" }}>
+                <Link
+                  href={targetHref(catchUp)}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 7,
+                    padding: "9px 16px",
+                    borderRadius: 999,
+                    background: N.goldGrad,
+                    color: N.ink,
+                    fontWeight: 700,
+                    fontSize: 13,
+                    textDecoration: "none",
+                    fontFamily: N.ui,
+                  }}
+                >
+                  <Icon name="book" size={15} color={N.ink} sw={1.8} /> Catch up · {catchUp.label}
+                </Link>
+                <button type="button" onClick={() => void rebalancePlan()} className="noor-press" style={repaceBtn}>
+                  Rebalance
+                </button>
+                <button type="button" onClick={() => void extendPlanBy(7)} className="noor-press" style={repaceBtn}>
+                  Extend +1 week
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* This week */}
           <div style={sectionLabel}>This week</div>
@@ -536,4 +588,16 @@ const inputStyle = {
   fontFamily: N.ui,
   fontSize: 15,
   boxSizing: "border-box",
+} as const;
+
+const repaceBtn = {
+  padding: "9px 16px",
+  borderRadius: 999,
+  border: `1px solid ${N.border}`,
+  background: N.card,
+  color: N.muted,
+  fontSize: 13,
+  fontWeight: 600,
+  fontFamily: N.ui,
+  cursor: "pointer",
 } as const;

--- a/apps/web/src/lib/plan-store.test.ts
+++ b/apps/web/src/lib/plan-store.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  type ActivePlan,
   type PlanTemplate,
   activatePlan,
+  addDays,
   buildBackup,
+  rangeOfJuz,
   rangeOfPages,
   templateById,
   toggleDayComplete,
@@ -11,7 +14,9 @@ import { webPlanStore } from "./plan-store";
 import {
   READING_PLAN_EVENT,
   clearPlan,
+  extendPlanBy,
   readActivePlan,
+  rebalancePlan,
   startCustomPlan,
   startPlan,
   todayStr,
@@ -104,5 +109,45 @@ describe("plan state through export/import (acceptance #61)", () => {
     const result = importBackup(fileText, "replace");
     expect(result.ok).toBe(true);
     expect(await webPlanStore.read()).toEqual(plan);
+  });
+});
+
+describe("re-pace glue (#70)", () => {
+  beforeEach(() => localStorage.clear());
+
+  /** A behind plan: started 10 days ago, ends 90 days out, barely read. */
+  const behindPlan = (): ActivePlan => {
+    const today = todayStr();
+    return {
+      template: {
+        id: "x",
+        name: "X",
+        tag: "",
+        len: "",
+        desc: "",
+        range: rangeOfJuz(1, 30),
+        schedule: { kind: "targetDate", endDate: addDays(today, 90) },
+      },
+      startDate: addDays(today, -10),
+      unitsRead: 1,
+    };
+  };
+
+  it("rebalances the active plan, keeping its end date and re-anchoring at today", async () => {
+    const today = todayStr();
+    await webPlanStore.write(behindPlan());
+    await rebalancePlan();
+    const after = await readActivePlan();
+    expect(after?.anchor).toEqual({ date: today, units: 1 });
+    expect(after?.template.schedule).toEqual({ kind: "targetDate", endDate: addDays(today, 90) });
+  });
+
+  it("extends the active plan's end date by a week and re-anchors", async () => {
+    const today = todayStr();
+    await webPlanStore.write(behindPlan());
+    await extendPlanBy(7);
+    const after = await readActivePlan();
+    expect(after?.template.schedule).toEqual({ kind: "targetDate", endDate: addDays(today, 97) });
+    expect(after?.anchor?.date).toBe(today);
   });
 });

--- a/apps/web/src/lib/reading-plan.ts
+++ b/apps/web/src/lib/reading-plan.ts
@@ -7,6 +7,8 @@ import {
   type ActivePlan,
   type PlanTemplate,
   activatePlan,
+  extendPlan,
+  rebalance,
   templateById,
   toggleDayComplete,
 } from "@ummahlibrary/core";
@@ -57,5 +59,21 @@ export async function toggleDay(day: number): Promise<void> {
   const plan = await store.read();
   if (!plan) return;
   await store.write(toggleDayComplete(plan, day));
+  emit();
+}
+
+/** Re-pace the active plan to keep its end date (catch-up rebalance, #70). */
+export async function rebalancePlan(): Promise<void> {
+  const plan = await store.read();
+  if (!plan) return;
+  await store.write(rebalance(plan, todayStr()));
+  emit();
+}
+
+/** Push the active plan's end date `days` later and re-pace (#70). */
+export async function extendPlanBy(days: number): Promise<void> {
+  const plan = await store.read();
+  if (!plan) return;
+  await store.write(extendPlan(plan, todayStr(), days));
   emit();
 }

--- a/packages/core/src/reading-plans.test.ts
+++ b/packages/core/src/reading-plans.test.ts
@@ -6,10 +6,12 @@ import {
   type PlanTemplate,
   PLAN_TEMPLATES,
   activatePlan,
+  catchUpPortion,
   computeTodayPortion,
   cumulativeUnits,
   currentDay,
   daysAheadBehind,
+  extendPlan,
   isDayComplete,
   isValidDateString,
   materializeDay,
@@ -21,12 +23,15 @@ import {
   rangeOfJuz,
   rangeOfPages,
   rangeOfSurahs,
+  rebalance,
+  repace,
   reschedule,
   setUnitsRead,
   surahList,
   templateById,
   toggleDayComplete,
   totalUnits,
+  unitsBehind,
   unitsRemaining,
   validatePlanDraft,
 } from "./reading-plans";
@@ -323,8 +328,61 @@ describe("materializeDay", () => {
 });
 
 describe("computeTodayPortion", () => {
-  it("returns the calendar day's portion", () => {
-    expect(computeTodayPortion(ramadan(), "2026-01-05").label).toBe("Juzʾ 5");
+  it("points at the next unread unit for an on-track reader", () => {
+    const onTrack = setUnitsRead(ramadan(), 4); // juzʾ 1–4 done by day 5
+    expect(computeTodayPortion(onTrack, "2026-01-05").label).toBe("Juzʾ 5");
+  });
+  it("points at the next unread unit when behind — never skips ahead", () => {
+    // Nothing read by day 5: the next portion is juzʾ 1, not the calendar's juzʾ 5.
+    expect(computeTodayPortion(ramadan(), "2026-01-05").label).toBe("Juzʾ 1");
+  });
+});
+
+describe("catch-up + re-pace (#70)", () => {
+  // Behind: by day 10 of a 30-day juzʾ-a-day plan, only 5 juzʾ have been read.
+  const behind = () => setUnitsRead(ramadan(), 5);
+  const T10 = "2026-01-10";
+
+  it("reports how far behind, in days and units", () => {
+    expect(daysAheadBehind(behind(), T10)).toBeLessThan(0);
+    expect(unitsBehind(behind(), T10)).toBe(5); // due 10, read 5
+  });
+
+  it("catch-up portion spans the backlog through today", () => {
+    const portion = catchUpPortion(behind(), T10);
+    expect(portion.fromUnit).toBe(6); // the next unread juzʾ
+    expect(portion.toUnit).toBe(10); // through today
+    expect(portion.count).toBe(5);
+  });
+
+  it("rebalance keeps the end date, re-paces, and lands the reader on track", () => {
+    const plan = rebalance(behind(), T10);
+    expect(planEndDate(plan)).toBe("2026-01-30"); // unchanged
+    expect(daysAheadBehind(plan, T10)).toBe(0); // on track right after
+    expect(cumulativeUnits(plan, planDuration(plan))).toBe(30); // still finishable
+    // 25 juzʾ over the remaining ~21 days is steeper than 1/day — some day reads 2.
+    let maxAmount = 0;
+    for (let d = 11; d <= planDuration(plan); d++) {
+      maxAmount = Math.max(maxAmount, cumulativeUnits(plan, d) - cumulativeUnits(plan, d - 1));
+    }
+    expect(maxAmount).toBe(2);
+  });
+
+  it("extend moves the end date later and eases the pace", () => {
+    const plan = extendPlan(behind(), T10, 10);
+    expect(daysBetween("2026-01-30", planEndDate(plan))).toBe(10); // +10 days
+    expect(daysAheadBehind(plan, T10)).toBeGreaterThanOrEqual(0); // no longer behind
+    expect(cumulativeUnits(plan, planDuration(plan))).toBe(30); // finishable
+  });
+
+  it("preserves overall progress through a re-pace", () => {
+    const plan = rebalance(behind(), T10);
+    expect(plan.unitsRead).toBe(5);
+    expect(percentComplete(plan)).toBe(17); // 5/30 ≈ 17%, unchanged
+  });
+
+  it("rejects an end date before today", () => {
+    expect(() => repace(behind(), T10, "2026-01-05")).toThrow(RangeError);
   });
 });
 

--- a/packages/core/src/reading-plans.ts
+++ b/packages/core/src/reading-plans.ts
@@ -81,6 +81,12 @@ export interface ActivePlan {
   startDate: string;
   /** Atomic units completed so far (a linear cursor, 0…total). */
   unitsRead: number;
+  /**
+   * Re-pace anchor (#70): when a plan is re-paced, the schedule re-anchors here
+   * so the remaining units spread from this date while overall progress
+   * (`unitsRead`, percent complete) is preserved. Absent on a fresh plan.
+   */
+  anchor?: { date: string; units: number };
 }
 
 /** What to read on a given day, resolved to deep-linkable Quran references. */
@@ -366,13 +372,24 @@ export function planEndDate(plan: ActivePlan): string {
   return s.kind === "targetDate" ? s.endDate : addDays(plan.startDate, planDuration(plan) - 1);
 }
 
-/** Units that should be read by the end of day `day` (even distribution). */
+/**
+ * Units that should be read by the end of day `day`. A fresh plan spreads evenly
+ * from the start; a re-paced plan (with an `anchor`) follows a two-segment line
+ * through (anchorDay, anchorUnits) → (duration, total), so the remaining units
+ * re-pace from the anchor while the percent complete stays put.
+ */
 export function cumulativeUnits(plan: ActivePlan, day: number): number {
   const total = planTotal(plan);
   const dur = planDuration(plan);
   if (day <= 0) return 0;
   if (day >= dur) return total;
-  return Math.floor((day * total) / dur);
+  const { anchor } = plan;
+  if (!anchor) return Math.floor((day * total) / dur);
+  const aDay = Math.min(Math.max(daysBetween(plan.startDate, anchor.date) + 1, 1), dur);
+  const aUnits = Math.min(Math.max(anchor.units, 0), total);
+  if (day <= aDay) return Math.floor((day * aUnits) / aDay);
+  if (dur === aDay) return total;
+  return aUnits + Math.floor(((day - aDay) * (total - aUnits)) / (dur - aDay));
 }
 
 /** The calendar day the reader is on (1-based), clamped to the plan length. */
@@ -432,11 +449,9 @@ export function projectedFinish(plan: ActivePlan, today: string): string {
   return addDays(today, need);
 }
 
-/** What to read on day `day`, resolved to references and a label. */
-export function materializeDay(plan: ActivePlan, day: number): DayPortion {
-  const { unit, units } = plan.template.range;
-  const from = cumulativeUnits(plan, day - 1);
-  const to = cumulativeUnits(plan, day);
+/** Build a day's portion from a half-open unit-index window `[from, to)`. */
+function buildPortion(range: PlanRange, day: number, from: number, to: number): DayPortion {
+  const { unit, units } = range;
   if (to <= from) {
     return {
       day,
@@ -472,9 +487,38 @@ export function materializeDay(plan: ActivePlan, day: number): DayPortion {
   };
 }
 
-/** Today's portion — what to read now to stay on schedule. */
+/** The idealised units scheduled for a single calendar day. */
+export function materializeDay(plan: ActivePlan, day: number): DayPortion {
+  return buildPortion(plan.template.range, day, cumulativeUnits(plan, day - 1), cumulativeUnits(plan, day));
+}
+
+/**
+ * Today's portion — the reader's **next unread** units, one day's worth. A
+ * reader who has fallen behind is pointed at where they actually are (their next
+ * unread unit), never skipped past it.
+ */
 export function computeTodayPortion(plan: ActivePlan, today: string): DayPortion {
-  return materializeDay(plan, currentDay(plan, today));
+  const day = currentDay(plan, today);
+  const total = planTotal(plan);
+  const amount = cumulativeUnits(plan, day) - cumulativeUnits(plan, day - 1);
+  const from = Math.min(plan.unitsRead, total);
+  return buildPortion(plan.template.range, day, from, Math.min(total, from + amount));
+}
+
+/**
+ * Everything due through today from the reader's cursor — today's portion plus
+ * any backlog. Reading it brings a behind reader back on schedule.
+ */
+export function catchUpPortion(plan: ActivePlan, today: string): DayPortion {
+  const day = currentDay(plan, today);
+  const total = planTotal(plan);
+  const from = Math.min(plan.unitsRead, total);
+  return buildPortion(plan.template.range, day, from, Math.max(from, cumulativeUnits(plan, day)));
+}
+
+/** How many units the reader is behind by (due through today, but unread). */
+export function unitsBehind(plan: ActivePlan, today: string): number {
+  return Math.max(0, cumulativeUnits(plan, currentDay(plan, today)) - plan.unitsRead);
 }
 
 /** A window of up to seven day numbers centred on `day` (for a week strip). */
@@ -524,6 +568,31 @@ export function reschedule(plan: ActivePlan, change: RescheduleChange): ActivePl
     throw new RangeError("A fixed plan must read at least one unit per day.");
   }
   return { ...plan, template: { ...plan.template, schedule: change } };
+}
+
+/**
+ * Re-pace from `today`, preserving overall progress (#70). The schedule
+ * re-anchors so the remaining units spread from today to `endDate`, while
+ * `unitsRead` and the percent complete stay put. Throws if `endDate` is before
+ * today.
+ */
+export function repace(plan: ActivePlan, today: string, endDate: string): ActivePlan {
+  if (daysBetween(today, endDate) < 0) throw new RangeError("The end date is before today.");
+  return {
+    ...plan,
+    template: { ...plan.template, schedule: { kind: "targetDate", endDate } },
+    anchor: { date: today, units: plan.unitsRead },
+  };
+}
+
+/** Keep the current end date and re-pace the remaining units from today. */
+export function rebalance(plan: ActivePlan, today: string): ActivePlan {
+  return repace(plan, today, planEndDate(plan));
+}
+
+/** Move the end date `days` later and re-pace the remaining units from today. */
+export function extendPlan(plan: ActivePlan, today: string, days: number): ActivePlan {
+  return repace(plan, today, addDays(planEndDate(plan), Math.max(1, Math.floor(days))));
 }
 
 // ── Validation (for the custom-plan creator) ────────────────────────────────


### PR DESCRIPTION
The behind-state recovery story (#70), on the re-anchor model (keep overall progress).

## Core (the unit-tested heart)
- **Re-pace anchor** on `ActivePlan` — keeps overall progress (`unitsRead`, %) while re-pacing the remaining work.
- **Anchored cumulative schedule** — a two-segment line through (anchor) → (end): rebalancing keeps your finish date and lands you on track.
- **Cursor-aware `computeTodayPortion`** — "today" points at your **next unread** unit; a behind reader is never skipped past juzʾ 6 to juzʾ 10.
- `catchUpPortion`, `unitsBehind`, and `repace` / `rebalance` / `extendPlan` — each produces a correct, finishable schedule.

## Web
A **"You're N days behind"** panel on the active plan:
- **Catch up** — read the backlog (deep-links to your next unread, sized to the backlog).
- **Rebalance** — keep the finish date, re-pace the rest from today.
- **Extend +1 week** — move the date out and ease the pace.

## Acceptance (#70)
- ✅ Behind-state UX · ✅ Catch up / Rebalance / Extend · ✅ each mode produces a correct, finishable schedule (unit-tested in core).

Mobile parity follows in #64.

## Checks
lint clean · typecheck 7/7 · 388 tests · coverage thresholds met (`reading-plans.ts` 100% lines / 97% branches). build + e2e via CI; behind-state shows on the Vercel preview.

Closes #70.