### PR TITLE
feat(web): reading-plan auto-advance + reader chip (#69)

### DIFF
--- a/apps/web/src/app/page/[number]/page.tsx
+++ b/apps/web/src/app/page/[number]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@ummahlibrary/core";
 import { quranRepository } from "@ummahlibrary/api";
 import { ReadingTracker } from "../../../components/ReadingTracker";
+import { PlanReaderChip } from "../../../components/PlanReaderChip";
 
 // Render all 604 Madani-Mushaf pages at build time.
 export const dynamicParams = false;
@@ -87,6 +88,7 @@ export default async function MushafPage({ params }: { params: Promise<{ number:
       </header>
 
       <ReadingTracker page={n} />
+      <PlanReaderChip />
       <div className="mushaf-page">
         {sections.map((section) => (
           <section key={section.surah.number}>

--- a/apps/web/src/components/PlanReaderChip.tsx
+++ b/apps/web/src/components/PlanReaderChip.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { type ActivePlan, todayProgress } from "@ummahlibrary/core";
+import { N, Icon } from "@ummahlibrary/ui";
+import { READING_PLAN_EVENT, readActivePlan, todayStr } from "../lib/reading-plan";
+
+const UNIT_LABEL: Record<string, string> = {
+  juz: "juzʾ",
+  hizb: "ḥizb",
+  page: "pages",
+  surah: "sūrahs",
+  ayah: "ayahs",
+};
+
+/**
+ * A slim floating chip shown in the reader while a plan is active —
+ * "Plan · 2 of 3 pages today" — that advances as you read, because the plan is
+ * subscribed to the reader's page signal (#69). Renders nothing with no plan.
+ */
+export function PlanReaderChip() {
+  const [plan, setPlan] = useState<ActivePlan | null>(null);
+
+  useEffect(() => {
+    const refresh = () => void readActivePlan().then(setPlan);
+    refresh();
+    window.addEventListener(READING_PLAN_EVENT, refresh);
+    return () => window.removeEventListener(READING_PLAN_EVENT, refresh);
+  }, []);
+
+  if (!plan) return null;
+  const { done, total } = todayProgress(plan, todayStr());
+  if (total === 0) return null;
+  const complete = done >= total;
+  const unit = UNIT_LABEL[plan.template.range.unit] ?? "units";
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 60,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        gap: 7,
+        padding: "6px 14px",
+        borderRadius: 999,
+        background: complete ? N.goldSoft : N.cardHi,
+        border: `1px solid ${complete ? N.gold : N.border}`,
+        color: complete ? N.gold : N.muted,
+        fontSize: 12.5,
+        fontWeight: 600,
+        fontFamily: N.ui,
+        boxShadow: "0 6px 18px rgba(0,0,0,.3)",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {complete ? (
+        <>
+          <Icon name="check" size={14} color={N.gold} sw={2} /> Today’s portion done
+        </>
+      ) : (
+        <>
+          <span style={{ color: N.gold, fontWeight: 700 }}>Plan</span> · {done} of {total} {unit} today
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -15,6 +15,7 @@ import { WordByWord } from "./WordByWord";
 import { HashHighlighter } from "./HashHighlighter";
 import { ReaderShortcuts } from "./ReaderShortcuts";
 import { ReadingTracker } from "./ReadingTracker";
+import { PlanReaderChip } from "./PlanReaderChip";
 import { recordMushafPage } from "../lib/reading-goals";
 
 type ReadingMode = "translation" | "reading" | "reading-tr";
@@ -205,6 +206,7 @@ export function SurahReaderClient({
       <ReaderShortcuts storageKey={`surah:${surah.number}`} />
       <ReadingTracker />
       <HashHighlighter />
+      <PlanReaderChip />
 
       {/* Scroll progress bar */}
       <div style={{ height: 3, background: N.borderSoft, flexShrink: 0 }}>

--- a/apps/web/src/lib/plan-store.test.ts
+++ b/apps/web/src/lib/plan-store.test.ts
@@ -13,6 +13,7 @@ import {
 import { webPlanStore } from "./plan-store";
 import {
   READING_PLAN_EVENT,
+  advancePlanToPage,
   clearPlan,
   extendPlanBy,
   readActivePlan,
@@ -149,5 +150,11 @@ describe("re-pace glue (#70)", () => {
     const after = await readActivePlan();
     expect(after?.template.schedule).toEqual({ kind: "targetDate", endDate: addDays(today, 97) });
     expect(after?.anchor?.date).toBe(today);
+  });
+
+  it("advances the active plan as pages are read (#69)", async () => {
+    await webPlanStore.write(activatePlan(templateById("quran-year")!, todayStr())); // page plan, 2/day
+    await advancePlanToPage(5);
+    expect((await readActivePlan())?.unitsRead).toBe(5);
   });
 });

--- a/apps/web/src/lib/reading-goals.ts
+++ b/apps/web/src/lib/reading-goals.ts
@@ -7,6 +7,7 @@
  */
 
 import type { KhatmaPlan } from "@ummahlibrary/core";
+import { advancePlanToPage } from "./reading-plan";
 
 export const READING_EVENT = "ul.reading";
 const GOAL_KEY = "ul.readingGoal"; // { target: number } pages/day
@@ -93,6 +94,7 @@ export function recordMushafPage(page: number): void {
   }
   const plan = readKhatma();
   if (plan && page > plan.currentPage) writeKhatma({ ...plan, currentPage: page });
+  void advancePlanToPage(page); // advance the active reading plan too (#69)
   emit();
 }
 

--- a/apps/web/src/lib/reading-plan.ts
+++ b/apps/web/src/lib/reading-plan.ts
@@ -7,6 +7,7 @@ import {
   type ActivePlan,
   type PlanTemplate,
   activatePlan,
+  advanceCursorToPage,
   extendPlan,
   rebalance,
   templateById,
@@ -76,4 +77,15 @@ export async function extendPlanBy(days: number): Promise<void> {
   if (!plan) return;
   await store.write(extendPlan(plan, todayStr(), days));
   emit();
+}
+
+/** Advance the active plan to a Madani page the reader has reached (#69). */
+export async function advancePlanToPage(page: number): Promise<void> {
+  const plan = await store.read();
+  if (!plan) return;
+  const next = advanceCursorToPage(plan, page);
+  if (next.unitsRead !== plan.unitsRead) {
+    await store.write(next);
+    emit();
+  }
 }

--- a/packages/core/src/reading-plans.test.ts
+++ b/packages/core/src/reading-plans.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { ayahCountOf } from "./quran-structure";
+import { ayahCountOf, pageNumberOf } from "./quran-structure";
 import { addDays, daysBetween } from "./reading-goals";
 import {
   type ActivePlan,
   type PlanTemplate,
   PLAN_TEMPLATES,
   activatePlan,
+  advanceCursorToPage,
   catchUpPortion,
   computeTodayPortion,
   cumulativeUnits,
@@ -29,6 +30,7 @@ import {
   setUnitsRead,
   surahList,
   templateById,
+  todayProgress,
   toggleDayComplete,
   totalUnits,
   unitsBehind,
@@ -383,6 +385,30 @@ describe("catch-up + re-pace (#70)", () => {
 
   it("rejects an end date before today", () => {
     expect(() => repace(behind(), T10, "2026-01-05")).toThrow(RangeError);
+  });
+});
+
+describe("reader auto-advance (#69)", () => {
+  const pagePlan = () => activatePlan(tpl(rangeOfPages(1, 10), { kind: "fixed", unitsPerDay: 2 }), START);
+
+  it("advances the cursor through page-units as pages are read", () => {
+    expect(advanceCursorToPage(pagePlan(), 4).unitsRead).toBe(4); // pages 1–4 read
+    expect(advanceCursorToPage(pagePlan(), 0).unitsRead).toBe(0); // nothing yet
+  });
+
+  it("advances a juzʾ plan when the juzʾ's last page is reached", () => {
+    const juz1EndPage = pageNumberOf({ sura: 2, aya: 141 }); // last verse of juzʾ 1
+    expect(advanceCursorToPage(ramadan(), juz1EndPage).unitsRead).toBe(1);
+    expect(advanceCursorToPage(ramadan(), juz1EndPage - 1).unitsRead).toBe(0);
+  });
+
+  it("never retreats the cursor (monotonic)", () => {
+    expect(advanceCursorToPage(setUnitsRead(pagePlan(), 6), 3).unitsRead).toBe(6);
+  });
+
+  it("reports today's portion progress for the chip", () => {
+    expect(todayProgress(setUnitsRead(ramadan(), 2), "2026-01-03")).toEqual({ done: 0, total: 1 });
+    expect(todayProgress(setUnitsRead(ramadan(), 3), "2026-01-03")).toEqual({ done: 1, total: 1 });
   });
 });
 

--- a/packages/core/src/reading-plans.ts
+++ b/packages/core/src/reading-plans.ts
@@ -29,6 +29,7 @@ import {
   TOTAL_JUZ,
   ayahCountOf,
   ordinalToRef,
+  pageNumberOf,
   pageRange,
 } from "./quran-structure";
 // UTC `YYYY-MM-DD` date maths is shared with the reading-goals domain, where
@@ -519,6 +520,27 @@ export function catchUpPortion(plan: ActivePlan, today: string): DayPortion {
 /** How many units the reader is behind by (due through today, but unread). */
 export function unitsBehind(plan: ActivePlan, today: string): number {
   return Math.max(0, cumulativeUnits(plan, currentDay(plan, today)) - plan.unitsRead);
+}
+
+/**
+ * Advance the cursor to reflect a Madani page the reader has reached: every plan
+ * unit whose last page has been read counts as done (monotonic — the cursor
+ * never retreats). Subscribes the plan to the reader's page signal (#69).
+ */
+export function advanceCursorToPage(plan: ActivePlan, page: number): ActivePlan {
+  const { unit, units } = plan.template.range;
+  let read = plan.unitsRead;
+  while (read < units.length && pageNumberOf(unitEndRef(unit, units[read]!)) <= page) read++;
+  return read > plan.unitsRead ? setUnitsRead(plan, read) : plan;
+}
+
+/** Today's portion progress for the reader chip: units done / scheduled today. */
+export function todayProgress(plan: ActivePlan, today: string): { done: number; total: number } {
+  const day = currentDay(plan, today);
+  const start = cumulativeUnits(plan, day - 1);
+  const total = cumulativeUnits(plan, day) - start;
+  const done = Math.min(total, Math.max(0, plan.unitsRead - start));
+  return { done, total };
 }
 
 /** A window of up to seven day numbers centred on `day` (for a week strip). */


### PR DESCRIPTION
Reading now advances your plan automatically — the last Reading Plans MVP piece, made trivial by the page concept (#79).

## What
- **Auto-advance**: a core `advanceCursorToPage(plan, page)` (monotonic, page→unit), hooked into the existing `recordMushafPage` signal. So reading pages in any reader advances the active plan's cursor — the day completes with **no "mark done" tap**.
- **Reader chip**: a slim `PlanReaderChip` — "Plan · X of Y today" while a plan is active, flipping to a subtle **"✓ Today's portion done"** on completion. Mounted in the surah + Mushaf page readers.
- `todayProgress(plan, today)` powers the chip.

## Verified locally
Seeded a page-plan, opened `/surah/2` → the chip auto-advanced from the page signal and showed the done state (screenshot on the thread).

## Acceptance (#69)
- ✅ Reading the day's portion advances the cursor / completes the day with no separate tap.
- ✅ Slim "Plan: X of Y today" chip while active; completion fires a subtle state.

## Note
Consistent with the goal/khatma model, opening a reader counts the page you land on — so a *short* page-plan portion can complete on open; juzʾ/longer portions fill as you scroll. Easy to make scroll-only later if preferred.

## Checks
lint clean · typecheck 7/7 · 393 tests · coverage met. build + e2e via CI.

Closes #69.