### PR TITLE
feat(web): opt-in daily reading-plan reminder (#71)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Hanken_Grotesk, IBM_Plex_Sans_Arabic, Amiri } from "next/font/google";
 import { ServiceWorkerRegister } from "../components/ServiceWorkerRegister";
 import { AdhkarReminderBanner } from "../components/AdhkarReminderBanner";
 import { PrayerReminderScheduler } from "../components/PrayerReminderScheduler";
+import { PlanReminderScheduler } from "../components/PlanReminderScheduler";
 import { AppShellWrapper } from "../components/AppShellWrapper";
 import "./globals.css";
 
@@ -88,6 +89,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         </a>
         <AdhkarReminderBanner />
         <PrayerReminderScheduler />
+        <PlanReminderScheduler />
         <AppShellWrapper>{children}</AppShellWrapper>
         <ServiceWorkerRegister />
       </body>

--- a/apps/web/src/components/PlanReminderScheduler.tsx
+++ b/apps/web/src/components/PlanReminderScheduler.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import { PLAN_REMINDER_KEY, syncPlanReminder } from "../lib/plan-reminders";
+import { READING_PLAN_EVENT } from "../lib/reading-plan";
+import { WebNotifier } from "../lib/web-notifier";
+
+// One notifier for the whole app; its in-page timer lives as long as the tab.
+const notifier = new WebNotifier();
+
+/**
+ * Mounted once in the layout. Keeps the active plan's daily reminder scheduled
+ * while a tab is open — on load, whenever the reminder preference or the active
+ * plan changes, and on a coarse interval so the schedule rolls over to the next
+ * day. Renders nothing (#71, ADR 0019).
+ */
+export function PlanReminderScheduler() {
+  useEffect(() => {
+    let cancelled = false;
+    const run = () => {
+      if (!cancelled) void syncPlanReminder(notifier);
+    };
+
+    run();
+    window.addEventListener(PLAN_REMINDER_KEY, run);
+    window.addEventListener(READING_PLAN_EVENT, run);
+    const tick = setInterval(run, 15 * 60 * 1000);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener(PLAN_REMINDER_KEY, run);
+      window.removeEventListener(READING_PLAN_EVENT, run);
+      clearInterval(tick);
+      void notifier.cancelAll();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/components/PlanReminderToggle.tsx
+++ b/apps/web/src/components/PlanReminderToggle.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { nextDailyReminder } from "@ummahlibrary/core";
+import { N, Icon } from "@ummahlibrary/ui";
+import {
+  DEFAULT_PLAN_REMINDER_TIME,
+  readPlanReminderPref,
+  setPlanReminderPref,
+} from "../lib/plan-reminders";
+import { WebNotifier } from "../lib/web-notifier";
+
+const notifier = new WebNotifier();
+
+const fmtTime = (d: Date) =>
+  d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+const fmtDay = (d: Date) =>
+  d.toDateString() === new Date().toDateString() ? "today" : "tomorrow";
+
+/**
+ * Opt-in daily reminder for the active plan (#71): a single nudge at a chosen
+ * time, delivered locally while a tab is open. Lives in the active-plan card.
+ */
+export function PlanReminderToggle() {
+  const [on, setOn] = useState(false);
+  const [time, setTime] = useState(DEFAULT_PLAN_REMINDER_TIME);
+  const [denied, setDenied] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const p = readPlanReminderPref();
+    setOn(p.on);
+    setTime(p.time);
+    setDenied(notifier.permission() === "denied");
+    setReady(true);
+  }, []);
+
+  async function toggle() {
+    if (!on) {
+      if (notifier.permission() === "default") await notifier.requestPermission();
+      setDenied(notifier.permission() === "denied");
+      setPlanReminderPref({ on: true, time });
+      setOn(true);
+    } else {
+      setPlanReminderPref({ on: false, time });
+      setOn(false);
+    }
+  }
+
+  function changeTime(next: string) {
+    setTime(next);
+    setPlanReminderPref({ on, time: next });
+  }
+
+  if (!ready) return null;
+  const next = on ? nextDailyReminder(time, new Date()) : null;
+
+  return (
+    <div
+      style={{
+        marginTop: 18,
+        border: `1px solid ${N.border}`,
+        borderRadius: 14,
+        padding: 16,
+        background: N.card,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 14 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <Icon name="bell" size={17} color={on ? N.gold : N.muted} sw={1.8} />
+          <div>
+            <strong style={{ color: N.fg, fontFamily: N.ui, fontSize: 14 }}>Daily reminder</strong>
+            <p style={{ margin: "2px 0 0", color: N.muted, fontSize: 12.5, fontFamily: N.ui }}>
+              A gentle nudge for today’s portion. Works while Ummah Library is open.
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          className="noor-press"
+          aria-pressed={on}
+          onClick={() => void toggle()}
+          style={{
+            flexShrink: 0,
+            padding: "7px 14px",
+            borderRadius: 999,
+            border: `1px solid ${on ? N.gold : N.border}`,
+            background: on ? N.goldSoft : N.card,
+            color: on ? N.gold : N.muted,
+            fontWeight: 700,
+            fontSize: 13,
+            fontFamily: N.ui,
+            cursor: "pointer",
+          }}
+        >
+          {on ? "🔔 On" : "🔕 Off"}
+        </button>
+      </div>
+
+      {on && (
+        <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 14, flexWrap: "wrap" }}>
+          <label style={{ display: "flex", alignItems: "center", gap: 8, color: N.muted, fontSize: 13, fontFamily: N.ui }}>
+            Remind me at
+            <input
+              type="time"
+              value={time}
+              onChange={(e) => changeTime(e.target.value)}
+              style={{
+                padding: "6px 10px",
+                borderRadius: 10,
+                border: `1px solid ${N.border}`,
+                background: N.cardHi,
+                color: N.fg,
+                fontFamily: N.ui,
+                fontSize: 13,
+              }}
+            />
+          </label>
+          {next && (
+            <span style={{ color: N.faint, fontSize: 12.5, fontFamily: N.ui }}>
+              Next: {fmtDay(next)} at {fmtTime(next)}
+            </span>
+          )}
+        </div>
+      )}
+
+      {on && denied && (
+        <p style={{ margin: "12px 0 0", color: N.faint, fontSize: 12.5, fontFamily: N.ui }}>
+          Notifications are blocked in your browser — enable them in site settings to get the nudge.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/PlansView.tsx
+++ b/apps/web/src/components/PlansView.tsx
@@ -22,6 +22,7 @@ import {
   validatePlanDraft,
 } from "@ummahlibrary/core";
 import { N, Khatam, Icon, Seg } from "@ummahlibrary/ui";
+import { PlanReminderToggle } from "./PlanReminderToggle";
 import {
   READING_PLAN_EVENT,
   clearPlan,
@@ -357,6 +358,8 @@ export function PlansView() {
               );
             })}
           </div>
+
+          <PlanReminderToggle />
         </>
       )}
 

--- a/apps/web/src/lib/plan-reminders.test.ts
+++ b/apps/web/src/lib/plan-reminders.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AppNotification, Notifier, NotifyPermission } from "@ummahlibrary/core";
+import { activatePlan, templateById } from "@ummahlibrary/core";
+import { webPlanStore } from "./plan-store";
+import {
+  DEFAULT_PLAN_REMINDER_TIME,
+  PLAN_REMINDER_ID,
+  PLAN_REMINDER_KEY,
+  readPlanReminderPref,
+  setPlanReminderPref,
+  syncPlanReminder,
+} from "./plan-reminders";
+
+/** An in-memory Notifier that records what was scheduled / cancelled. */
+class FakeNotifier implements Notifier {
+  scheduled = new Map<string, AppNotification>();
+  cancelled: string[] = [];
+  constructor(private readonly perm: NotifyPermission = "granted") {}
+  isSupported() {
+    return true;
+  }
+  permission() {
+    return this.perm;
+  }
+  async requestPermission() {
+    return this.perm;
+  }
+  async schedule(n: AppNotification) {
+    this.scheduled.set(n.id, n);
+  }
+  async cancel(id: string) {
+    this.cancelled.push(id);
+    this.scheduled.delete(id);
+  }
+  async cancelAll() {
+    this.scheduled.clear();
+  }
+}
+
+const seedPlan = () =>
+  webPlanStore.write(activatePlan(templateById("ramadan-khatm")!, "2026-01-01"));
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("plan reminder preference", () => {
+  it("defaults to off at the default time", () => {
+    expect(readPlanReminderPref()).toEqual({ on: false, time: DEFAULT_PLAN_REMINDER_TIME });
+  });
+
+  it("round-trips a saved preference", () => {
+    setPlanReminderPref({ on: true, time: "07:30" });
+    expect(readPlanReminderPref()).toEqual({ on: true, time: "07:30" });
+  });
+
+  it("falls back safely on a malformed stored value", () => {
+    localStorage.setItem(PLAN_REMINDER_KEY, "{not json");
+    expect(readPlanReminderPref().on).toBe(false);
+  });
+});
+
+describe("syncPlanReminder", () => {
+  it("schedules a daily nudge when on, granted, and a plan is active", async () => {
+    await seedPlan();
+    setPlanReminderPref({ on: true, time: "20:00" });
+    const n = new FakeNotifier("granted");
+    await syncPlanReminder(n);
+
+    expect(n.cancelled).toContain(PLAN_REMINDER_ID); // idempotent: cancels first
+    const note = n.scheduled.get(PLAN_REMINDER_ID);
+    expect(note).toBeDefined();
+    expect(note?.title.length).toBeGreaterThan(0);
+    expect(typeof note?.at).toBe("string");
+  });
+
+  it("is a no-op when the reminder is off", async () => {
+    await seedPlan();
+    setPlanReminderPref({ on: false, time: "20:00" });
+    const n = new FakeNotifier("granted");
+    await syncPlanReminder(n);
+    expect(n.scheduled.size).toBe(0);
+  });
+
+  it("is a no-op without notification permission", async () => {
+    await seedPlan();
+    setPlanReminderPref({ on: true, time: "20:00" });
+    const n = new FakeNotifier("denied");
+    await syncPlanReminder(n);
+    expect(n.scheduled.size).toBe(0);
+  });
+
+  it("is a no-op when no plan is active", async () => {
+    setPlanReminderPref({ on: true, time: "20:00" });
+    const n = new FakeNotifier("granted");
+    await syncPlanReminder(n);
+    expect(n.scheduled.size).toBe(0);
+  });
+});

--- a/apps/web/src/lib/plan-reminders.ts
+++ b/apps/web/src/lib/plan-reminders.ts
@@ -1,0 +1,75 @@
+/**
+ * Reading-plan daily reminder (#71). Opt-in, a single daily nudge at a chosen
+ * time. All local: the on/off + time preference lives in `localStorage`, the
+ * message copy is the pure core helper (`planReminderContent`), and delivery
+ * goes through the {@link Notifier} port — the web adapter fires while a tab is
+ * open (ADR 0019). No server push; the honest limit of a no-backend app. The
+ * same core helpers will back a future Expo notifier behind the same port.
+ */
+import { type Notifier, nextDailyReminder, planReminderContent } from "@ummahlibrary/core";
+import { readActivePlan, todayStr } from "./reading-plan";
+
+export const PLAN_REMINDER_KEY = "ul.planReminder";
+export const PLAN_REMINDER_ID = "plan:daily";
+export const DEFAULT_PLAN_REMINDER_TIME = "20:00";
+
+export interface PlanReminderPref {
+  on: boolean;
+  /** Local wall-clock time, `HH:MM`. */
+  time: string;
+}
+
+const FALLBACK: PlanReminderPref = { on: false, time: DEFAULT_PLAN_REMINDER_TIME };
+
+export function readPlanReminderPref(): PlanReminderPref {
+  try {
+    const raw = localStorage.getItem(PLAN_REMINDER_KEY);
+    if (raw) {
+      const p = JSON.parse(raw) as Partial<PlanReminderPref>;
+      return {
+        on: p.on === true,
+        time: typeof p.time === "string" ? p.time : DEFAULT_PLAN_REMINDER_TIME,
+      };
+    }
+  } catch {
+    /* storage unavailable */
+  }
+  return { ...FALLBACK };
+}
+
+/** Persist the preference and notify the scheduler (and any open toggles). */
+export function setPlanReminderPref(pref: PlanReminderPref): void {
+  try {
+    localStorage.setItem(PLAN_REMINDER_KEY, JSON.stringify(pref));
+  } catch {
+    /* storage unavailable */
+  }
+  window.dispatchEvent(new CustomEvent(PLAN_REMINDER_KEY, { detail: pref }));
+}
+
+/**
+ * (Re)schedule the active plan's daily reminder through the notifier. Idempotent:
+ * cancels the pending one first, then schedules the next occurrence of the chosen
+ * time with copy reflecting today's progress. A no-op when the reminder is off,
+ * permission isn't granted, there's no active plan, or the time is malformed.
+ */
+export async function syncPlanReminder(notifier: Notifier): Promise<void> {
+  await notifier.cancel(PLAN_REMINDER_ID);
+  const pref = readPlanReminderPref();
+  if (!pref.on || notifier.permission() !== "granted") return;
+
+  const plan = await readActivePlan();
+  if (!plan) return;
+
+  const at = nextDailyReminder(pref.time, new Date());
+  if (!at) return;
+
+  const { title, body } = planReminderContent(plan, todayStr());
+  await notifier.schedule({
+    id: PLAN_REMINDER_ID,
+    title,
+    body,
+    at: at.toISOString(),
+    tag: PLAN_REMINDER_ID,
+  });
+}

--- a/packages/core/src/reading-plans.test.ts
+++ b/packages/core/src/reading-plans.test.ts
@@ -16,9 +16,11 @@ import {
   isDayComplete,
   isValidDateString,
   materializeDay,
+  nextDailyReminder,
   percentComplete,
   planDuration,
   planEndDate,
+  planReminderContent,
   planWeekWindow,
   projectedFinish,
   rangeOfJuz,
@@ -33,6 +35,7 @@ import {
   todayProgress,
   toggleDayComplete,
   totalUnits,
+  unitWord,
   unitsBehind,
   unitsRemaining,
   validatePlanDraft,
@@ -494,5 +497,58 @@ describe("validatePlanDraft", () => {
     expect(validatePlanDraft({ range: rangeOfJuz(1, 30), schedule: { kind: "targetDate", endDate: "2025-12-01" }, startDate: START })).toContain(
       "The end date can’t be before the start date.",
     );
+  });
+});
+
+// ── Daily reminders (#71) ────────────────────────────────────────────────────
+
+describe("daily reminders", () => {
+  it("pluralises unit words sensibly", () => {
+    expect(unitWord("page", 1)).toBe("page");
+    expect(unitWord("page", 3)).toBe("pages");
+    expect(unitWord("surah", 1)).toBe("sūrah");
+    expect(unitWord("surah", 2)).toBe("sūrahs");
+    expect(unitWord("juz", 5)).toBe("juzʾ");
+    expect(unitWord("hizb", 2)).toBe("ḥizb");
+  });
+
+  it("schedules today when the reminder time is still ahead", () => {
+    const now = new Date(2026, 0, 1, 12, 0, 0);
+    const at = nextDailyReminder("20:00", now);
+    expect(at?.getDate()).toBe(1);
+    expect(at?.getHours()).toBe(20);
+    expect(at?.getMinutes()).toBe(0);
+  });
+
+  it("rolls to tomorrow when the time has passed or equals now", () => {
+    const now = new Date(2026, 0, 1, 12, 0, 0);
+    expect(nextDailyReminder("08:00", now)?.getDate()).toBe(2);
+    expect(nextDailyReminder("12:00", now)?.getDate()).toBe(2);
+  });
+
+  it("rejects malformed reminder times", () => {
+    const now = new Date(2026, 0, 1, 12, 0, 0);
+    expect(nextDailyReminder("nope", now)).toBeNull();
+    expect(nextDailyReminder("25:00", now)).toBeNull();
+    expect(nextDailyReminder("12:60", now)).toBeNull();
+  });
+
+  it("shows today's portion when on track", () => {
+    const c = planReminderContent(ramadan(), START); // day 1, nothing read yet
+    expect(c.title).toContain("Today’s reading");
+    expect(c.body).toContain("1 juzʾ today");
+  });
+
+  it("celebrates a completed daily portion", () => {
+    const c = planReminderContent(setUnitsRead(ramadan(), 1), START);
+    expect(c.title).toContain("done");
+    expect(c.body).toContain("on track");
+  });
+
+  it("nudges gently when behind — never guilt-framed", () => {
+    const c = planReminderContent(setUnitsRead(ramadan(), 2), "2026-01-05"); // day 5, only 2 read
+    expect(c.title).toContain("pick up where you left off");
+    expect(c.body).toContain("3 juzʾ");
+    expect(c.body.toLowerCase()).not.toMatch(/missed|failed|behind|should/);
   });
 });

--- a/packages/core/src/reading-plans.ts
+++ b/packages/core/src/reading-plans.ts
@@ -543,6 +543,75 @@ export function todayProgress(plan: ActivePlan, today: string): { done: number; 
   return { done, total };
 }
 
+/** A unit's display word, count-aware — the vocabulary the reader chip uses. */
+export function unitWord(unit: PlanUnit, count: number): string {
+  switch (unit) {
+    case "juz":
+      return "juzʾ";
+    case "hizb":
+      return "ḥizb";
+    case "page":
+      return count === 1 ? "page" : "pages";
+    case "surah":
+      return count === 1 ? "sūrah" : "sūrahs";
+    case "ayah":
+      return count === 1 ? "ayah" : "ayahs";
+  }
+}
+
+/**
+ * The next wall-clock occurrence of a daily `HH:MM` reminder, relative to `now`:
+ * today if the time is still ahead, otherwise tomorrow. Pure — the clock is
+ * injected — so it's deterministic for a given `now`. Returns `null` for a
+ * malformed time (#71).
+ */
+export function nextDailyReminder(time: string, now: Date): Date | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(time.trim());
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h > 23 || min > 59) return null;
+  const at = new Date(now);
+  at.setHours(h, min, 0, 0);
+  if (at.getTime() <= now.getTime()) at.setDate(at.getDate() + 1);
+  return at;
+}
+
+/**
+ * The copy for a plan's daily reminder, adapted to where the reader stands:
+ * a "done" note when today's portion is complete, a gentle catch-up note when
+ * behind from earlier days, otherwise today's target. Never guilt-framed (#71).
+ */
+export function planReminderContent(
+  plan: ActivePlan,
+  today: string,
+): { title: string; body: string } {
+  const { done, total } = todayProgress(plan, today);
+  const unit = plan.template.range.unit;
+  const name = plan.template.name;
+
+  if (total > 0 && done >= total) {
+    return {
+      title: `${name} — today’s portion done ✓`,
+      body: "You’re on track. Keep the streak alive tomorrow, insha’Allah.",
+    };
+  }
+  // "Behind" counts only earlier days' shortfall, so a fresh day's reading is
+  // never framed as catching up.
+  if (daysAheadBehind(plan, today) < 0) {
+    const back = unitsBehind(plan, today);
+    return {
+      title: `${name} — pick up where you left off`,
+      body: `About ${back} ${unitWord(unit, back)} to be back on track. No rush — a little today goes a long way.`,
+    };
+  }
+  const left = Math.max(1, total - done);
+  return {
+    title: `Today’s reading — ${name}`,
+    body: `${left} ${unitWord(unit, left)} today. Open the Book when you’re ready.`,
+  };
+}
+
 /** A window of up to seven day numbers centred on `day` (for a week strip). */
 export function planWeekWindow(plan: ActivePlan, day: number): number[] {
   const len = planDuration(plan);


### PR DESCRIPTION
## What

Implements #71 (web + shared core): a single, gentle **daily reminder** for the active reading plan — opt-in, with an easy on/off and a chosen time.

- **Opt-in toggle** on the active-plan card: 🔔 On / 🔕 Off, a time picker, and a live *"Next: …"* label.
- **Adaptive, never-guilt-framed copy.** On track → *"Today's reading — N pages today"*; portion done → *"today's portion done ✓"*; behind from earlier days → *"pick up where you left off — about N to be back on track"*. A fresh day is never framed as catching up.
- **All local.** Preference in `localStorage`; copy is a pure `core` helper; delivery goes through the existing `Notifier` port (the web adapter fires while a tab is open). No server push — consistent with prayer/adhkar reminders (ADR 0019).

## How it's structured

| Layer | Change |
|---|---|
| `core/reading-plans.ts` | `nextDailyReminder` (next `HH:MM`, clock injected), `planReminderContent` (adaptive copy), count-aware `unitWord` — all pure, unit-tested |
| `web/lib/plan-reminders.ts` | preference + idempotent `syncPlanReminder(notifier)` |
| `web/components/PlanReminderToggle.tsx` | the UI on the active-plan card |
| `web/components/PlanReminderScheduler.tsx` | mounted in layout; reschedules on load, on preference/plan change, and on a coarse tick for day rollover |

No new ADR — reuses the `Notifier` port and the local-first pattern (ADR 0019). No new dependency edge.

## Testing — all angles

- **Loop:** `pnpm lint`, `pnpm typecheck`, `pnpm test` (**407**, +14 new), `pnpm build` all pass.
- **Core unit tests:** `nextDailyReminder` (today / tomorrow / equals-now / malformed / out-of-range), `unitWord` pluralisation, `planReminderContent` (on-track / done / behind, asserting no guilt words).
- **Web lib tests:** `syncPlanReminder` with a fake `Notifier` — schedules when on+granted+active-plan; no-op when off / unpermitted / no plan; preference round-trips and survives malformed storage.
- **Visual:** verified on the running app (seeded plan) — the "Daily reminder" card renders with the toggle, time picker `20:00`, and *"Next: tomorrow at 08:00 PM"*; `aria-pressed=true` when on.

## Mobile — deferred (tracked)

#71 is labelled web + mobile, but the mobile app currently has **no notification infrastructure** (no `expo-notifications`, no `Notifier` adapter). A proper mobile reminder needs a native dependency + a **dev build** (scheduled local notifications don't run in Expo Go), which can't be installed or verified in CI/this environment. The reminder **logic already lives in `core`**, so mobile becomes a thin `ExpoNotifier` + a `PlanReminderToggle.native` over the same port and helpers — a focused follow-up. This PR therefore lands the web + core half; **#71 stays open for the mobile adapter.**

Part of #71.