### PR TITLE
feat(web): plan detail page — progress ring, heatmap, pause/resume (#68)

### DIFF
--- a/apps/web/src/app/plans/[id]/page.tsx
+++ b/apps/web/src/app/plans/[id]/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { PLAN_TEMPLATES, templateById } from "@ummahlibrary/core";
+import { PlanDetailView } from "../../../components/PlanDetailView";
+
+// Only the catalogue ids (plus a started custom plan) have a detail page.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return [...PLAN_TEMPLATES.map((t) => ({ id: t.id })), { id: "custom" }];
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const name = templateById(id)?.name ?? "Reading plan";
+  return { title: `${name} · Reading plans` };
+}
+
+export default async function PlanDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <PlanDetailView templateId={id} />;
+}

--- a/apps/web/src/components/PlanDetailView.tsx
+++ b/apps/web/src/components/PlanDetailView.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  type ActivePlan,
+  type DayPortion,
+  computeTodayPortion,
+  currentDay,
+  daysAheadBehind,
+  effectiveToday,
+  isDayComplete,
+  isPaused,
+  percentComplete,
+  planDuration,
+  planEndDate,
+  templateById,
+} from "@ummahlibrary/core";
+import { N, Khatam, Icon } from "@ummahlibrary/ui";
+import {
+  READING_PLAN_EVENT,
+  clearPlan,
+  extendPlanBy,
+  pausePlan,
+  readActivePlan,
+  rebalancePlan,
+  resumePlan,
+  startPlan,
+  todayStr,
+} from "../lib/reading-plan";
+
+const RING = 52;
+const CIRC = 2 * Math.PI * RING;
+
+function targetHref(p: DayPortion): string {
+  switch (p.target.kind) {
+    case "juz":
+      return `/juz/${p.target.juz}`;
+    case "surah":
+      return `/surah/${p.target.surah}`;
+    default:
+      return `/surah/${p.startRef.sura}`;
+  }
+}
+
+const actionBtn = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 7,
+  padding: "9px 14px",
+  borderRadius: 12,
+  border: `1px solid ${N.border}`,
+  background: N.card,
+  color: N.fg,
+  fontFamily: N.ui,
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: "pointer",
+} as const;
+
+export function PlanDetailView({ templateId }: { templateId: string }) {
+  const [plan, setPlan] = useState<ActivePlan | null>(null);
+  const [ready, setReady] = useState(false);
+  const [confirmAbandon, setConfirmAbandon] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    const refresh = () =>
+      void readActivePlan().then((p) => {
+        setPlan(p);
+        setReady(true);
+      });
+    refresh();
+    window.addEventListener(READING_PLAN_EVENT, refresh);
+    return () => window.removeEventListener(READING_PLAN_EVENT, refresh);
+  }, []);
+
+  if (!ready) return null;
+
+  const template = templateById(templateId);
+  const isActive = !!plan && plan.template.id === templateId;
+
+  // ── Active plan: the rich detail ──────────────────────────────────────────
+  if (isActive && plan) {
+    const paused = isPaused(plan);
+    const today = effectiveToday(plan, todayStr());
+    const total = planDuration(plan);
+    const day = currentDay(plan, today);
+    const pct = percentComplete(plan);
+    const behind = daysAheadBehind(plan, today);
+    const portion = computeTodayPortion(plan, today);
+
+    return (
+      <div style={{ maxWidth: 640, margin: "0 auto", padding: "8px 0 60px" }}>
+        <Link href="/plans" style={{ color: N.muted, fontSize: 13, fontFamily: N.ui, textDecoration: "none" }}>
+          ← All plans
+        </Link>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 18, margin: "18px 0 22px" }}>
+          <div style={{ position: "relative", width: 140, height: 140, flexShrink: 0 }}>
+            <svg width={140} height={140} viewBox="0 0 140 140">
+              <circle cx={70} cy={70} r={RING} fill="none" stroke={N.border} strokeWidth={10} />
+              <circle
+                cx={70}
+                cy={70}
+                r={RING}
+                fill="none"
+                stroke={N.gold}
+                strokeWidth={10}
+                strokeLinecap="round"
+                strokeDasharray={CIRC}
+                strokeDashoffset={CIRC * (1 - pct / 100)}
+                transform="rotate(-90 70 70)"
+              />
+            </svg>
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "grid",
+                placeItems: "center",
+                textAlign: "center",
+              }}
+            >
+              <div>
+                <div style={{ fontSize: 28, fontWeight: 800, color: N.fg, fontFamily: N.ui }}>{pct}%</div>
+                <div style={{ fontSize: 12, color: N.faint, fontFamily: N.ui }}>
+                  Day {day} of {total}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div style={{ minWidth: 0 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <Khatam size={26} color={N.gold} sw={1} opacity={0.7} />
+              <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, color: N.fg, fontFamily: N.ui }}>
+                {plan.template.name}
+              </h1>
+            </div>
+            <p style={{ margin: "6px 0 0", color: N.muted, fontSize: 13.5, fontFamily: N.ui }}>
+              {plan.template.tag} · ends {planEndDate(plan)}
+            </p>
+            {paused && (
+              <span
+                style={{
+                  display: "inline-block",
+                  marginTop: 10,
+                  padding: "3px 10px",
+                  borderRadius: 999,
+                  background: N.cardHi,
+                  border: `1px solid ${N.border}`,
+                  color: N.muted,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  fontFamily: N.ui,
+                }}
+              >
+                ⏸ Paused
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Today's portion / paused notice */}
+        {paused ? (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 14,
+              padding: 16,
+              borderRadius: 14,
+              border: `1px solid ${N.border}`,
+              background: N.card,
+            }}
+          >
+            <span style={{ color: N.muted, fontSize: 13.5, fontFamily: N.ui }}>
+              Paused on {plan.pausedOn}. Your place is held — resume any time.
+            </span>
+            <button type="button" className="noor-press" style={{ ...actionBtn, borderColor: N.gold, color: N.gold }} onClick={() => void resumePlan()}>
+              <Icon name="play" size={14} color={N.gold} /> Resume
+            </button>
+          </div>
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 14,
+              padding: 16,
+              borderRadius: 14,
+              border: `1px solid ${N.gold}`,
+              background: N.goldSoft,
+            }}
+          >
+            <div>
+              <div style={{ fontSize: 11, letterSpacing: 1, textTransform: "uppercase", color: N.gold, fontWeight: 700, fontFamily: N.ui }}>
+                Today
+              </div>
+              <div style={{ marginTop: 4, color: N.fg, fontSize: 15, fontWeight: 600, fontFamily: N.ui }}>{portion.label}</div>
+            </div>
+            <Link
+              href={targetHref(portion)}
+              className="noor-press"
+              style={{ ...actionBtn, background: N.goldGrad, border: "none", color: N.ink, textDecoration: "none" }}
+            >
+              <Icon name="book" size={15} color={N.ink} sw={1.8} /> Read now
+            </Link>
+          </div>
+        )}
+
+        {!paused && behind < 0 && (
+          <p style={{ marginTop: 12, color: N.muted, fontSize: 13, fontFamily: N.ui }}>
+            You’re {Math.abs(behind)} {Math.abs(behind) === 1 ? "day" : "days"} behind — re-pace below to catch up gently.
+          </p>
+        )}
+
+        {/* Heatmap */}
+        <h2 style={{ fontSize: 12, letterSpacing: 1.2, textTransform: "uppercase", color: N.faint, fontWeight: 700, fontFamily: N.ui, margin: "28px 0 12px" }}>
+          Your days
+        </h2>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(16px, 1fr))", gap: 5 }}>
+          {Array.from({ length: total }, (_, i) => i + 1).map((d) => {
+            const done = isDayComplete(plan, d);
+            const isToday = d === day;
+            const missed = d < day && !done;
+            const bg = done ? N.gold : missed ? N.cardHi : "transparent";
+            const border = isToday ? N.gold : done ? N.gold : N.border;
+            return (
+              <div
+                key={d}
+                title={`Day ${d}${done ? " · done" : missed ? " · missed" : isToday ? " · today" : ""}`}
+                style={{
+                  aspectRatio: "1 / 1",
+                  borderRadius: 4,
+                  background: bg,
+                  border: `1px solid ${border}`,
+                  boxShadow: isToday ? `0 0 0 2px ${N.goldSoft}` : "none",
+                }}
+              />
+            );
+          })}
+        </div>
+        <div style={{ display: "flex", gap: 16, marginTop: 12, color: N.faint, fontSize: 11.5, fontFamily: N.ui }}>
+          <Legend swatch={N.gold} label="Done" />
+          <Legend swatch={N.cardHi} label="Missed" />
+          <Legend swatch="transparent" label="Upcoming" />
+        </div>
+
+        {/* Actions */}
+        <h2 style={{ fontSize: 12, letterSpacing: 1.2, textTransform: "uppercase", color: N.faint, fontWeight: 700, fontFamily: N.ui, margin: "28px 0 12px" }}>
+          Manage
+        </h2>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+          <button type="button" className="noor-press" style={actionBtn} onClick={() => void rebalancePlan()}>
+            <Icon name="repeat" size={14} color={N.fg} sw={1.8} /> Re-pace (keep end date)
+          </button>
+          <button type="button" className="noor-press" style={actionBtn} onClick={() => void extendPlanBy(7)}>
+            <Icon name="plus" size={14} color={N.fg} sw={1.8} /> Extend +1 week
+          </button>
+          {paused ? (
+            <button type="button" className="noor-press" style={actionBtn} onClick={() => void resumePlan()}>
+              <Icon name="play" size={14} color={N.fg} /> Resume
+            </button>
+          ) : (
+            <button type="button" className="noor-press" style={actionBtn} onClick={() => void pausePlan()}>
+              <Icon name="pause" size={14} color={N.fg} /> Pause
+            </button>
+          )}
+          {confirmAbandon ? (
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+              <span style={{ color: N.muted, fontSize: 13, fontFamily: N.ui }}>Abandon this plan?</span>
+              <button
+                type="button"
+                className="noor-press"
+                style={{ ...actionBtn, background: N.cardHi, color: N.fg }}
+                onClick={() => {
+                  void clearPlan();
+                  router.push("/plans");
+                }}
+              >
+                Yes, abandon
+              </button>
+              <button type="button" className="noor-press" style={actionBtn} onClick={() => setConfirmAbandon(false)}>
+                Keep
+              </button>
+            </span>
+          ) : (
+            <button type="button" className="noor-press" style={{ ...actionBtn, color: N.muted }} onClick={() => setConfirmAbandon(true)}>
+              <Icon name="close" size={14} color={N.muted} sw={1.8} /> Abandon
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── A known catalogue template, not yet started: preview + start ───────────
+  if (template) {
+    return (
+      <div style={{ maxWidth: 560, margin: "0 auto", padding: "8px 0 60px" }}>
+        <Link href="/plans" style={{ color: N.muted, fontSize: 13, fontFamily: N.ui, textDecoration: "none" }}>
+          ← All plans
+        </Link>
+        <div style={{ marginTop: 18, padding: 22, borderRadius: 16, border: `1px solid ${N.border}`, background: N.card }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <Khatam size={28} color={N.gold} sw={1} opacity={0.7} />
+            <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, color: N.fg, fontFamily: N.ui }}>{template.name}</h1>
+          </div>
+          <p style={{ margin: "8px 0 0", color: N.muted, fontSize: 13.5, fontFamily: N.ui }}>
+            {template.tag} · {template.len}
+          </p>
+          <p style={{ margin: "12px 0 0", color: N.fg, fontSize: 14.5, lineHeight: 1.5, fontFamily: N.ui }}>{template.desc}</p>
+          {plan && (
+            <p style={{ margin: "14px 0 0", color: N.faint, fontSize: 12.5, fontFamily: N.ui }}>
+              Starting this replaces your current plan ({plan.template.name}).
+            </p>
+          )}
+          <button
+            type="button"
+            className="noor-press"
+            style={{ ...actionBtn, marginTop: 18, background: N.goldGrad, border: "none", color: N.ink }}
+            onClick={() => void startPlan(templateId)}
+          >
+            <Icon name="book" size={15} color={N.ink} sw={1.8} /> Start this plan
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Unknown id (e.g. a custom plan that isn't active) ─────────────────────
+  return (
+    <div style={{ maxWidth: 480, margin: "40px auto", textAlign: "center" }}>
+      <p style={{ color: N.muted, fontSize: 14, fontFamily: N.ui }}>That plan isn’t available.</p>
+      <Link href="/plans" style={{ color: N.gold, fontSize: 14, fontFamily: N.ui }}>
+        Browse reading plans →
+      </Link>
+    </div>
+  );
+}
+
+function Legend({ swatch, label }: { swatch: string; label: string }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+      <span style={{ width: 11, height: 11, borderRadius: 3, background: swatch, border: `1px solid ${N.border}` }} />
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/components/PlanReaderChip.tsx
+++ b/apps/web/src/components/PlanReaderChip.tsx
@@ -28,7 +28,7 @@ export function PlanReaderChip() {
     return () => window.removeEventListener(READING_PLAN_EVENT, refresh);
   }, []);
 
-  if (!plan) return null;
+  if (!plan || plan.pausedOn) return null; // hidden while the plan is paused (#68)
   const { done, total } = todayProgress(plan, todayStr());
   if (total === 0) return null;
   const complete = done >= total;

--- a/apps/web/src/components/PlansView.tsx
+++ b/apps/web/src/components/PlansView.tsx
@@ -29,6 +29,7 @@ import {
   extendPlanBy,
   readActivePlan,
   rebalancePlan,
+  resumePlan,
   startCustomPlan,
   startPlan,
   todayStr,
@@ -83,12 +84,16 @@ export function PlansView() {
   }, []);
 
   const today = todayStr();
+  // While paused the clock is frozen at the pause day (#68), so a break never
+  // reads as "behind". The custom creator below still uses the real `today`.
+  const viewToday = plan?.pausedOn ?? today;
+  const paused = !!plan?.pausedOn;
   const totalDays = plan ? planDuration(plan) : 0;
-  const day = plan ? currentDay(plan, today) : 0;
-  const portion = plan ? computeTodayPortion(plan, today) : undefined;
+  const day = plan ? currentDay(plan, viewToday) : 0;
+  const portion = plan ? computeTodayPortion(plan, viewToday) : undefined;
   const pct = plan ? percentComplete(plan) : 0;
-  const behind = plan ? daysAheadBehind(plan, today) : 0;
-  const catchUp = plan ? catchUpPortion(plan, today) : undefined;
+  const behind = plan ? daysAheadBehind(plan, viewToday) : 0;
+  const catchUp = plan ? catchUpPortion(plan, viewToday) : undefined;
 
   // Custom plan draft — whole Quran by pages; validate + preview the pace live.
   const customRange = rangeOfPages(1, 604);
@@ -198,7 +203,7 @@ export function PlansView() {
                       fontFamily: N.ui,
                     }}
                   >
-                    Active · Day {day} of {totalDays}
+                    {paused ? "⏸ Paused" : "Active"} · Day {day} of {totalDays}
                   </div>
                   <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: -0.5, color: N.fg, fontFamily: N.ui }}>
                     {plan.template.name}
@@ -266,6 +271,44 @@ export function PlansView() {
             >
               Leave plan
             </button>
+            {paused && (
+              <button
+                type="button"
+                onClick={() => void resumePlan()}
+                className="noor-press"
+                style={{
+                  padding: "9px 16px",
+                  borderRadius: 999,
+                  border: `1px solid ${N.gold}`,
+                  background: N.goldSoft,
+                  color: N.gold,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  fontFamily: N.ui,
+                }}
+              >
+                ▶ Resume
+              </button>
+            )}
+            <Link
+              href={`/plans/${plan.template.id}`}
+              className="noor-press"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                padding: "9px 16px",
+                borderRadius: 999,
+                border: `1px solid ${N.border}`,
+                background: N.card,
+                color: N.muted,
+                fontSize: 13,
+                fontWeight: 600,
+                fontFamily: N.ui,
+                textDecoration: "none",
+              }}
+            >
+              Details →
+            </Link>
           </div>
 
           {/* Behind-state + recovery (#70) */}

--- a/apps/web/src/lib/plan-reminders.ts
+++ b/apps/web/src/lib/plan-reminders.ts
@@ -59,7 +59,7 @@ export async function syncPlanReminder(notifier: Notifier): Promise<void> {
   if (!pref.on || notifier.permission() !== "granted") return;
 
   const plan = await readActivePlan();
-  if (!plan) return;
+  if (!plan || plan.pausedOn) return; // a paused plan doesn't nudge (#68)
 
   const at = nextDailyReminder(pref.time, new Date());
   if (!at) return;

--- a/apps/web/src/lib/reading-plan.ts
+++ b/apps/web/src/lib/reading-plan.ts
@@ -9,7 +9,9 @@ import {
   activatePlan,
   advanceCursorToPage,
   extendPlan,
+  pausePlan as applyPause,
   rebalance,
+  resumePlan as applyResume,
   templateById,
   toggleDayComplete,
 } from "@ummahlibrary/core";
@@ -76,6 +78,22 @@ export async function extendPlanBy(days: number): Promise<void> {
   const plan = await store.read();
   if (!plan) return;
   await store.write(extendPlan(plan, todayStr(), days));
+  emit();
+}
+
+/** Pause the active plan, freezing its clock (#68). */
+export async function pausePlan(): Promise<void> {
+  const plan = await store.read();
+  if (!plan || plan.pausedOn) return;
+  await store.write(applyPause(plan, todayStr()));
+  emit();
+}
+
+/** Resume a paused plan, shifting its timeline past the break (#68). */
+export async function resumePlan(): Promise<void> {
+  const plan = await store.read();
+  if (!plan?.pausedOn) return;
+  await store.write(applyResume(plan, todayStr()));
   emit();
 }
 

--- a/packages/core/src/reading-plans.test.ts
+++ b/packages/core/src/reading-plans.test.ts
@@ -12,11 +12,14 @@ import {
   cumulativeUnits,
   currentDay,
   daysAheadBehind,
+  effectiveToday,
   extendPlan,
   isDayComplete,
+  isPaused,
   isValidDateString,
   materializeDay,
   nextDailyReminder,
+  pausePlan,
   percentComplete,
   planDuration,
   planEndDate,
@@ -29,6 +32,7 @@ import {
   rebalance,
   repace,
   reschedule,
+  resumePlan,
   setUnitsRead,
   surahList,
   templateById,
@@ -550,5 +554,58 @@ describe("daily reminders", () => {
     expect(c.title).toContain("pick up where you left off");
     expect(c.body).toContain("3 juzʾ");
     expect(c.body.toLowerCase()).not.toMatch(/missed|failed|behind|should/);
+  });
+});
+
+// ── Pause / resume (#68) ─────────────────────────────────────────────────────
+
+describe("pause and resume", () => {
+  it("is not paused by default", () => {
+    const p = ramadan();
+    expect(isPaused(p)).toBe(false);
+    expect(effectiveToday(p, "2026-01-10")).toBe("2026-01-10");
+  });
+
+  it("pausing freezes the clock so a break never accrues 'behind'", () => {
+    const onTrack = setUnitsRead(ramadan(), 4); // completed through day 4
+    const p = pausePlan(onTrack, "2026-01-05");
+    expect(isPaused(p)).toBe(true);
+    expect(p.pausedOn).toBe("2026-01-05");
+    expect(effectiveToday(p, "2026-01-20")).toBe("2026-01-05");
+    expect(currentDay(p, effectiveToday(p, "2026-01-20"))).toBe(5);
+    expect(daysAheadBehind(p, effectiveToday(p, "2026-01-20"))).toBe(0);
+    // without the freeze, a long break would read as deeply behind
+    expect(daysAheadBehind(p, "2026-01-20")).toBeLessThan(0);
+  });
+
+  it("pausing is idempotent", () => {
+    const p = pausePlan(ramadan(), "2026-01-05");
+    expect(pausePlan(p, "2026-01-09")).toBe(p);
+  });
+
+  it("resuming shifts the timeline forward by the break, preserving the day", () => {
+    const paused = pausePlan(ramadan(), "2026-01-05");
+    const resumed = resumePlan(paused, "2026-01-12"); // a 7-day break
+    expect(isPaused(resumed)).toBe(false);
+    expect(resumed.pausedOn).toBeUndefined();
+    expect(resumed.startDate).toBe("2026-01-08");
+    expect(currentDay(resumed, "2026-01-12")).toBe(5); // back where we left off
+    expect(planEndDate(resumed)).toBe("2026-02-06"); // deadline pushed out 7 days
+  });
+
+  it("resume is a no-op when not paused", () => {
+    const p = ramadan();
+    expect(resumePlan(p, "2026-01-12")).toBe(p);
+  });
+
+  it("resume shifts the re-pace anchor too", () => {
+    const anchored: ActivePlan = {
+      ...ramadan(),
+      anchor: { date: "2026-01-03", units: 2 },
+      pausedOn: "2026-01-05",
+    };
+    const resumed = resumePlan(anchored, "2026-01-12");
+    expect(resumed.anchor).toEqual({ date: "2026-01-10", units: 2 }); // +7 days
+    expect(resumed.pausedOn).toBeUndefined();
   });
 });

--- a/packages/core/src/reading-plans.ts
+++ b/packages/core/src/reading-plans.ts
@@ -88,6 +88,13 @@ export interface ActivePlan {
    * (`unitsRead`, percent complete) is preserved. Absent on a fresh plan.
    */
   anchor?: { date: string; units: number };
+  /**
+   * Paused since this `YYYY-MM-DD` (#68). While paused the clock is frozen at
+   * this day — callers pass it as the effective `today` (see {@link effectiveToday})
+   * — so a break never accrues "behind". Resuming shifts the timeline forward by
+   * the break and clears this. Absent on an active plan.
+   */
+  pausedOn?: string;
 }
 
 /** What to read on a given day, resolved to deep-linkable Quran references. */
@@ -684,6 +691,42 @@ export function rebalance(plan: ActivePlan, today: string): ActivePlan {
 /** Move the end date `days` later and re-pace the remaining units from today. */
 export function extendPlan(plan: ActivePlan, today: string, days: number): ActivePlan {
   return repace(plan, today, addDays(planEndDate(plan), Math.max(1, Math.floor(days))));
+}
+
+// ── Pause / resume (#68) ────────────────────────────────────────────────────
+
+/** Whether the plan's clock is currently frozen by a pause. */
+export function isPaused(plan: ActivePlan): boolean {
+  return typeof plan.pausedOn === "string";
+}
+
+/**
+ * The date the schedule should treat as "today" — the pause day while paused,
+ * otherwise the real `today`. Freezing the clock is what stops a break from
+ * accruing "behind"; every display helper already takes `today`, so callers
+ * just pass this through.
+ */
+export function effectiveToday(plan: ActivePlan, today: string): string {
+  return plan.pausedOn ?? today;
+}
+
+/** Pause the plan, freezing its clock at `today`. Idempotent. */
+export function pausePlan(plan: ActivePlan, today: string): ActivePlan {
+  return plan.pausedOn ? plan : { ...plan, pausedOn: today };
+}
+
+/**
+ * Resume a paused plan: shift the whole timeline forward by the break so the
+ * reader picks up exactly where they left off (same day number, same pace) with
+ * the end date pushed out — a break is never penalised. A no-op if not paused.
+ */
+export function resumePlan(plan: ActivePlan, today: string): ActivePlan {
+  if (!plan.pausedOn) return plan;
+  const gap = Math.max(0, daysBetween(plan.pausedOn, today));
+  const next: ActivePlan = { ...plan, startDate: addDays(plan.startDate, gap) };
+  if (plan.anchor) next.anchor = { ...plan.anchor, date: addDays(plan.anchor.date, gap) };
+  delete next.pausedOn;
+  return next;
 }
 
 // ── Validation (for the custom-plan creator) ────────────────────────────────


### PR DESCRIPTION
## What

A per-plan detail page at **`/plans/[id]`** — statically generated for every catalogue id (and a started custom plan).

- **Progress ring** — % complete, *Day X of N*.
- **Today's portion** + **Read now** (links straight to the day's juzʾ/sūrah/page).
- **Calendar heatmap** — done / missed / upcoming days, with a legend.
- **Manage actions** — re-pace (keep end date), extend +1 week, **pause/resume**, abandon (two-step confirm).

The overview (`/plans`) now links each plan to its detail page, shows a *Paused* state + a *Resume* action, and reads through the frozen clock so a pause never shows false "behind".

## Pause — the one new behaviour (pure core)

Re-pace and abandon already existed; **pause** is added to the engine:

- `ActivePlan` gains optional `pausedOn`.
- `pausePlan(plan, today)` freezes the clock at that day; `resumePlan(plan, today)` shifts the whole timeline forward by the break — **same day number, same pace, end date pushed out** — so a break is never penalised.
- `isPaused` / `effectiveToday` let every display helper treat the pause day as `today`, so no "behind" accrues while paused.
- The reader chip and the daily reminder go quiet while paused.

All pure and deterministic (clock injected) — no I/O in `core`.

## Testing — all angles

- **Loop:** `pnpm lint`, `pnpm typecheck`, `pnpm test` (**413**, +6 new), `pnpm build` all pass; `/plans/[id]` prerenders for every catalogue id.
- **Core unit tests:** pause freezes the clock (and a long break never reads as behind); pausing is idempotent; resume shifts the timeline by the break preserving the day and pushing the deadline out; resume shifts the re-pace anchor too; resume is a no-op when not paused.
- **Visual (seeded plan):** active detail renders ring (10%, Day 7/30), today's portion + Read now, the "3 days behind" note, the heatmap (done/missed/today/upcoming) and Manage actions; paused detail freezes the clock, drops the "behind" note, holds the place and swaps Pause→Resume.
- **Interaction (real DOM clicks):** Pause → "your place is held" + `pausedOn` persisted; Resume → back to active + `pausedOn` cleared.

## Architecture

No new ADR — ADR 0025 already scopes the progress detail view as a follow-up, and pause is a small model increment alongside the #70 re-pace anchor (no new dependency edge, port, or delivery mode). Colours/icons use existing `packages/ui` tokens only (ADR 0023).

Closes #68.