### PR TITLE
feat(web): plan completion milestone + share card (#63)

### DIFF
--- a/apps/web/src/components/PlanCompletionCard.tsx
+++ b/apps/web/src/components/PlanCompletionCard.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { type ActivePlan, PLAN_TEMPLATES, planDuration, totalUnits, unitWord } from "@ummahlibrary/core";
+import { N, Khatam, Icon } from "@ummahlibrary/ui";
+import { renderPlanCardImage, shareOrDownload } from "../lib/share-image";
+
+/**
+ * Completion milestone for a finished plan (#63): a celebration, a shareable
+ * progress card (reusing the ayah image renderer), and a nudge to begin the next
+ * journey. Shown in place of the active-plan card once every unit is read.
+ */
+export function PlanCompletionCard({ plan }: { plan: ActivePlan }) {
+  const [busy, setBusy] = useState(false);
+
+  const unit = plan.template.range.unit;
+  const total = totalUnits(plan.template.range);
+  const days = planDuration(plan);
+  const name = plan.template.name;
+  const suggestions = PLAN_TEMPLATES.filter((t) => t.id !== plan.template.id).slice(0, 2);
+
+  async function share() {
+    setBusy(true);
+    try {
+      const blob = await renderPlanCardImage({
+        heading: "Quran journey complete",
+        arabic: "ٱلْحَمْدُ لِلّٰهِ",
+        subtitle: `${name} · ${total} ${unitWord(unit, total)} · ${days} days`,
+      });
+      if (blob) await shareOrDownload(blob, `plan-${plan.template.id}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        borderRadius: 18,
+        padding: 28,
+        textAlign: "center",
+        border: `1px solid ${N.gold}`,
+        background: `linear-gradient(135deg, ${N.goldSoft}, ${N.card})`,
+      }}
+    >
+      <div style={{ display: "grid", placeItems: "center" }}>
+        <Khatam size={84} color={N.gold} sw={1} opacity={0.85} />
+      </div>
+      <div style={{ fontSize: 12, letterSpacing: 1.4, textTransform: "uppercase", color: N.gold, fontWeight: 800, fontFamily: N.ui }}>
+        Plan complete
+      </div>
+      <h2 style={{ margin: "8px 0 0", fontSize: 25, fontWeight: 800, color: N.fg, fontFamily: N.ui }}>
+        Alhamdulillah — you finished {name}
+      </h2>
+      <p style={{ margin: "8px 0 0", color: N.muted, fontSize: 14, fontFamily: N.ui }}>
+        {total} {unitWord(unit, total)} over {days} {days === 1 ? "day" : "days"}. May Allah accept it.
+      </p>
+
+      <div style={{ display: "flex", justifyContent: "center", gap: 10, marginTop: 20 }}>
+        <button
+          type="button"
+          className="noor-press"
+          disabled={busy}
+          onClick={() => void share()}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "11px 18px",
+            borderRadius: 12,
+            border: "none",
+            background: N.goldGrad,
+            color: N.ink,
+            fontWeight: 700,
+            fontSize: 14,
+            fontFamily: N.ui,
+            cursor: busy ? "default" : "pointer",
+            opacity: busy ? 0.7 : 1,
+          }}
+        >
+          <Icon name="share" size={16} color={N.ink} sw={1.8} /> {busy ? "Preparing…" : "Share your achievement"}
+        </button>
+      </div>
+
+      {suggestions.length > 0 && (
+        <div style={{ marginTop: 26 }}>
+          <div style={{ fontSize: 12, letterSpacing: 1, textTransform: "uppercase", color: N.faint, fontWeight: 700, fontFamily: N.ui }}>
+            Begin a new journey
+          </div>
+          <div style={{ display: "flex", justifyContent: "center", gap: 10, marginTop: 12, flexWrap: "wrap" }}>
+            {suggestions.map((t) => (
+              <Link
+                key={t.id}
+                href={`/plans/${t.id}`}
+                className="noor-press"
+                style={{
+                  display: "inline-flex",
+                  flexDirection: "column",
+                  gap: 2,
+                  padding: "10px 16px",
+                  borderRadius: 12,
+                  border: `1px solid ${N.border}`,
+                  background: N.card,
+                  color: N.fg,
+                  textDecoration: "none",
+                  fontFamily: N.ui,
+                }}
+              >
+                <span style={{ fontWeight: 700, fontSize: 13.5 }}>{t.name}</span>
+                <span style={{ fontSize: 11.5, color: N.faint }}>
+                  {t.tag} · {t.len}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/PlanDetailView.tsx
+++ b/apps/web/src/components/PlanDetailView.tsx
@@ -12,12 +12,14 @@ import {
   effectiveToday,
   isDayComplete,
   isPaused,
+  isPlanComplete,
   percentComplete,
   planDuration,
   planEndDate,
   templateById,
 } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
+import { PlanCompletionCard } from "./PlanCompletionCard";
 import {
   READING_PLAN_EVENT,
   clearPlan,
@@ -96,6 +98,12 @@ export function PlanDetailView({ templateId }: { templateId: string }) {
         <Link href="/plans" style={{ color: N.muted, fontSize: 13, fontFamily: N.ui, textDecoration: "none" }}>
           ← All plans
         </Link>
+
+        {isPlanComplete(plan) && (
+          <div style={{ marginTop: 16 }}>
+            <PlanCompletionCard plan={plan} />
+          </div>
+        )}
 
         <div style={{ display: "flex", alignItems: "center", gap: 18, margin: "18px 0 22px" }}>
           <div style={{ position: "relative", width: 140, height: 140, flexShrink: 0 }}>

--- a/apps/web/src/components/PlansView.tsx
+++ b/apps/web/src/components/PlansView.tsx
@@ -14,6 +14,7 @@ import {
   currentDay,
   daysAheadBehind,
   isDayComplete,
+  isPlanComplete,
   percentComplete,
   planDuration,
   planEndDate,
@@ -23,6 +24,7 @@ import {
 } from "@ummahlibrary/core";
 import { N, Khatam, Icon, Seg } from "@ummahlibrary/ui";
 import { PlanReminderToggle } from "./PlanReminderToggle";
+import { PlanCompletionCard } from "./PlanCompletionCard";
 import {
   READING_PLAN_EVENT,
   clearPlan,
@@ -136,7 +138,9 @@ export function PlansView() {
 
   return (
     <div>
-      {plan && portion && (
+      {plan && isPlanComplete(plan) && <PlanCompletionCard plan={plan} />}
+
+      {plan && portion && !isPlanComplete(plan) && (
         <>
           {/* Active plan */}
           <div

--- a/apps/web/src/lib/share-image.ts
+++ b/apps/web/src/lib/share-image.ts
@@ -110,6 +110,82 @@ export async function renderAyahImage(input: AyahImageInput): Promise<Blob | nul
   return new Promise((resolve) => canvas.toBlob((b) => resolve(b), "image/png"));
 }
 
+interface PlanCardInput {
+  /** English headline, e.g. "Quran journey complete". */
+  heading: string;
+  /** A short Arabic phrase rendered large (Amiri), e.g. "ٱلْحَمْدُ لِلّٰهِ". */
+  arabic: string;
+  /** Plan name + scope, e.g. "Ramadan Khatm · 30 juzʾ · 30 days". */
+  subtitle: string;
+}
+
+/**
+ * Render a square "plan complete" share card (#63) — reuses this module's
+ * canvas + fixed palette + {@link shareOrDownload}, the same way ayah cards are
+ * made. Entirely client-side; no server, no upload.
+ */
+export async function renderPlanCardImage(input: PlanCardInput): Promise<Blob | null> {
+  try {
+    await document.fonts.load("104px Amiri");
+  } catch {
+    /* fall back to whatever is available */
+  }
+
+  const SIZE = 1080;
+  const canvas = document.createElement("canvas");
+  const scale = 2;
+  canvas.width = SIZE * scale;
+  canvas.height = SIZE * scale;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.scale(scale, scale);
+  const cx = SIZE / 2;
+
+  ctx.fillStyle = BG;
+  ctx.fillRect(0, 0, SIZE, SIZE);
+  ctx.fillStyle = ACCENT;
+  ctx.fillRect(0, 0, SIZE, 10);
+  ctx.fillRect(0, SIZE - 10, SIZE, 10);
+
+  // Check badge
+  ctx.strokeStyle = ACCENT;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.lineWidth = 8;
+  ctx.beginPath();
+  ctx.arc(cx, 300, 86, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.lineWidth = 13;
+  ctx.beginPath();
+  ctx.moveTo(cx - 40, 302);
+  ctx.lineTo(cx - 10, 334);
+  ctx.lineTo(cx + 44, 268);
+  ctx.stroke();
+
+  ctx.textAlign = "center";
+  ctx.fillStyle = FG;
+  ctx.font = "700 56px system-ui, sans-serif";
+  ctx.fillText(input.heading, cx, 480);
+
+  ctx.direction = "rtl";
+  ctx.fillStyle = ACCENT;
+  ctx.font = "600 104px Amiri, serif";
+  ctx.fillText(input.arabic, cx, 650);
+  ctx.direction = "ltr";
+
+  ctx.fillStyle = MUTED;
+  ctx.font = "36px system-ui, sans-serif";
+  for (const [i, line] of wrap(ctx, input.subtitle, SIZE - 160).entries()) {
+    ctx.fillText(line, cx, 760 + i * 50);
+  }
+
+  ctx.fillStyle = MUTED;
+  ctx.font = "28px system-ui, sans-serif";
+  ctx.fillText("app.ummahlibrary.org", cx, SIZE - 90);
+
+  return new Promise((resolve) => canvas.toBlob((b) => resolve(b), "image/png"));
+}
+
 /** Share the image via the Web Share API if possible, else download it. */
 export async function shareOrDownload(blob: Blob, reference: string): Promise<void> {
   const file = new File([blob], `ummah-library-${reference.replace(":", "_")}.png`, {

--- a/packages/core/src/reading-plans.test.ts
+++ b/packages/core/src/reading-plans.test.ts
@@ -16,6 +16,7 @@ import {
   extendPlan,
   isDayComplete,
   isPaused,
+  isPlanComplete,
   isValidDateString,
   materializeDay,
   nextDailyReminder,
@@ -607,5 +608,17 @@ describe("pause and resume", () => {
     const resumed = resumePlan(anchored, "2026-01-12");
     expect(resumed.anchor).toEqual({ date: "2026-01-10", units: 2 }); // +7 days
     expect(resumed.pausedOn).toBeUndefined();
+  });
+});
+
+// ── Completion (#63) ─────────────────────────────────────────────────────────
+
+describe("completion", () => {
+  it("is complete only when every unit is read", () => {
+    const p = ramadan(); // 30 juzʾ
+    expect(isPlanComplete(p)).toBe(false);
+    expect(isPlanComplete(setUnitsRead(p, 29))).toBe(false);
+    expect(isPlanComplete(setUnitsRead(p, 30))).toBe(true);
+    expect(percentComplete(setUnitsRead(p, 30))).toBe(100);
   });
 });

--- a/packages/core/src/reading-plans.ts
+++ b/packages/core/src/reading-plans.ts
@@ -419,6 +419,12 @@ export function percentComplete(plan: ActivePlan): number {
   return Math.round((Math.min(plan.unitsRead, total) / total) * 100);
 }
 
+/** Whether every scheduled unit has been read — the plan is finished (#63). */
+export function isPlanComplete(plan: ActivePlan): boolean {
+  const total = planTotal(plan);
+  return total > 0 && plan.unitsRead >= total;
+}
+
 /** Whether everything scheduled through day `day` has been read. */
 export function isDayComplete(plan: ActivePlan, day: number): boolean {
   return plan.unitsRead >= cumulativeUnits(plan, day);


### PR DESCRIPTION
## What

When a reading plan reaches 100%, both `/plans` and `/plans/[id]` show a **completion milestone** in place of the active card:

- **Celebration** — "Alhamdulillah — you finished {plan}", with the scope (e.g. *30 juzʾ over 30 days*).
- **Shareable progress card** — a square *"Quran journey complete"* image (check badge, Amiri-rendered الْحَمْدُ لِلّٰهِ, plan stats, footer), shared via the Web Share API or downloaded.
- **Begin a new journey** — two follow-on plan suggestions linking to their detail pages.

## Reuses the existing renderer

The share card is rendered by **`renderPlanCardImage`** added to `apps/web/src/lib/share-image.ts` — it reuses that module's canvas, fixed palette, `wrap` helper, and `shareOrDownload`, exactly as the issue asked ("reuse the existing ayah-to-image renderer"). Entirely client-side; no server, no upload.

## Files

- `core/reading-plans.ts` — `isPlanComplete` (every scheduled unit read), unit-tested.
- `web/lib/share-image.ts` — `renderPlanCardImage`.
- `web/components/PlanCompletionCard.tsx` — the celebration + share + follow-on UI.
- `web/components/PlansView.tsx`, `PlanDetailView.tsx` — show it once complete.

## Testing — all angles

- **Loop:** `pnpm lint`, `pnpm typecheck`, `pnpm test` (**414**, +1 new), `pnpm build` all pass.
- **Core:** `isPlanComplete` is false at 29/30, true at 30/30 (with 100% percent).
- **Visual (seeded 100% plan):** the completion card renders on `/plans` with the celebration, Share button and two follow-on suggestions; the catalogue marks the plan "Completed".
- **Share image (real canvas):** clicking *Share* generated and downloaded a 1080² PNG — verified visually (check badge, Amiri Arabic, "Ramadan Khatm · 30 juzʾ · 30 days", footer).

## Architecture

No new ADR — a UI milestone over existing helpers; the renderer reuses `share-image.ts`; colours/icons use `packages/ui` tokens only (ADR 0023).

Closes #63.