### PR TITLE
feat(mobile): plan detail screen + completion milestone parity (#64)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -35,6 +35,7 @@ const linking: LinkingOptions<RootTabParamList> = {
           MushafPage: "page/:page",
           Tafsir: "tafsir",
           Plans: "plans",
+          PlanDetail: "plans/:id",
         },
       },
       Tools: {

--- a/apps/mobile/src/components/PlanCompletionCard.tsx
+++ b/apps/mobile/src/components/PlanCompletionCard.tsx
@@ -1,0 +1,122 @@
+import { useMemo } from "react";
+import { Pressable, Share, StyleSheet, Text, View } from "../Type";
+import { Khatam, Icon } from "@ummahlibrary/ui";
+import { useTheme, type Palette } from "../theme";
+import { FONT } from "../fonts";
+import { type ActivePlan, PLAN_TEMPLATES, planDuration, totalUnits, unitWord } from "../plans";
+
+/**
+ * Completion milestone for a finished plan (#63), mirroring the web card: a
+ * celebration, a text share (mobile has no canvas, so the image card is
+ * web-only), and a nudge to begin the next journey.
+ */
+export function PlanCompletionCard({
+  plan,
+  onStart,
+}: {
+  plan: ActivePlan;
+  onStart: (templateId: string) => void;
+}) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+
+  const unit = plan.template.range.unit;
+  const total = totalUnits(plan.template.range);
+  const days = planDuration(plan);
+  const name = plan.template.name;
+  const suggestions = PLAN_TEMPLATES.filter((t) => t.id !== plan.template.id).slice(0, 2);
+
+  function share() {
+    void Share.share({
+      message: `${name} complete — ${total} ${unitWord(unit, total)} over ${days} days. Alhamdulillah. · Ummah Library`,
+    });
+  }
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.crest}>
+        <Khatam size={72} color={colors.accent} sw={1} opacity={0.85} />
+      </View>
+      <Text style={styles.kicker}>Plan complete</Text>
+      <Text style={styles.title}>Alhamdulillah — you finished {name}</Text>
+      <Text style={styles.sub}>
+        {total} {unitWord(unit, total)} over {days} {days === 1 ? "day" : "days"}. May Allah accept it.
+      </Text>
+
+      <Pressable style={styles.shareBtn} onPress={share}>
+        <Icon name="share" size={15} color={colors.ink} sw={1.8} />
+        <Text style={styles.shareText}>Share your achievement</Text>
+      </Pressable>
+
+      {suggestions.length > 0 && (
+        <View style={styles.next}>
+          <Text style={styles.nextLabel}>Begin a new journey</Text>
+          <View style={styles.suggestions}>
+            {suggestions.map((t) => (
+              <Pressable key={t.id} style={styles.suggestion} onPress={() => onStart(t.id)}>
+                <Text style={styles.suggestionName}>{t.name}</Text>
+                <Text style={styles.suggestionMeta}>
+                  {t.tag} · {t.len}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function makeStyles(c: Palette) {
+  return StyleSheet.create({
+    card: {
+      borderRadius: 18,
+      padding: 22,
+      alignItems: "center",
+      borderWidth: 1,
+      borderColor: c.accent,
+      backgroundColor: c.accentSoft,
+    },
+    crest: { marginBottom: 2 },
+    kicker: {
+      color: c.accent,
+      fontSize: 11,
+      letterSpacing: 1.4,
+      textTransform: "uppercase",
+      fontFamily: FONT.extrabold,
+    },
+    title: { color: c.fg, fontSize: 19, fontFamily: FONT.extrabold, textAlign: "center", marginTop: 6, letterSpacing: -0.3 },
+    sub: { color: c.muted, fontSize: 13.5, textAlign: "center", marginTop: 8, lineHeight: 20 },
+    shareBtn: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+      marginTop: 18,
+      paddingVertical: 11,
+      paddingHorizontal: 18,
+      borderRadius: 11,
+      backgroundColor: c.accent,
+    },
+    shareText: { color: c.ink, fontSize: 13.5, fontFamily: FONT.bold },
+    next: { marginTop: 22, alignSelf: "stretch" },
+    nextLabel: {
+      color: c.faint,
+      fontSize: 11,
+      letterSpacing: 1.2,
+      textTransform: "uppercase",
+      fontFamily: FONT.bold,
+      textAlign: "center",
+    },
+    suggestions: { flexDirection: "row", gap: 10, marginTop: 12, justifyContent: "center", flexWrap: "wrap" },
+    suggestion: {
+      paddingVertical: 10,
+      paddingHorizontal: 14,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bgElev,
+    },
+    suggestionName: { color: c.fg, fontSize: 13, fontFamily: FONT.bold },
+    suggestionMeta: { color: c.faint, fontSize: 11, marginTop: 2 },
+  });
+}

--- a/apps/mobile/src/navigation/ReadStack.tsx
+++ b/apps/mobile/src/navigation/ReadStack.tsx
@@ -9,6 +9,7 @@ import { ReadingGoalsScreen } from "../screens/ReadingGoalsScreen";
 import { MushafPageScreen } from "../screens/MushafPageScreen";
 import { TafsirScreen } from "../screens/TafsirScreen";
 import { PlansScreen } from "../screens/PlansScreen";
+import { PlanDetailScreen } from "../screens/PlanDetailScreen";
 import type { ReadStackParamList } from "./types";
 
 const Stack = createNativeStackNavigator<ReadStackParamList>();
@@ -45,6 +46,7 @@ export function ReadStack() {
       />
       <Stack.Screen name="Tafsir" component={TafsirScreen} options={{ title: "Tafsir" }} />
       <Stack.Screen name="Plans" component={PlansScreen} options={{ title: "Reading Plans" }} />
+      <Stack.Screen name="PlanDetail" component={PlanDetailScreen} options={{ title: "Plan", headerBackTitle: "Plans" }} />
     </Stack.Navigator>
   );
 }

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -16,6 +16,7 @@ export type ReadStackParamList = {
   MushafPage: { page: number };
   Tafsir: undefined;
   Plans: undefined;
+  PlanDetail: { id: string };
 };
 
 /** The Hifz tab's stack: memorization dashboard → review session. */

--- a/apps/mobile/src/plans.ts
+++ b/apps/mobile/src/plans.ts
@@ -9,7 +9,9 @@ import {
   activatePlan,
   advanceCursorToPage,
   extendPlan,
+  pausePlan as applyPause,
   rebalance,
+  resumePlan as applyResume,
   templateById,
   toggleDayComplete,
 } from "@ummahlibrary/core";
@@ -23,13 +25,18 @@ export {
   computeTodayPortion,
   currentDay,
   daysAheadBehind,
+  effectiveToday,
   isDayComplete,
+  isPaused,
+  isPlanComplete,
   percentComplete,
   planDuration,
   planEndDate,
   planWeekWindow,
   rangeOfPages,
   todayProgress,
+  totalUnits,
+  unitWord,
   validatePlanDraft,
 } from "@ummahlibrary/core";
 export type {
@@ -87,4 +94,18 @@ export async function advancePlanToPage(page: number): Promise<void> {
   if (!plan) return;
   const next = advanceCursorToPage(plan, page);
   if (next.unitsRead !== plan.unitsRead) await store.write(next);
+}
+
+/** Pause the active plan, freezing its clock (#68). */
+export async function pausePlan(): Promise<void> {
+  const plan = await store.read();
+  if (!plan || plan.pausedOn) return;
+  await store.write(applyPause(plan, todayStr()));
+}
+
+/** Resume a paused plan, shifting its timeline past the break (#68). */
+export async function resumePlan(): Promise<void> {
+  const plan = await store.read();
+  if (!plan?.pausedOn) return;
+  await store.write(applyResume(plan, todayStr()));
 }

--- a/apps/mobile/src/screens/PlanDetailScreen.tsx
+++ b/apps/mobile/src/screens/PlanDetailScreen.tsx
@@ -1,0 +1,374 @@
+import { useCallback, useMemo, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "../Type";
+import Svg, { Circle } from "react-native-svg";
+import { useFocusEffect } from "@react-navigation/native";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { Icon, Khatam } from "@ummahlibrary/ui";
+import { useTheme, type Palette } from "../theme";
+import { FONT } from "../fonts";
+import {
+  type ActivePlan,
+  type DayPortion,
+  clearPlan,
+  computeTodayPortion,
+  currentDay,
+  daysAheadBehind,
+  effectiveToday,
+  extendPlanBy,
+  isDayComplete,
+  isPaused,
+  isPlanComplete,
+  pausePlan,
+  percentComplete,
+  planDuration,
+  planEndDate,
+  readActivePlan,
+  rebalancePlan,
+  resumePlan,
+  startPlan,
+  todayStr,
+} from "../plans";
+import { PlanCompletionCard } from "../components/PlanCompletionCard";
+import type { ReadStackParamList } from "../navigation/types";
+
+type Props = NativeStackScreenProps<ReadStackParamList, "PlanDetail">;
+type Nav = Props["navigation"];
+
+function openTarget(navigation: Nav, portion: DayPortion) {
+  const t = portion.target;
+  if (t.kind === "juz") navigation.navigate("JuzReader", { juz: t.juz });
+  else if (t.kind === "surah") navigation.navigate("SurahReader", { surah: t.surah });
+  else navigation.navigate("SurahReader", { surah: portion.startRef.sura });
+}
+
+export function PlanDetailScreen({ navigation }: Props) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const [plan, setPlan] = useState<ActivePlan | null>(null);
+  const [ready, setReady] = useState(false);
+  const [confirmAbandon, setConfirmAbandon] = useState(false);
+
+  const refresh = useCallback(() => {
+    void readActivePlan().then((p) => {
+      setPlan(p);
+      setReady(true);
+    });
+  }, []);
+  useFocusEffect(refresh);
+
+  const R = 46;
+  const C = 2 * Math.PI * R;
+
+  if (!ready) return <View style={styles.screen} />;
+  if (!plan) {
+    return (
+      <View style={[styles.screen, styles.center]}>
+        <Text style={styles.muted}>No active plan.</Text>
+      </View>
+    );
+  }
+
+  const paused = isPaused(plan);
+  const complete = isPlanComplete(plan);
+  const today = effectiveToday(plan, todayStr());
+  const total = planDuration(plan);
+  const day = currentDay(plan, today);
+  const pct = percentComplete(plan);
+  const behind = daysAheadBehind(plan, today);
+  const portion = computeTodayPortion(plan, today);
+
+  return (
+    <ScrollView contentContainerStyle={styles.screen}>
+      {complete && (
+        <View style={{ marginBottom: 18 }}>
+          <PlanCompletionCard plan={plan} onStart={(id) => void startPlan(id).then(refresh)} />
+        </View>
+      )}
+
+      <View style={styles.header}>
+        <View style={styles.ringWrap}>
+          <Svg width={104} height={104}>
+            <Circle cx={52} cy={52} r={R} stroke={colors.border} strokeWidth={9} fill="none" />
+            <Circle
+              cx={52}
+              cy={52}
+              r={R}
+              stroke={colors.accent}
+              strokeWidth={9}
+              fill="none"
+              strokeDasharray={C}
+              strokeDashoffset={C * (1 - pct / 100)}
+              strokeLinecap="round"
+              transform="rotate(-90 52 52)"
+            />
+          </Svg>
+          <View style={styles.ringCenter}>
+            <Text style={styles.ringPct}>{pct}%</Text>
+            <Text style={styles.ringDay}>
+              Day {day}/{total}
+            </Text>
+          </View>
+        </View>
+        <View style={styles.headMeta}>
+          <View style={styles.nameRow}>
+            <Khatam size={22} color={colors.accent} sw={1} opacity={0.7} />
+            <Text style={styles.name}>{plan.template.name}</Text>
+          </View>
+          <Text style={styles.endText}>
+            {plan.template.tag} · ends {planEndDate(plan)}
+          </Text>
+          {paused && (
+            <View style={styles.pausedPill}>
+              <Text style={styles.pausedPillText}>⏸ Paused</Text>
+            </View>
+          )}
+        </View>
+      </View>
+
+      {paused ? (
+        <View style={styles.pausedCard}>
+          <Text style={styles.pausedNote}>Paused on {plan.pausedOn}. Your place is held — resume any time.</Text>
+          <Pressable style={styles.resumeBtn} onPress={() => void resumePlan().then(refresh)}>
+            <Icon name="play" size={14} color={colors.ink} />
+            <Text style={styles.resumeText}>Resume</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <View style={styles.todayCard}>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.todayKicker}>Today</Text>
+            <Text style={styles.todayLabel}>{portion.label}</Text>
+          </View>
+          <Pressable style={styles.readBtn} onPress={() => openTarget(navigation, portion)}>
+            <Icon name="book" size={14} color={colors.ink} sw={1.8} />
+            <Text style={styles.readText}>Read now</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {!paused && behind < 0 && (
+        <Text style={styles.behindNote}>
+          You’re {Math.abs(behind)} {Math.abs(behind) === 1 ? "day" : "days"} behind — re-pace below to catch up
+          gently.
+        </Text>
+      )}
+
+      <Text style={styles.sectionLabel}>Your days</Text>
+      <View style={styles.heat}>
+        {Array.from({ length: total }, (_, i) => i + 1).map((d) => {
+          const done = isDayComplete(plan, d);
+          const isToday = d === day;
+          const missed = d < day && !done;
+          return (
+            <View
+              key={d}
+              style={[
+                styles.heatCell,
+                done && styles.heatDone,
+                missed && styles.heatMissed,
+                isToday && styles.heatToday,
+              ]}
+            />
+          );
+        })}
+      </View>
+      <View style={styles.legend}>
+        <Legend styles={styles} colors={colors} kind="done" label="Done" />
+        <Legend styles={styles} colors={colors} kind="missed" label="Missed" />
+        <Legend styles={styles} colors={colors} kind="upcoming" label="Upcoming" />
+      </View>
+
+      <Text style={styles.sectionLabel}>Manage</Text>
+      <View style={styles.manage}>
+        <Pressable style={styles.pill} onPress={() => void rebalancePlan().then(refresh)}>
+          <Icon name="repeat" size={13} color={colors.fg} sw={1.8} />
+          <Text style={styles.pillText}>Re-pace</Text>
+        </Pressable>
+        <Pressable style={styles.pill} onPress={() => void extendPlanBy(7).then(refresh)}>
+          <Icon name="plus" size={13} color={colors.fg} sw={2} />
+          <Text style={styles.pillText}>Extend +1wk</Text>
+        </Pressable>
+        {paused ? (
+          <Pressable style={styles.pill} onPress={() => void resumePlan().then(refresh)}>
+            <Icon name="play" size={13} color={colors.fg} />
+            <Text style={styles.pillText}>Resume</Text>
+          </Pressable>
+        ) : (
+          <Pressable style={styles.pill} onPress={() => void pausePlan().then(refresh)}>
+            <Icon name="pause" size={13} color={colors.fg} />
+            <Text style={styles.pillText}>Pause</Text>
+          </Pressable>
+        )}
+        {confirmAbandon ? (
+          <>
+            <Pressable
+              style={[styles.pill, styles.pillDanger]}
+              onPress={() => void clearPlan().then(() => navigation.goBack())}
+            >
+              <Text style={styles.pillText}>Yes, abandon</Text>
+            </Pressable>
+            <Pressable style={styles.pill} onPress={() => setConfirmAbandon(false)}>
+              <Text style={styles.pillText}>Keep</Text>
+            </Pressable>
+          </>
+        ) : (
+          <Pressable style={styles.pill} onPress={() => setConfirmAbandon(true)}>
+            <Icon name="close" size={13} color={colors.muted} sw={1.8} />
+            <Text style={styles.pillTextMuted}>Abandon</Text>
+          </Pressable>
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
+function Legend({
+  styles,
+  colors,
+  kind,
+  label,
+}: {
+  styles: ReturnType<typeof makeStyles>;
+  colors: Palette;
+  kind: "done" | "missed" | "upcoming";
+  label: string;
+}) {
+  return (
+    <View style={styles.legendItem}>
+      <View
+        style={[
+          styles.legendSwatch,
+          kind === "done" && { backgroundColor: colors.accent, borderColor: colors.accent },
+          kind === "missed" && { backgroundColor: colors.bgElev },
+        ]}
+      />
+      <Text style={styles.legendLabel}>{label}</Text>
+    </View>
+  );
+}
+
+function makeStyles(c: Palette) {
+  return StyleSheet.create({
+    screen: { padding: 18, paddingBottom: 40, backgroundColor: c.bg },
+    center: { flex: 1, alignItems: "center", justifyContent: "center" },
+    muted: { color: c.muted, fontSize: 14 },
+
+    header: { flexDirection: "row", alignItems: "center", gap: 16 },
+    ringWrap: { width: 104, height: 104, alignItems: "center", justifyContent: "center" },
+    ringCenter: { position: "absolute", alignItems: "center" },
+    ringPct: { color: c.fg, fontSize: 22, fontFamily: FONT.extrabold },
+    ringDay: { color: c.faint, fontSize: 11, marginTop: 1 },
+    headMeta: { flex: 1, minWidth: 0 },
+    nameRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+    name: { color: c.fg, fontSize: 20, fontFamily: FONT.extrabold, letterSpacing: -0.4, flexShrink: 1 },
+    endText: { color: c.muted, fontSize: 13, marginTop: 5 },
+    pausedPill: {
+      alignSelf: "flex-start",
+      marginTop: 10,
+      paddingVertical: 3,
+      paddingHorizontal: 10,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bgElev,
+    },
+    pausedPillText: { color: c.muted, fontSize: 12, fontFamily: FONT.bold },
+
+    pausedCard: {
+      marginTop: 18,
+      padding: 16,
+      borderRadius: 14,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bgElev,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+    },
+    pausedNote: { color: c.muted, fontSize: 13, flex: 1, lineHeight: 19 },
+    resumeBtn: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      paddingVertical: 9,
+      paddingHorizontal: 14,
+      borderRadius: 10,
+      backgroundColor: c.accent,
+    },
+    resumeText: { color: c.ink, fontSize: 13, fontFamily: FONT.bold },
+
+    todayCard: {
+      marginTop: 18,
+      padding: 16,
+      borderRadius: 14,
+      borderWidth: 1,
+      borderColor: c.accent,
+      backgroundColor: c.accentSoft,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+    },
+    todayKicker: {
+      color: c.accent,
+      fontSize: 11,
+      letterSpacing: 1,
+      textTransform: "uppercase",
+      fontFamily: FONT.bold,
+    },
+    todayLabel: { color: c.fg, fontSize: 15, fontFamily: FONT.semibold, marginTop: 3 },
+    readBtn: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 7,
+      paddingVertical: 10,
+      paddingHorizontal: 15,
+      borderRadius: 10,
+      backgroundColor: c.accent,
+    },
+    readText: { color: c.ink, fontSize: 13, fontFamily: FONT.bold },
+
+    behindNote: { color: c.muted, fontSize: 13, marginTop: 12, lineHeight: 19 },
+
+    sectionLabel: {
+      color: c.faint,
+      fontSize: 12,
+      letterSpacing: 1.2,
+      textTransform: "uppercase",
+      fontFamily: FONT.bold,
+      marginTop: 26,
+      marginBottom: 11,
+    },
+    heat: { flexDirection: "row", flexWrap: "wrap", gap: 6 },
+    heatCell: {
+      width: 24,
+      height: 24,
+      borderRadius: 5,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: "transparent",
+    },
+    heatDone: { backgroundColor: c.accent, borderColor: c.accent },
+    heatMissed: { backgroundColor: c.bgElev },
+    heatToday: { borderColor: c.accent, borderWidth: 2 },
+    legend: { flexDirection: "row", gap: 16, marginTop: 12 },
+    legendItem: { flexDirection: "row", alignItems: "center", gap: 6 },
+    legendSwatch: { width: 11, height: 11, borderRadius: 3, borderWidth: 1, borderColor: c.border },
+    legendLabel: { color: c.faint, fontSize: 11.5 },
+
+    manage: { flexDirection: "row", flexWrap: "wrap", gap: 9 },
+    pill: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 7,
+      paddingVertical: 9,
+      paddingHorizontal: 14,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bgElev,
+    },
+    pillDanger: { backgroundColor: c.bg },
+    pillText: { color: c.fg, fontSize: 13, fontFamily: FONT.semibold },
+    pillTextMuted: { color: c.muted, fontSize: 13, fontFamily: FONT.semibold },
+  });
+}

--- a/apps/mobile/src/screens/PlansScreen.tsx
+++ b/apps/mobile/src/screens/PlansScreen.tsx
@@ -21,6 +21,7 @@ import {
   daysAheadBehind,
   extendPlanBy,
   isDayComplete,
+  isPlanComplete,
   percentComplete,
   planDuration,
   planEndDate,
@@ -28,12 +29,14 @@ import {
   rangeOfPages,
   readActivePlan,
   rebalancePlan,
+  resumePlan,
   startCustomPlan,
   startPlan,
   todayStr,
   toggleDay,
   validatePlanDraft,
 } from "../plans";
+import { PlanCompletionCard } from "../components/PlanCompletionCard";
 import type { ReadStackParamList } from "../navigation/types";
 
 type Props = NativeStackScreenProps<ReadStackParamList, "Plans">;
@@ -65,12 +68,16 @@ export function PlansScreen({ navigation }: Props) {
   useFocusEffect(refresh);
 
   const today = todayStr();
+  // Frozen at the pause day while paused (#68), so a break never reads as behind.
+  const viewToday = plan?.pausedOn ?? today;
+  const paused = !!plan?.pausedOn;
+  const complete = plan ? isPlanComplete(plan) : false;
   const totalDays = plan ? planDuration(plan) : 0;
-  const day = plan ? currentDay(plan, today) : 0;
-  const portion = plan ? computeTodayPortion(plan, today) : undefined;
+  const day = plan ? currentDay(plan, viewToday) : 0;
+  const portion = plan ? computeTodayPortion(plan, viewToday) : undefined;
   const pct = plan ? percentComplete(plan) : 0;
-  const behind = plan ? daysAheadBehind(plan, today) : 0;
-  const catchUp = plan ? catchUpPortion(plan, today) : undefined;
+  const behind = plan ? daysAheadBehind(plan, viewToday) : 0;
+  const catchUp = plan ? catchUpPortion(plan, viewToday) : undefined;
 
   // Custom plan draft — whole Quran by pages, by pace or by days-to-finish.
   const customRange = rangeOfPages(1, 604);
@@ -115,7 +122,9 @@ export function PlansScreen({ navigation }: Props) {
       <Text style={styles.h1}>Reading plans</Text>
       <Text style={styles.subtitle}>Structured journeys through the Book</Text>
 
-      {ready && plan && portion ? (
+      {ready && plan && complete ? (
+        <PlanCompletionCard plan={plan} onStart={(id) => void startPlan(id).then(refresh)} />
+      ) : ready && plan && portion ? (
         <>
           <View style={styles.activeCard}>
             <View style={styles.watermark} pointerEvents="none">
@@ -142,7 +151,7 @@ export function PlansScreen({ navigation }: Props) {
               </View>
               <View style={styles.activeMeta}>
                 <Text style={styles.activeKicker}>
-                  Active · Day {day} of {totalDays}
+                  {paused ? "⏸ Paused" : "Active"} · Day {day} of {totalDays}
                 </Text>
                 <Text style={styles.activeName}>{plan.template.name}</Text>
                 <Text style={styles.activeToday}>
@@ -167,6 +176,17 @@ export function PlansScreen({ navigation }: Props) {
             </Pressable>
             <Pressable style={styles.pill} onPress={() => void clearPlan().then(refresh)}>
               <Text style={styles.pillText}>Leave plan</Text>
+            </Pressable>
+            {paused && (
+              <Pressable style={[styles.pill, styles.pillOn]} onPress={() => void resumePlan().then(refresh)}>
+                <Text style={styles.pillTextOn}>▶ Resume</Text>
+              </Pressable>
+            )}
+            <Pressable
+              style={styles.pill}
+              onPress={() => navigation.navigate("PlanDetail", { id: plan.template.id })}
+            >
+              <Text style={styles.pillText}>Details</Text>
             </Pressable>
           </View>
 

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -353,7 +353,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         </View>
       </ScrollView>
 
-      {activePlan && (
+      {activePlan && !activePlan.pausedOn && (
         <View style={styles.chipWrap} pointerEvents="none">
           <PlanChip plan={activePlan} styles={styles} colors={colors} />
         </View>


### PR DESCRIPTION
## What

Mobile parity for the two reading-plan features just shipped on web — the **detail page (#68)** and the **completion milestone (#63)** — built over the already-shared `core` engine.

- **`PlanDetailScreen`** (ReadStack `PlanDetail`, deep link `plans/:id`): progress ring, full **done / missed / upcoming heatmap**, today's portion + "Read now", and manage actions — re-pace, extend +1wk, **pause/resume**, abandon (two-step confirm).
- **`PlanCompletionCard`**: shown once a plan is complete (on the plans screen, and atop the detail), with a celebration, a **text share** via RN's `Share` API, and two follow-on plan suggestions. (Mobile has no canvas, so the *image* share card stays web-only — needs `react-native-view-shot`, a future native add.)
- **`PlansScreen`**: a **Details** link into the new screen, a **Paused** state with a frozen clock (no false "behind") + Resume, and the completion card in place of the active card.
- The reader's plan chip hides while paused.

Pause/resume glue wraps the core `pausePlan`/`resumePlan` over the `PlanStore` — no new logic; the schedule maths and `isPlanComplete` were already merged with #68/#63.

## Testing

- **Loop:** `pnpm lint`, `pnpm typecheck` (incl. mobile), `pnpm test` (414), `pnpm build` all pass.
- **Visual — Expo Web (mobile viewport):** verified all states — **active** (ring 10% Day 7/30, today + Read now, "3 days behind" note, full heatmap, Manage row), **paused** ("⏸ Paused", "your place is held" + Resume, no false behind, Manage swaps Pause→Resume), and **complete** ("Alhamdulillah — you finished Ramadan Khatm", Share, "Begin a new journey" with two suggestions).

## Notes

No new ADR — pure UI parity over shared `core`; design uses `packages/ui` primitives + `useNoorTheme` (ADR 0023). The mobile **daily reminder** (#71) remains separate — it needs the native notification stack.

Part of #64.