### PR TITLE
feat(core): ReadingGoalsStore port + migrate goals/streaks (#73)

### DIFF
--- a/apps/mobile/src/reading-goals-store.ts
+++ b/apps/mobile/src/reading-goals-store.ts
@@ -1,0 +1,26 @@
+/**
+ * Mobile `ReadingGoalsStore` adapter (ADR 0024): the reader's habit state in
+ * AsyncStorage under the existing `ul.reading*` / `ul.khatma` keys. Persistence
+ * only — the habit maths live in `@ummahlibrary/core` and the glue — so a synced
+ * adapter (#25) can replace it without touching the feature. Mirrors web.
+ */
+import type { KhatmaPlan, ReadingGoalsState, ReadingGoalsStore } from "@ummahlibrary/core";
+import { KEYS, getJSON, setJSON } from "./storage";
+
+export const mobileReadingGoalsStore: ReadingGoalsStore = {
+  read: async (): Promise<ReadingGoalsState> => {
+    const [goalObj, active, log, pages, khatma] = await Promise.all([
+      getJSON<{ target: number } | null>(KEYS.readingGoal, null),
+      getJSON<string[]>(KEYS.readingActive, []),
+      getJSON<Record<string, number>>(KEYS.readingLog, {}),
+      getJSON<{ date: string; pages: number[] }>(KEYS.readingPages, { date: "", pages: [] }),
+      getJSON<KhatmaPlan | null>(KEYS.khatma, null),
+    ]);
+    return { goal: goalObj?.target ?? null, activeDates: active, log, pages, khatma };
+  },
+  writeGoal: (target) => setJSON(KEYS.readingGoal, { target }),
+  writeActiveDates: (dates) => setJSON(KEYS.readingActive, dates),
+  writeLog: (log) => setJSON(KEYS.readingLog, log),
+  writePages: (pages) => setJSON(KEYS.readingPages, pages),
+  writeKhatma: (khatma) => setJSON(KEYS.khatma, khatma),
+};

--- a/apps/mobile/src/reading-goals.ts
+++ b/apps/mobile/src/reading-goals.ts
@@ -1,12 +1,13 @@
 /**
  * Local-first reading-habit state (ADR 0006): a daily page goal, an activity log
  * (drives the streak), today's distinct Mushaf pages (drives the daily goal),
- * a per-day page count, and an optional khatma plan. Mirrors the web reader's
- * `ul.reading*` / `ul.khatma` keys; the maths lives in `@ummahlibrary/core`.
+ * a per-day page count, and an optional khatma plan. Persistence goes through the
+ * `ReadingGoalsStore` port (mobile adapter `mobileReadingGoalsStore`, ADR 0024);
+ * the maths lives in `@ummahlibrary/core`.
  */
 import type { KhatmaPlan } from "@ummahlibrary/core";
 import { advancePlanToPage } from "./plans";
-import { KEYS, getJSON, setJSON } from "./storage";
+import { mobileReadingGoalsStore as store } from "./reading-goals-store";
 import { localISODate } from "./utils";
 
 export const DEFAULT_GOAL = 4;
@@ -22,53 +23,47 @@ export interface ReadingState {
 }
 
 export async function readReadingState(): Promise<ReadingState> {
-  const [goalObj, log, active, khatma] = await Promise.all([
-    getJSON<{ target: number }>(KEYS.readingGoal, { target: DEFAULT_GOAL }),
-    getJSON<Record<string, number>>(KEYS.readingLog, {}),
-    getJSON<string[]>(KEYS.readingActive, []),
-    getJSON<KhatmaPlan | null>(KEYS.khatma, null),
-  ]);
-  return { goal: goalObj.target, log, active, khatma, pagesToday: log[todayStr()] ?? 0 };
+  const s = await store.read();
+  return {
+    goal: s.goal ?? DEFAULT_GOAL,
+    log: s.log,
+    active: s.activeDates,
+    khatma: s.khatma,
+    pagesToday: s.log[todayStr()] ?? 0,
+  };
 }
 
 export async function writeGoal(target: number): Promise<void> {
-  await setJSON(KEYS.readingGoal, { target: Math.max(1, Math.floor(target) || DEFAULT_GOAL) });
+  await store.writeGoal(Math.max(1, Math.floor(target) || DEFAULT_GOAL));
 }
 
 export async function writeKhatma(plan: KhatmaPlan): Promise<void> {
-  await setJSON(KEYS.khatma, plan);
+  await store.writeKhatma(plan);
 }
 
 export async function clearKhatma(): Promise<void> {
-  await setJSON(KEYS.khatma, null);
+  await store.writeKhatma(null);
 }
 
 /**
  * Record a Mushaf page as read today (de-duplicated): bumps the daily page
- * count, keeps the streak alive, and advances the khatma cursor.
+ * count, keeps the streak alive, advances the khatma cursor, and advances any
+ * active reading plan (#69).
  */
 export async function recordMushafPage(page: number): Promise<void> {
   const t = todayStr();
+  const s = await store.read();
 
-  const active = await getJSON<string[]>(KEYS.readingActive, []);
-  if (!active.includes(t)) await setJSON(KEYS.readingActive, [...active, t].slice(-400));
+  if (!s.activeDates.includes(t)) await store.writeActiveDates([...s.activeDates, t].slice(-400));
 
-  const seen = await getJSON<{ date: string; pages: number[] }>(KEYS.readingPages, {
-    date: t,
-    pages: [],
-  });
-  const pages = seen.date === t ? seen.pages : [];
+  const pages = s.pages.date === t ? s.pages.pages : [];
   if (!pages.includes(page)) {
     pages.push(page);
-    await setJSON(KEYS.readingPages, { date: t, pages });
-    const log = await getJSON<Record<string, number>>(KEYS.readingLog, {});
-    log[t] = pages.length;
-    await setJSON(KEYS.readingLog, log);
+    await store.writePages({ date: t, pages });
+    await store.writeLog({ ...s.log, [t]: pages.length });
   }
 
-  const plan = await getJSON<KhatmaPlan | null>(KEYS.khatma, null);
-  if (plan && page > plan.currentPage) await setJSON(KEYS.khatma, { ...plan, currentPage: page });
+  if (s.khatma && page > s.khatma.currentPage) await store.writeKhatma({ ...s.khatma, currentPage: page });
 
-  // Advance any active reading plan to the page just reached (#69).
   await advancePlanToPage(page);
 }

--- a/apps/web/src/components/HomeHeroCards.tsx
+++ b/apps/web/src/components/HomeHeroCards.tsx
@@ -12,7 +12,7 @@ import {
 } from "@ummahlibrary/core";
 import { Khatam, N } from "@ummahlibrary/ui";
 import { HomePrayerCard } from "./HomePrayerCard";
-import { activeDates, pagesToday, readGoal, today } from "../lib/reading-goals";
+import { readReadingState, today } from "../lib/reading-goals";
 
 const COORDS_KEY = "ul.prayerCoords";
 const METHOD_KEY = "ul.prayerMethod";
@@ -55,11 +55,9 @@ export function HomeHeroCards() {
 
   useEffect(() => {
     setReady(true);
-    setReading({
-      pages: pagesToday(),
-      goal: readGoal(),
-      streak: computeStreak(activeDates(), today()),
-    });
+    void readReadingState().then((s) =>
+      setReading({ pages: s.pagesToday, goal: s.goal, streak: computeStreak(s.activeDates, today()) }),
+    );
     const saved = read<Coordinates | null>(COORDS_KEY, null);
     if (saved) {
       const method = localStorage.getItem(METHOD_KEY) ?? DEFAULT_CALCULATION_METHOD;

--- a/apps/web/src/components/ProfileView.tsx
+++ b/apps/web/src/components/ProfileView.tsx
@@ -6,7 +6,7 @@ import { N, Khatam } from "@ummahlibrary/ui";
 import { allRecords, surahProgressMap } from "../lib/hifz-store";
 import { getStreak } from "../lib/hifz-streak";
 import { readPrayerLog, today } from "../lib/prayer-tracker";
-import { activeDates } from "../lib/reading-goals";
+import { readReadingState } from "../lib/reading-goals";
 import { readCollections } from "../lib/collections";
 
 interface Stats {
@@ -51,16 +51,17 @@ export function ProfileView() {
     const log = readPrayerLog();
     const hifzStreak = getStreak().count;
     const prayer = prayerStreak(log, t);
-    const stats: Stats = {
-      hifzStreak,
-      memorized: allRecords().length,
-      surahsStarted: surahProgressMap(new Date()).size,
-      prayerStreak: prayer,
-      names: namesLearned(),
-      saved: totalSavedAyahs(readCollections()),
-      bestStreak: Math.max(hifzStreak, prayer, longestStreak(log), computeStreak(activeDates(), t)),
-    };
-    setS(stats);
+    void readReadingState().then((reading) =>
+      setS({
+        hifzStreak,
+        memorized: allRecords().length,
+        surahsStarted: surahProgressMap(new Date()).size,
+        prayerStreak: prayer,
+        names: namesLearned(),
+        saved: totalSavedAyahs(readCollections()),
+        bestStreak: Math.max(hifzStreak, prayer, longestStreak(log), computeStreak(reading.activeDates, t)),
+      }),
+    );
   }, []);
 
   const statCards: [string, string][] = [

--- a/apps/web/src/components/RamadanView.tsx
+++ b/apps/web/src/components/RamadanView.tsx
@@ -12,7 +12,7 @@ import {
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
 import type { IconName } from "@ummahlibrary/ui";
 import { RAMADAN_EVENT, readFasts, readWorship, toggleFast, toggleWorship } from "../lib/ramadan";
-import { readingLog } from "../lib/reading-goals";
+import { readReadingState } from "../lib/reading-goals";
 
 const WORSHIP: { key: string; label: string; icon: IconName }[] = [
   { key: "suhur", label: "Suhūr", icon: "sun" },
@@ -78,7 +78,7 @@ export function RamadanView() {
     const sync = () => {
       setFasts(readFasts());
       setWorship(readWorship(today));
-      setPagesRead(Object.values(readingLog()).reduce((a, b) => a + b, 0));
+      void readReadingState().then((s) => setPagesRead(Object.values(s.log).reduce((a, b) => a + b, 0)));
     };
     sync();
     window.addEventListener(RAMADAN_EVENT, sync);

--- a/apps/web/src/components/ReadingGoalBadge.tsx
+++ b/apps/web/src/components/ReadingGoalBadge.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { computeStreak, goalMet } from "@ummahlibrary/core";
-import { READING_EVENT, activeDates, pagesToday, readGoal, today } from "../lib/reading-goals";
+import { READING_EVENT, readReadingState, today } from "../lib/reading-goals";
 
 /** Home badge: today's streak and progress toward the daily reading goal. */
 export function ReadingGoalBadge() {
@@ -11,11 +11,9 @@ export function ReadingGoalBadge() {
 
   useEffect(() => {
     const update = () =>
-      setState({
-        streak: computeStreak(activeDates(), today()),
-        pages: pagesToday(),
-        goal: readGoal(),
-      });
+      void readReadingState().then((s) =>
+        setState({ streak: computeStreak(s.activeDates, today()), pages: s.pagesToday, goal: s.goal }),
+      );
     update();
     window.addEventListener(READING_EVENT, update);
     return () => window.removeEventListener(READING_EVENT, update);

--- a/apps/web/src/components/ReadingGoalsView.test.tsx
+++ b/apps/web/src/components/ReadingGoalsView.test.tsx
@@ -1,26 +1,30 @@
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { today } from "../lib/reading-goals";
 import { ReadingGoalsView } from "./ReadingGoalsView";
 
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
 describe("ReadingGoalsView", () => {
-  it("reflects the stored goal and today's pages", () => {
+  it("reflects the stored goal and today's pages", async () => {
     localStorage.setItem("ul.readingGoal", JSON.stringify({ target: 8 }));
     localStorage.setItem("ul.readingLog", JSON.stringify({ [today()]: 3 }));
 
     render(<ReadingGoalsView />);
 
-    expect(screen.getByText("of 8 pages today")).toBeInTheDocument();
-    expect(screen.getByText(/5 pages to reach today/)).toBeInTheDocument();
+    expect(await screen.findByText("of 8 pages today")).toBeInTheDocument();
+    expect(await screen.findByText(/5 pages to reach today/)).toBeInTheDocument();
   });
 
   it("changes the daily goal when a pill is clicked, and persists it", async () => {
     render(<ReadingGoalsView />);
+    await userEvent.click(await screen.findByRole("button", { name: "16 pages" }));
 
-    await userEvent.click(screen.getByRole("button", { name: "16 pages" }));
-
-    expect(screen.getByText("of 16 pages today")).toBeInTheDocument();
-    expect(JSON.parse(localStorage.getItem("ul.readingGoal") ?? "{}").target).toBe(16);
+    expect(await screen.findByText("of 16 pages today")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem("ul.readingGoal") ?? "{}").target).toBe(16),
+    );
   });
 });

--- a/apps/web/src/components/ReadingGoalsView.tsx
+++ b/apps/web/src/components/ReadingGoalsView.tsx
@@ -14,12 +14,8 @@ import {
 } from "@ummahlibrary/core";
 import {
   READING_EVENT,
-  activeDates,
   clearKhatma,
-  pagesToday,
-  readGoal,
-  readingLog,
-  readKhatma,
+  readReadingState,
   today,
   writeGoal,
   writeKhatma,
@@ -74,13 +70,14 @@ export function ReadingGoalsView() {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    const refresh = () => {
-      setGoal(readGoal());
-      setStreak(computeStreak(activeDates(), today()));
-      setPages(pagesToday());
-      setWeek(lastSevenDays(readingLog()));
-      setKhatma(readKhatma());
-    };
+    const refresh = () =>
+      void readReadingState().then((s) => {
+        setGoal(s.goal);
+        setStreak(computeStreak(s.activeDates, today()));
+        setPages(s.pagesToday);
+        setWeek(lastSevenDays(s.log));
+        setKhatma(s.khatma);
+      });
     refresh();
     setReady(true);
     window.addEventListener(READING_EVENT, refresh);
@@ -89,7 +86,7 @@ export function ReadingGoalsView() {
 
   function changeGoal(next: number) {
     setGoal(next);
-    writeGoal(next);
+    void writeGoal(next);
   }
 
   function startKhatma(days: number) {
@@ -99,7 +96,7 @@ export function ReadingGoalsView() {
       targetDate: addDays(today(), days),
     };
     setKhatma(plan);
-    writeKhatma(plan);
+    void writeKhatma(plan);
   }
 
   function adjustKhatma(deltaPages: number) {
@@ -107,7 +104,7 @@ export function ReadingGoalsView() {
     const currentPage = Math.min(khatma.totalPages, Math.max(0, khatma.currentPage + deltaPages));
     const plan = { ...khatma, currentPage };
     setKhatma(plan);
-    writeKhatma(plan);
+    void writeKhatma(plan);
   }
 
   if (!ready) return null;
@@ -335,7 +332,7 @@ export function ReadingGoalsView() {
             <button onClick={() => adjustKhatma(-1)} style={pill(false)}>
               −1
             </button>
-            <button onClick={clearKhatma} style={pill(false)}>
+            <button onClick={() => void clearKhatma()} style={pill(false)}>
               Clear
             </button>
           </>

--- a/apps/web/src/components/ReadingTracker.tsx
+++ b/apps/web/src/components/ReadingTracker.tsx
@@ -10,8 +10,8 @@ import { markActivity, recordMushafPage } from "../lib/reading-goals";
  */
 export function ReadingTracker({ page }: { page?: number }) {
   useEffect(() => {
-    if (typeof page === "number") recordMushafPage(page);
-    else markActivity();
+    if (typeof page === "number") void recordMushafPage(page);
+    else void markActivity();
   }, [page]);
   return null;
 }

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -159,7 +159,7 @@ export function SurahReaderClient({
     });
     if (current > 0 && current !== lastPageRef.current) {
       lastPageRef.current = current;
-      recordMushafPage(current);
+      void recordMushafPage(current);
     }
   }, []);
 
@@ -167,7 +167,7 @@ export function SurahReaderClient({
   useEffect(() => {
     const first = pageNumberOf({ sura: surah.number, aya: ayahs[0]?.aya ?? 1 });
     lastPageRef.current = first;
-    recordMushafPage(first);
+    void recordMushafPage(first);
   }, [surah.number, ayahs]);
 
   const segValue = MODE_TO_SEG[mode] ?? "verse";

--- a/apps/web/src/lib/reading-goals-store.test.ts
+++ b/apps/web/src/lib/reading-goals-store.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { webReadingGoalsStore as store } from "./reading-goals-store";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("webReadingGoalsStore", () => {
+  it("reads sensible defaults when nothing is stored", async () => {
+    expect(await store.read()).toEqual({
+      goal: null,
+      activeDates: [],
+      log: {},
+      pages: { date: "", pages: [] },
+      khatma: null,
+    });
+  });
+
+  it("round-trips each piece under the existing keys", async () => {
+    await store.writeGoal(7);
+    await store.writeActiveDates(["2026-01-01"]);
+    await store.writeLog({ "2026-01-01": 5 });
+    await store.writePages({ date: "2026-01-01", pages: [1, 2] });
+    await store.writeKhatma({ totalPages: 604, currentPage: 12, targetDate: "2030-01-01" });
+
+    const s = await store.read();
+    expect(s.goal).toBe(7);
+    expect(s.activeDates).toEqual(["2026-01-01"]);
+    expect(s.log).toEqual({ "2026-01-01": 5 });
+    expect(s.pages).toEqual({ date: "2026-01-01", pages: [1, 2] });
+    expect(s.khatma?.currentPage).toBe(12);
+    // the adapter must keep the same localStorage key the backup reads
+    expect(JSON.parse(localStorage.getItem("ul.readingGoal") ?? "{}").target).toBe(7);
+  });
+
+  it("removes the khatma when written null", async () => {
+    await store.writeKhatma({ totalPages: 604, currentPage: 1, targetDate: "2030-01-01" });
+    await store.writeKhatma(null);
+    expect((await store.read()).khatma).toBeNull();
+    expect(localStorage.getItem("ul.khatma")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/reading-goals-store.ts
+++ b/apps/web/src/lib/reading-goals-store.ts
@@ -1,0 +1,52 @@
+/**
+ * Web `ReadingGoalsStore` adapter (ADR 0024): the reader's habit state in
+ * `localStorage` under the existing `ul.reading*` / `ul.khatma` keys. Persistence
+ * only — the habit maths live in `@ummahlibrary/core` and the glue — so a synced
+ * adapter (#25) can replace it without touching the feature. Mirrors mobile.
+ */
+import type { KhatmaPlan, ReadingGoalsState, ReadingGoalsStore } from "@ummahlibrary/core";
+
+const GOAL_KEY = "ul.readingGoal";
+const ACTIVE_KEY = "ul.readingActive";
+const PAGES_KEY = "ul.readingPages";
+const LOG_KEY = "ul.readingLog";
+const KHATMA_KEY = "ul.khatma";
+
+function get<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+function set(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+export const webReadingGoalsStore: ReadingGoalsStore = {
+  read: async (): Promise<ReadingGoalsState> => ({
+    goal: get<{ target: number } | null>(GOAL_KEY, null)?.target ?? null,
+    activeDates: get<string[]>(ACTIVE_KEY, []),
+    log: get<Record<string, number>>(LOG_KEY, {}),
+    pages: get<{ date: string; pages: number[] }>(PAGES_KEY, { date: "", pages: [] }),
+    khatma: get<KhatmaPlan | null>(KHATMA_KEY, null),
+  }),
+  writeGoal: async (target) => set(GOAL_KEY, { target }),
+  writeActiveDates: async (dates) => set(ACTIVE_KEY, dates),
+  writeLog: async (log) => set(LOG_KEY, log),
+  writePages: async (pages) => set(PAGES_KEY, pages),
+  writeKhatma: async (khatma) => {
+    if (khatma) set(KHATMA_KEY, khatma);
+    else
+      try {
+        localStorage.removeItem(KHATMA_KEY);
+      } catch {
+        /* ignore */
+      }
+  },
+};

--- a/apps/web/src/lib/reading-goals.test.ts
+++ b/apps/web/src/lib/reading-goals.test.ts
@@ -1,54 +1,54 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_GOAL,
-  activeDates,
   clearKhatma,
   markActivity,
-  pagesToday,
-  readGoal,
-  readKhatma,
-  readingLog,
+  readReadingState,
   recordMushafPage,
   today,
   writeGoal,
   writeKhatma,
 } from "./reading-goals";
 
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
 describe("reading-goals storage", () => {
   it("formats today as local YYYY-MM-DD", () => {
     expect(today(new Date(2026, 0, 9))).toBe("2026-01-09");
   });
 
-  it("goal defaults to DEFAULT_GOAL and floors to >= 1", () => {
-    expect(readGoal()).toBe(DEFAULT_GOAL);
-    writeGoal(8);
-    expect(readGoal()).toBe(8);
-    writeGoal(0);
-    expect(readGoal()).toBe(DEFAULT_GOAL);
+  it("goal defaults to DEFAULT_GOAL and floors to >= 1", async () => {
+    expect((await readReadingState()).goal).toBe(DEFAULT_GOAL);
+    await writeGoal(8);
+    expect((await readReadingState()).goal).toBe(8);
+    await writeGoal(0);
+    expect((await readReadingState()).goal).toBe(DEFAULT_GOAL);
   });
 
-  it("records today's activity exactly once", () => {
-    markActivity();
-    markActivity();
-    expect(activeDates()).toEqual([today()]);
+  it("records today's activity exactly once", async () => {
+    await markActivity();
+    await markActivity();
+    expect((await readReadingState()).activeDates).toEqual([today()]);
   });
 
-  it("logs distinct Mushaf pages read today and marks activity", () => {
-    recordMushafPage(3);
-    recordMushafPage(3); // duplicate — ignored
-    recordMushafPage(4);
+  it("logs distinct Mushaf pages read today and marks activity", async () => {
+    await recordMushafPage(3);
+    await recordMushafPage(3); // duplicate — ignored
+    await recordMushafPage(4);
 
-    expect(pagesToday()).toBe(2);
-    expect(readingLog()[today()]).toBe(2);
-    expect(activeDates()).toContain(today());
+    const s = await readReadingState();
+    expect(s.pagesToday).toBe(2);
+    expect(s.log[today()]).toBe(2);
+    expect(s.activeDates).toContain(today());
   });
 
-  it("advances the khatma cursor as later pages are read, and clears", () => {
-    writeKhatma({ totalPages: 604, currentPage: 0, targetDate: "2030-01-01" });
-    recordMushafPage(10);
-    expect(readKhatma()?.currentPage).toBe(10);
+  it("advances the khatma cursor as later pages are read, and clears", async () => {
+    await writeKhatma({ totalPages: 604, currentPage: 0, targetDate: "2030-01-01" });
+    await recordMushafPage(10);
+    expect((await readReadingState()).khatma?.currentPage).toBe(10);
 
-    clearKhatma();
-    expect(readKhatma()).toBeNull();
+    await clearKhatma();
+    expect((await readReadingState()).khatma).toBeNull();
   });
 });

--- a/apps/web/src/lib/reading-goals.ts
+++ b/apps/web/src/lib/reading-goals.ts
@@ -1,20 +1,17 @@
 /**
  * Local-first reading habit state (ADR 0006): a daily goal, an activity log
  * (which days you read — drives the streak), per-day Mushaf pages read (drives
- * the daily goal), and an optional khatma plan. All in `localStorage`; the
- * computation lives in `@ummahlibrary/core`. A window event lets the home badge
- * and the goals page re-render together.
+ * the daily goal), and an optional khatma plan. Persistence goes through the
+ * `ReadingGoalsStore` port (web adapter `webReadingGoalsStore`, ADR 0024); this
+ * layer adds the habit logic and a window event so the home badge and the goals
+ * page re-render together.
  */
 
 import type { KhatmaPlan } from "@ummahlibrary/core";
 import { advancePlanToPage } from "./reading-plan";
+import { webReadingGoalsStore as store } from "./reading-goals-store";
 
 export const READING_EVENT = "ul.reading";
-const GOAL_KEY = "ul.readingGoal"; // { target: number } pages/day
-const ACTIVE_KEY = "ul.readingActive"; // string[] of YYYY-MM-DD with any reading
-const PAGES_KEY = "ul.readingPages"; // { date: "YYYY-MM-DD", pages: number[] } today's distinct mushaf pages
-const LOG_KEY = "ul.readingLog"; // { "YYYY-MM-DD": number } pages read that day
-const KHATMA_KEY = "ul.khatma"; // KhatmaPlan | (absent)
 
 export const DEFAULT_GOAL = 4;
 
@@ -23,21 +20,6 @@ export function today(d = new Date()): string {
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
 
-function get<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-function set(key: string, value: unknown): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    /* storage unavailable */
-  }
-}
 function emit(): void {
   try {
     window.dispatchEvent(new CustomEvent(READING_EVENT));
@@ -46,70 +28,67 @@ function emit(): void {
   }
 }
 
-export function readGoal(): number {
-  return get<{ target: number }>(GOAL_KEY, { target: DEFAULT_GOAL }).target;
+/** The reader's resolved habit state for the badge, goals page and profile. */
+export interface ReadingState {
+  goal: number;
+  activeDates: string[];
+  log: Record<string, number>;
+  pagesToday: number;
+  khatma: KhatmaPlan | null;
 }
-export function writeGoal(target: number): void {
-  set(GOAL_KEY, { target: Math.max(1, Math.floor(target) || DEFAULT_GOAL) });
+
+export async function readReadingState(): Promise<ReadingState> {
+  const s = await store.read();
+  return {
+    goal: s.goal ?? DEFAULT_GOAL,
+    activeDates: s.activeDates,
+    log: s.log,
+    pagesToday: s.log[today()] ?? 0,
+    khatma: s.khatma,
+  };
+}
+
+export async function writeGoal(target: number): Promise<void> {
+  await store.writeGoal(Math.max(1, Math.floor(target) || DEFAULT_GOAL));
   emit();
 }
 
-/** Dates (YYYY-MM-DD) with any reading activity — pruned to the last ~400. */
-export function activeDates(): string[] {
-  return get<string[]>(ACTIVE_KEY, []);
-}
-export function readingLog(): Record<string, number> {
-  return get<Record<string, number>>(LOG_KEY, {});
-}
-export function pagesToday(): number {
-  return readingLog()[today()] ?? 0;
-}
-
 /** Record that the reader was opened today (keeps the streak alive). */
-export function markActivity(): void {
+export async function markActivity(): Promise<void> {
   const t = today();
-  const dates = activeDates();
-  if (!dates.includes(t)) {
-    dates.push(t);
-    set(ACTIVE_KEY, dates.slice(-400));
+  const s = await store.read();
+  if (!s.activeDates.includes(t)) {
+    await store.writeActiveDates([...s.activeDates, t].slice(-400));
     emit();
   }
 }
 
 /**
  * Record a Mushaf page as read today (de-duplicated), updating the daily page
- * count and advancing the khatma cursor. Also marks activity.
+ * count and advancing the khatma cursor. Also marks activity and advances the
+ * active reading plan (#69).
  */
-export function recordMushafPage(page: number): void {
-  markActivity();
+export async function recordMushafPage(page: number): Promise<void> {
   const t = today();
-  const seen = get<{ date: string; pages: number[] }>(PAGES_KEY, { date: t, pages: [] });
-  const pages = seen.date === t ? seen.pages : [];
+  const s = await store.read();
+  if (!s.activeDates.includes(t)) await store.writeActiveDates([...s.activeDates, t].slice(-400));
+
+  const pages = s.pages.date === t ? s.pages.pages : [];
   if (!pages.includes(page)) {
     pages.push(page);
-    set(PAGES_KEY, { date: t, pages });
-    const log = readingLog();
-    log[t] = pages.length;
-    set(LOG_KEY, log);
+    await store.writePages({ date: t, pages });
+    await store.writeLog({ ...s.log, [t]: pages.length });
   }
-  const plan = readKhatma();
-  if (plan && page > plan.currentPage) writeKhatma({ ...plan, currentPage: page });
-  void advancePlanToPage(page); // advance the active reading plan too (#69)
+  if (s.khatma && page > s.khatma.currentPage) await store.writeKhatma({ ...s.khatma, currentPage: page });
+  void advancePlanToPage(page);
   emit();
 }
 
-export function readKhatma(): KhatmaPlan | null {
-  return get<KhatmaPlan | null>(KHATMA_KEY, null);
-}
-export function writeKhatma(plan: KhatmaPlan): void {
-  set(KHATMA_KEY, plan);
+export async function writeKhatma(plan: KhatmaPlan): Promise<void> {
+  await store.writeKhatma(plan);
   emit();
 }
-export function clearKhatma(): void {
-  try {
-    localStorage.removeItem(KHATMA_KEY);
-  } catch {
-    /* ignore */
-  }
+export async function clearKhatma(): Promise<void> {
+  await store.writeKhatma(null);
   emit();
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -19,6 +19,7 @@ import type {
 import type { HifzCard } from "./hifz";
 import type { Coordinates, Madhab, PrayerTimings } from "./prayer";
 import type { ActivePlan, PlanTemplate } from "./reading-plans";
+import type { KhatmaPlan } from "./reading-goals";
 
 /** Access to the Arabic Quran text and surah structure. */
 export interface QuranRepository {
@@ -180,4 +181,36 @@ export interface PlanStore {
   write(plan: ActivePlan): Promise<void>;
   /** Stop the active plan. */
   clear(): Promise<void>;
+}
+
+/** The reader's habit state as persisted — one field per stored key (ADR 0024). */
+export interface ReadingGoalsState {
+  /** Daily page goal, or `null` if the reader hasn't set one. */
+  goal: number | null;
+  /** Dates (`YYYY-MM-DD`) with any reading activity — drives the streak. */
+  activeDates: string[];
+  /** Pages read per day, `{ "YYYY-MM-DD": count }`. */
+  log: Record<string, number>;
+  /** Today's distinct Mushaf pages (the `date` guards a day rollover). */
+  pages: { date: string; pages: number[] };
+  /** The optional khatma plan. */
+  khatma: KhatmaPlan | null;
+}
+
+/**
+ * Persists the reader's habit state on-device (ADR 0024): the daily goal, the
+ * activity log/streak, today's pages, and the khatma. The web adapter uses
+ * `localStorage`, mobile uses `AsyncStorage`; a synced adapter can replace
+ * either without touching the habit logic — the seam for #25. One method per
+ * stored key keeps writes as granular as the direct calls they replace.
+ */
+export interface ReadingGoalsStore {
+  /** The full habit snapshot (each key with its stored value or a default). */
+  read(): Promise<ReadingGoalsState>;
+  writeGoal(target: number): Promise<void>;
+  writeActiveDates(dates: string[]): Promise<void>;
+  writeLog(log: Record<string, number>): Promise<void>;
+  writePages(pages: { date: string; pages: number[] }): Promise<void>;
+  /** Save the khatma, or remove it when `null`. */
+  writeKhatma(khatma: KhatmaPlan | null): Promise<void>;
 }


### PR DESCRIPTION
## What

Sub-task 2 of the typed-storage-ports seam (#73, ADR 0024 — after `PlanStore`). The reader's habit state — daily goal, activity log/streak, today's pages, and the khatma — now persists through a typed **`ReadingGoalsStore`** port instead of direct `localStorage`/`AsyncStorage` in the glue. A future synced adapter (#25) slots in with **zero feature-logic changes**.

- **core:** `ReadingGoalsStore` + `ReadingGoalsState` in `ports.ts` — one method per stored key, so writes stay as granular as the direct calls they replace.
- **web:** `webReadingGoalsStore` adapter over the same `ul.reading*` / `ul.khatma` keys; the glue becomes async and exposes a single `readReadingState()` aggregate; the **seven consumers** (badge, tracker, goals view, hero cards, reader, ramadan, profile) load through the existing effect+event pattern.
- **mobile:** `mobileReadingGoalsStore` adapter; the glue routes through it with the public API (`ReadingState`, function names) unchanged.

## Behaviour unchanged

Same keys, same JSON formats, same semantics — the key-agnostic backup keeps working untouched. No new ADR (ADR 0024 already records this pattern, naming goals/streaks).

## Testing

- **Loop:** `pnpm lint`, `pnpm typecheck`, `pnpm test` (**417**), `pnpm build` all pass.
- **Unit:** reading-goals lib test rewritten for the async API; `ReadingGoalsView` test updated to `findBy`/`waitFor`; new `webReadingGoalsStore` round-trip + khatma-removal test.
- **Visual:** `/goals` renders identically (ring "3 of 8 pages today", week chart, "5 days" streak, goal pills selected) with the data now loaded async via the store.

Part of #73 (remaining sub-tasks: BookmarksStore + notes, tasbih/prayer/settings stores, shared backup mechanism).