### PR TITLE
feat(core): LibraryStore port + migrate bookmarks, collections & notes (#73)

### DIFF
--- a/apps/mobile/src/state/LibraryContext.tsx
+++ b/apps/mobile/src/state/LibraryContext.tsx
@@ -21,6 +21,7 @@ import {
   isDue,
 } from "@ummahlibrary/core";
 import { KEYS, getJSON, setJSON } from "../storage";
+import { mobileLibraryStore as library } from "./library-store";
 import { EMPTY_STREAK, advanceStreak, type StreakData } from "../hifz";
 
 export interface HifzRecord {
@@ -79,12 +80,12 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     void (async () => {
       const [bm, lr, hz, st, cols, nts] = await Promise.all([
-        getJSON<number[]>(KEYS.bookmarks, []),
+        library.readBookmarks(),
         getJSON<{ surah: number } | null>(KEYS.lastRead, null),
         getJSON<HifzStore>(KEYS.hifz, {}),
         getJSON<StreakData>(KEYS.hifzStreak, EMPTY_STREAK),
-        getJSON<Collection[]>(KEYS.collections, []),
-        getJSON<Record<string, string>>(KEYS.ayahNotes, {}),
+        library.readCollections(),
+        library.readNotes(),
       ]);
       setBookmarks(bm);
       setLastReadState(lr?.surah ?? null);
@@ -98,7 +99,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
 
   const updateCollections = useCallback((next: Collection[]) => {
     setCollections(next);
-    void setJSON(KEYS.collections, next);
+    void library.writeCollections(next);
   }, []);
 
   const setNote = useCallback((ref: VerseKey, text: string) => {
@@ -107,7 +108,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
       const next = { ...prev };
       if (text.trim()) next[key] = text;
       else delete next[key];
-      void setJSON(KEYS.ayahNotes, next);
+      void library.writeNotes(next);
       return next;
     });
   }, []);
@@ -123,7 +124,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
   const toggleBookmark = useCallback((surah: number) => {
     setBookmarks((prev) => {
       const next = prev.includes(surah) ? prev.filter((n) => n !== surah) : [...prev, surah];
-      void setJSON(KEYS.bookmarks, next);
+      void library.writeBookmarks(next);
       return next;
     });
   }, []);

--- a/apps/mobile/src/state/library-store.ts
+++ b/apps/mobile/src/state/library-store.ts
@@ -1,0 +1,18 @@
+/**
+ * Mobile `LibraryStore` adapter (ADR 0024): the reader's saved library —
+ * surah bookmarks, ayah collections, per-ayah notes — in AsyncStorage under the
+ * existing `ul.bookmarks` / `ul.collections` / `ul.ayahNotes` keys. Persistence
+ * only; a synced adapter (#25) can replace it without touching the library
+ * logic. Mirrors web.
+ */
+import type { Collection, LibraryStore } from "@ummahlibrary/core";
+import { KEYS, getJSON, setJSON } from "../storage";
+
+export const mobileLibraryStore: LibraryStore = {
+  readBookmarks: () => getJSON<number[]>(KEYS.bookmarks, []),
+  writeBookmarks: (surahs) => setJSON(KEYS.bookmarks, surahs),
+  readCollections: () => getJSON<Collection[]>(KEYS.collections, []),
+  writeCollections: (collections) => setJSON(KEYS.collections, collections),
+  readNotes: () => getJSON<Record<string, string>>(KEYS.ayahNotes, {}),
+  writeNotes: (notes) => setJSON(KEYS.ayahNotes, notes),
+};

--- a/apps/web/src/components/AyahActions.tsx
+++ b/apps/web/src/components/AyahActions.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import {
+  type Collection,
   collectionsWithAyah,
   createCard,
   createCollection,
@@ -126,7 +127,7 @@ export function AyahActions({
   const [tafsirOpen, setTafsirOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
 
-  const [collections, setCollections] = useState(() => [] as ReturnType<typeof readCollections>);
+  const [collections, setCollections] = useState<Collection[]>([]);
   const [note, setNote] = useState("");
   const [newName, setNewName] = useState("");
   const [tracked, setTracked] = useState(false);
@@ -144,7 +145,7 @@ export function AyahActions({
 
   useEffect(() => {
     setTracked(isTracked({ sura: surah, aya }));
-    setCollections(readCollections());
+    void readCollections().then(setCollections);
   }, [surah, aya]);
 
   useEffect(() => {
@@ -186,25 +187,25 @@ export function AyahActions({
 
   // ── collections + note ──
   function openSave() {
-    setCollections(readCollections());
-    setNote(readNote(ref));
+    void readCollections().then(setCollections);
+    void readNote(ref).then(setNote);
     setSaveOpen((o) => !o);
   }
   function toggleCol(id: string) {
     const next = toggleAyah(collections, id, ref);
     setCollections(next);
-    writeCollections(next);
+    void writeCollections(next);
   }
   function addCollection() {
     const id = newId();
     const next = toggleAyah(createCollection(collections, id, newName), id, ref);
     setCollections(next);
-    writeCollections(next);
+    void writeCollections(next);
     setNewName("");
   }
   function saveNote(text: string) {
     setNote(text);
-    writeNote(ref, text);
+    void writeNote(ref, text);
   }
 
   // ── more menu actions ──
@@ -274,8 +275,8 @@ export function AyahActions({
 
   function addReflection() {
     setMoreOpen(false);
-    setCollections(readCollections());
-    setNote(readNote(ref));
+    void readCollections().then(setCollections);
+    void readNote(ref).then(setNote);
     setSaveOpen(true);
   }
 

--- a/apps/web/src/components/CollectionsView.tsx
+++ b/apps/web/src/components/CollectionsView.tsx
@@ -36,8 +36,8 @@ export function CollectionsView() {
 
   useEffect(() => {
     const refresh = () => {
-      setCollections(readCollections());
-      setNotes(readNotes());
+      void readCollections().then(setCollections);
+      void readNotes().then(setNotes);
     };
     refresh();
     setReady(true);
@@ -96,7 +96,7 @@ export function CollectionsView() {
 
   function persist(next: Collection[]) {
     setCollections(next);
-    writeCollections(next);
+    void writeCollections(next);
   }
 
   if (!ready) return null;

--- a/apps/web/src/components/ProfileView.tsx
+++ b/apps/web/src/components/ProfileView.tsx
@@ -51,14 +51,14 @@ export function ProfileView() {
     const log = readPrayerLog();
     const hifzStreak = getStreak().count;
     const prayer = prayerStreak(log, t);
-    void readReadingState().then((reading) =>
+    void Promise.all([readReadingState(), readCollections()]).then(([reading, collections]) =>
       setS({
         hifzStreak,
         memorized: allRecords().length,
         surahsStarted: surahProgressMap(new Date()).size,
         prayerStreak: prayer,
         names: namesLearned(),
-        saved: totalSavedAyahs(readCollections()),
+        saved: totalSavedAyahs(collections),
         bestStreak: Math.max(hifzStreak, prayer, longestStreak(log), computeStreak(reading.activeDates, t)),
       }),
     );

--- a/apps/web/src/components/ReaderControls.tsx
+++ b/apps/web/src/components/ReaderControls.tsx
@@ -3,8 +3,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { EditionManager } from "./EditionManager";
+import { readBookmarks, toggleBookmark as toggleBm } from "../lib/bookmarks";
 
-const BOOKMARKS_KEY = "ul.bookmarks";
 const LAST_READ_KEY = "ul.lastRead";
 const SCALE_KEY = "ul.scale";
 const SCALE_MIN = 0.8;
@@ -41,7 +41,7 @@ export function ReaderControls({
 
   // Hydrate from localStorage and record this surah as last-read.
   useEffect(() => {
-    setBookmarked(read<number[]>(BOOKMARKS_KEY, []).includes(surahNumber));
+    void readBookmarks().then((list) => setBookmarked(list.includes(surahNumber)));
     write(LAST_READ_KEY, { surah: surahNumber });
 
     const savedScale = read<number>(SCALE_KEY, 1);
@@ -57,12 +57,7 @@ export function ReaderControls({
   }
 
   function toggleBookmark(): void {
-    const list = read<number[]>(BOOKMARKS_KEY, []);
-    const next = list.includes(surahNumber)
-      ? list.filter((n) => n !== surahNumber)
-      : [...list, surahNumber].sort((a, b) => a - b);
-    write(BOOKMARKS_KEY, next);
-    setBookmarked(next.includes(surahNumber));
+    void toggleBm(surahNumber).then((next) => setBookmarked(next.includes(surahNumber)));
   }
 
   return (

--- a/apps/web/src/components/ReaderToolbar.tsx
+++ b/apps/web/src/components/ReaderToolbar.tsx
@@ -6,6 +6,7 @@ import { N, Icon } from "@ummahlibrary/ui";
 import type { IconName } from "@ummahlibrary/ui";
 import { type EditionChoice, DEFAULT_EDITIONS, readEditions } from "../lib/editions";
 import { fetchCatalogue } from "../lib/catalogue";
+import { readBookmarks, toggleBookmark as toggleBm } from "../lib/bookmarks";
 import { TranslationSettings } from "./TranslationSettings";
 import { TafsirPicker } from "./TafsirPicker";
 import { WBW_KEY } from "./WordByWord";
@@ -13,7 +14,6 @@ import { WBW_KEY } from "./WordByWord";
 const SCALE_KEY = "ul.scale";
 const SCALE_MIN = 0.8;
 const SCALE_MAX = 1.8;
-const BOOKMARKS_KEY = "ul.bookmarks";
 const LAST_READ_KEY = "ul.lastRead";
 const RECITER_KEY = "ul.reciter";
 
@@ -73,7 +73,7 @@ export function ReaderToolbar({
     const savedScale = read<number>(SCALE_KEY, 1);
     setScale(savedScale);
     document.documentElement.style.setProperty("--reading-scale", String(savedScale));
-    setBookmarked(read<number[]>(BOOKMARKS_KEY, []).includes(surahNumber));
+    void readBookmarks().then((list) => setBookmarked(list.includes(surahNumber)));
     write(LAST_READ_KEY, { surah: surahNumber });
     const r = localStorage.getItem(RECITER_KEY);
     if (r && reciters.some((x) => x.id === r)) setReciterId(r);
@@ -103,12 +103,7 @@ export function ReaderToolbar({
     document.documentElement.style.setProperty("--reading-scale", String(next));
   }
   function toggleBookmark() {
-    const list = read<number[]>(BOOKMARKS_KEY, []);
-    const next = list.includes(surahNumber)
-      ? list.filter((n) => n !== surahNumber)
-      : [...list, surahNumber].sort((a, b) => a - b);
-    write(BOOKMARKS_KEY, next);
-    setBookmarked(next.includes(surahNumber));
+    void toggleBm(surahNumber).then((next) => setBookmarked(next.includes(surahNumber)));
   }
   function chooseReciter(id: string) {
     setReciterId(id);

--- a/apps/web/src/components/ReadingShelf.tsx
+++ b/apps/web/src/components/ReadingShelf.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { readBookmarks } from "../lib/bookmarks";
 
 interface SurahRef {
   number: number;
@@ -26,7 +27,7 @@ export function ReadingShelf({ surahs }: { surahs: SurahRef[] }) {
 
   useEffect(() => {
     setLastRead(read<{ surah: number } | null>("ul.lastRead", null)?.surah ?? null);
-    setBookmarks(read<number[]>("ul.bookmarks", []));
+    void readBookmarks().then(setBookmarks);
     setReady(true);
   }, []);
 

--- a/apps/web/src/lib/bookmarks.test.ts
+++ b/apps/web/src/lib/bookmarks.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readBookmarks, toggleBookmark } from "./bookmarks";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("bookmarks", () => {
+  it("starts empty", async () => {
+    expect(await readBookmarks()).toEqual([]);
+  });
+
+  it("toggles a surah on and off, keeping the list sorted", async () => {
+    expect(await toggleBookmark(36)).toEqual([36]);
+    expect(await toggleBookmark(2)).toEqual([2, 36]);
+    expect(await toggleBookmark(36)).toEqual([2]);
+    expect(await readBookmarks()).toEqual([2]);
+  });
+});

--- a/apps/web/src/lib/bookmarks.ts
+++ b/apps/web/src/lib/bookmarks.ts
@@ -1,0 +1,20 @@
+/**
+ * Surah bookmarks (ADR 0006), persisted through the `LibraryStore` port (web
+ * adapter `webLibraryStore`, ADR 0024) under the existing `ul.bookmarks` key.
+ * Replaces the per-component `localStorage` access the reader/dock/shelf used.
+ */
+import { webLibraryStore as store } from "./library-store";
+
+export function readBookmarks(): Promise<number[]> {
+  return store.readBookmarks();
+}
+
+/** Toggle a surah's bookmark; resolves with the updated (sorted) list. */
+export async function toggleBookmark(surah: number): Promise<number[]> {
+  const list = await store.readBookmarks();
+  const next = list.includes(surah)
+    ? list.filter((n) => n !== surah)
+    : [...list, surah].sort((a, b) => a - b);
+  await store.writeBookmarks(next);
+  return next;
+}

--- a/apps/web/src/lib/collections.test.ts
+++ b/apps/web/src/lib/collections.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Collection } from "@ummahlibrary/core";
 import {
   COLLECTIONS_EVENT,
@@ -10,31 +10,34 @@ import {
   writeNote,
 } from "./collections";
 
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
 describe("collections storage", () => {
-  it("starts empty", () => {
-    expect(readCollections()).toEqual([]);
-    expect(readNotes()).toEqual({});
+  it("starts empty", async () => {
+    expect(await readCollections()).toEqual([]);
+    expect(await readNotes()).toEqual({});
   });
 
-  it("round-trips collections and emits a change event", () => {
+  it("round-trips collections and emits a change event", async () => {
     const handler = vi.fn();
     window.addEventListener(COLLECTIONS_EVENT, handler);
 
     const cols: Collection[] = [{ id: "c1", name: "Favourites", ayahs: [{ sura: 1, aya: 1 }] }];
-    writeCollections(cols);
+    await writeCollections(cols);
 
-    expect(readCollections()).toEqual(cols);
+    expect(await readCollections()).toEqual(cols);
     expect(handler).toHaveBeenCalled();
     window.removeEventListener(COLLECTIONS_EVENT, handler);
   });
 
-  it("writes, reads, and clears a per-āyah note", () => {
+  it("writes, reads, and clears a per-āyah note", async () => {
     const ref = { sura: 2, aya: 255 };
-    writeNote(ref, "Āyat al-Kursī");
-    expect(readNote(ref)).toBe("Āyat al-Kursī");
+    await writeNote(ref, "Āyat al-Kursī");
+    expect(await readNote(ref)).toBe("Āyat al-Kursī");
 
-    writeNote(ref, "   "); // blank clears it
-    expect(readNote(ref)).toBe("");
+    await writeNote(ref, "   "); // blank clears it
+    expect(await readNote(ref)).toBe("");
   });
 
   it("generates unique ids", () => {

--- a/apps/web/src/lib/collections.ts
+++ b/apps/web/src/lib/collections.ts
@@ -1,24 +1,15 @@
 /**
  * Local-first storage for ayah collections and per-ayah notes (ADR 0006). The
- * model logic is pure in `@ummahlibrary/core`; this layer reads/writes
- * `localStorage` and broadcasts changes so the reader and `/collections` stay
- * in sync.
+ * model logic is pure in `@ummahlibrary/core`; persistence goes through the
+ * `LibraryStore` port (web adapter `webLibraryStore`, ADR 0024). A window event
+ * keeps the reader and `/collections` in sync.
  */
 
 import { type Collection, type VerseKey, ayahKey } from "@ummahlibrary/core";
+import { webLibraryStore as store } from "./library-store";
 
 export const COLLECTIONS_EVENT = "ul.collections";
-const COLLECTIONS_KEY = "ul.collections";
-const NOTES_KEY = "ul.ayahNotes";
 
-function get<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
 function emit(): void {
   try {
     window.dispatchEvent(new CustomEvent(COLLECTIONS_EVENT));
@@ -27,15 +18,11 @@ function emit(): void {
   }
 }
 
-export function readCollections(): Collection[] {
-  return get<Collection[]>(COLLECTIONS_KEY, []);
+export function readCollections(): Promise<Collection[]> {
+  return store.readCollections();
 }
-export function writeCollections(collections: Collection[]): void {
-  try {
-    localStorage.setItem(COLLECTIONS_KEY, JSON.stringify(collections));
-  } catch {
-    /* ignore */
-  }
+export async function writeCollections(collections: Collection[]): Promise<void> {
+  await store.writeCollections(collections);
   emit();
 }
 
@@ -43,21 +30,17 @@ export function newId(): string {
   return `c${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 }
 
-export function readNotes(): Record<string, string> {
-  return get<Record<string, string>>(NOTES_KEY, {});
+export function readNotes(): Promise<Record<string, string>> {
+  return store.readNotes();
 }
-export function readNote(ref: VerseKey): string {
-  return readNotes()[ayahKey(ref)] ?? "";
+export async function readNote(ref: VerseKey): Promise<string> {
+  return (await store.readNotes())[ayahKey(ref)] ?? "";
 }
-export function writeNote(ref: VerseKey, text: string): void {
-  const notes = readNotes();
+export async function writeNote(ref: VerseKey, text: string): Promise<void> {
+  const notes = await store.readNotes();
   const key = ayahKey(ref);
   if (text.trim()) notes[key] = text;
   else delete notes[key];
-  try {
-    localStorage.setItem(NOTES_KEY, JSON.stringify(notes));
-  } catch {
-    /* ignore */
-  }
+  await store.writeNotes(notes);
   emit();
 }

--- a/apps/web/src/lib/library-store.ts
+++ b/apps/web/src/lib/library-store.ts
@@ -1,0 +1,37 @@
+/**
+ * Web `LibraryStore` adapter (ADR 0024): the reader's saved library —
+ * surah bookmarks, ayah collections, per-ayah notes — in `localStorage` under
+ * the existing `ul.bookmarks` / `ul.collections` / `ul.ayahNotes` keys.
+ * Persistence only; a synced adapter (#25) can replace it without touching the
+ * library logic. Mirrors mobile.
+ */
+import type { Collection, LibraryStore } from "@ummahlibrary/core";
+
+const BOOKMARKS_KEY = "ul.bookmarks";
+const COLLECTIONS_KEY = "ul.collections";
+const NOTES_KEY = "ul.ayahNotes";
+
+function get<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+function set(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+export const webLibraryStore: LibraryStore = {
+  readBookmarks: async () => get<number[]>(BOOKMARKS_KEY, []),
+  writeBookmarks: async (surahs) => set(BOOKMARKS_KEY, surahs),
+  readCollections: async () => get<Collection[]>(COLLECTIONS_KEY, []),
+  writeCollections: async (collections) => set(COLLECTIONS_KEY, collections),
+  readNotes: async () => get<Record<string, string>>(NOTES_KEY, {}),
+  writeNotes: async (notes) => set(NOTES_KEY, notes),
+};

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -16,6 +16,7 @@ import type {
   Translation,
   VerseKey,
 } from "./entities";
+import type { Collection } from "./collections";
 import type { HifzCard } from "./hifz";
 import type { Coordinates, Madhab, PrayerTimings } from "./prayer";
 import type { ActivePlan, PlanTemplate } from "./reading-plans";
@@ -213,4 +214,22 @@ export interface ReadingGoalsStore {
   writePages(pages: { date: string; pages: number[] }): Promise<void>;
   /** Save the khatma, or remove it when `null`. */
   writeKhatma(khatma: KhatmaPlan | null): Promise<void>;
+}
+
+/**
+ * Persists the reader's saved library on-device (ADR 0024): surah bookmarks,
+ * ayah collections, and per-ayah notes (keyed by `sura:aya`). Web uses
+ * `localStorage`, mobile `AsyncStorage`; a synced adapter (#25) replaces either
+ * without touching the library logic — one method per stored key.
+ */
+export interface LibraryStore {
+  /** Bookmarked surah numbers. */
+  readBookmarks(): Promise<number[]>;
+  writeBookmarks(surahs: number[]): Promise<void>;
+  /** Ayah collections, in display order. */
+  readCollections(): Promise<Collection[]>;
+  writeCollections(collections: Collection[]): Promise<void>;
+  /** Per-ayah notes, `{ "sura:aya": text }`. */
+  readNotes(): Promise<Record<string, string>>;
+  writeNotes(notes: Record<string, string>): Promise<void>;
 }


### PR DESCRIPTION
## What

Sub-task 3 of the typed-storage-ports seam (#73, ADR 0024). The reader's **saved library** — surah bookmarks, ayah collections, per-ayah notes — now persists through a typed **`LibraryStore`** port. For bookmarks this also removes **duplicated `localStorage` access inlined in three reader components**, replacing it with a shared glue.

- **core:** `LibraryStore` in `ports.ts` (bookmarks / collections / notes — one method per stored key).
- **web:** `webLibraryStore` adapter over the same `ul.bookmarks` / `ul.collections` / `ul.ayahNotes` keys; `collections.ts` goes async via the store; a new `bookmarks.ts` glue replaces the inline logic in **ReaderToolbar, ReaderControls, ReadingShelf**; **AyahActions, CollectionsView, ProfileView** load through the store.
- **mobile:** `mobileLibraryStore` adapter; `LibraryContext` routes bookmarks/collections/notes through it (lastRead / hifz / streak untouched).

## Behaviour unchanged

Same keys, same JSON, same semantics — the key-agnostic backup keeps working. Bookmarks stay sorted (as the toolbar did). No new ADR (ADR 0024 names bookmarks & notes).

## Testing

- **Loop:** `pnpm lint`, `pnpm typecheck`, `pnpm test` (**419**), `pnpm build` all pass.
- **Unit:** collections test updated for the async API; new `bookmarks` round-trip (toggle on/off, sorted) test.
- **Visual:** `/collections` renders the seeded collection with both ayahs and the per-ayah note loaded async via the store; the home reading card still works (no regression to the ReadingGoalsStore migration).

Part of #73 (remaining: tasbih/prayer-tracker/settings stores, shared backup mechanism).