### PR TITLE
feat(core): PrayerTrackerStore port + migrate the prayer log (#73)

### DIFF
--- a/apps/mobile/src/prayer-tracker-store.ts
+++ b/apps/mobile/src/prayer-tracker-store.ts
@@ -1,0 +1,13 @@
+/**
+ * Mobile `PrayerTrackerStore` adapter (ADR 0024): the prayer log in AsyncStorage
+ * under the existing `ul.prayerLog` key. Persistence only — the stats live in
+ * `@ummahlibrary/core` — so a synced adapter (#25) can replace it without
+ * touching the tracker. Mirrors web.
+ */
+import type { PrayerTrackerLog, PrayerTrackerStore } from "@ummahlibrary/core";
+import { KEYS, getJSON, setJSON } from "./storage";
+
+export const mobilePrayerTrackerStore: PrayerTrackerStore = {
+  read: () => getJSON<PrayerTrackerLog>(KEYS.prayerLog, {}),
+  write: (log) => setJSON(KEYS.prayerLog, log),
+};

--- a/apps/mobile/src/screens/PrayerTrackerScreen.tsx
+++ b/apps/mobile/src/screens/PrayerTrackerScreen.tsx
@@ -15,7 +15,7 @@ import {
   statusFor,
 } from "@ummahlibrary/core";
 import { useTheme, type Palette } from "../theme";
-import { KEYS, getJSON, setJSON } from "../storage";
+import { mobilePrayerTrackerStore as prayerStore } from "../prayer-tracker-store";
 import { localISODate } from "../utils";
 
 const STATUS_LABEL: Record<PrayerStatus, string> = {
@@ -35,13 +35,13 @@ export function PrayerTrackerScreen() {
   const today = localISODate(new Date());
 
   useEffect(() => {
-    void getJSON<PrayerTrackerLog>(KEYS.prayerLog, {}).then(setLog);
+    void prayerStore.read().then(setLog);
   }, []);
 
   function cycle(prayer: (typeof OBLIGATORY_PRAYERS)[number]) {
     setLog((prev) => {
       const next = setPrayerStatus(prev, today, prayer, nextPrayerStatus(statusFor(prev[today], prayer)));
-      void setJSON(KEYS.prayerLog, next);
+      void prayerStore.write(next);
       return next;
     });
   }

--- a/apps/web/src/components/HomePrayerCard.tsx
+++ b/apps/web/src/components/HomePrayerCard.tsx
@@ -30,9 +30,9 @@ export function HomePrayerCard() {
 
   useEffect(() => {
     setTodayStr(today());
-    setLog(readPrayerLog());
+    void readPrayerLog().then(setLog);
     setReady(true);
-    const onChange = () => setLog(readPrayerLog());
+    const onChange = () => void readPrayerLog().then(setLog);
     window.addEventListener(PRAYER_TRACKER_EVENT, onChange);
     return () => window.removeEventListener(PRAYER_TRACKER_EVENT, onChange);
   }, []);
@@ -84,7 +84,7 @@ export function HomePrayerCard() {
               key={p}
               type="button"
               disabled={!ready}
-              onClick={() => ready && setLog(cyclePrayer(todayStr, p))}
+              onClick={() => ready && void cyclePrayer(todayStr, p).then(setLog)}
               aria-label={`${PRAYER_LABELS[p]}: ${st === "none" ? "not logged" : st} — tap to change`}
               style={{
                 display: "flex",

--- a/apps/web/src/components/PrayerTracker.tsx
+++ b/apps/web/src/components/PrayerTracker.tsx
@@ -49,9 +49,9 @@ export function PrayerTracker() {
 
   useEffect(() => {
     setTodayStr(today());
-    setLog(readPrayerLog());
+    void readPrayerLog().then(setLog);
     setReady(true);
-    const onChange = () => setLog(readPrayerLog());
+    const onChange = () => void readPrayerLog().then(setLog);
     window.addEventListener(PRAYER_TRACKER_EVENT, onChange);
     return () => window.removeEventListener(PRAYER_TRACKER_EVENT, onChange);
   }, []);
@@ -100,7 +100,7 @@ export function PrayerTracker() {
               <button
                 key={p}
                 type="button"
-                onClick={() => setLog(cyclePrayer(todayStr, p))}
+                onClick={() => void cyclePrayer(todayStr, p).then(setLog)}
                 aria-label={`${PRAYER_LABELS[p]}: ${statusLabel(st)} — tap to change`}
                 style={{
                   padding: "16px 6px",

--- a/apps/web/src/components/ProfileView.tsx
+++ b/apps/web/src/components/ProfileView.tsx
@@ -48,19 +48,20 @@ export function ProfileView() {
 
   useEffect(() => {
     const t = today();
-    const log = readPrayerLog();
     const hifzStreak = getStreak().count;
-    const prayer = prayerStreak(log, t);
-    void Promise.all([readReadingState(), readCollections()]).then(([reading, collections]) =>
-      setS({
-        hifzStreak,
-        memorized: allRecords().length,
-        surahsStarted: surahProgressMap(new Date()).size,
-        prayerStreak: prayer,
-        names: namesLearned(),
-        saved: totalSavedAyahs(collections),
-        bestStreak: Math.max(hifzStreak, prayer, longestStreak(log), computeStreak(reading.activeDates, t)),
-      }),
+    void Promise.all([readReadingState(), readCollections(), readPrayerLog()]).then(
+      ([reading, collections, log]) => {
+        const prayer = prayerStreak(log, t);
+        setS({
+          hifzStreak,
+          memorized: allRecords().length,
+          surahsStarted: surahProgressMap(new Date()).size,
+          prayerStreak: prayer,
+          names: namesLearned(),
+          saved: totalSavedAyahs(collections),
+          bestStreak: Math.max(hifzStreak, prayer, longestStreak(log), computeStreak(reading.activeDates, t)),
+        });
+      },
     );
   }, []);
 

--- a/apps/web/src/lib/prayer-tracker-store.ts
+++ b/apps/web/src/lib/prayer-tracker-store.ts
@@ -1,0 +1,27 @@
+/**
+ * Web `PrayerTrackerStore` adapter (ADR 0024): the prayer log in `localStorage`
+ * under the existing `ul.prayerLog` key. Persistence only — the stats live in
+ * `@ummahlibrary/core` — so a synced adapter (#25) can replace it without
+ * touching the tracker. Mirrors mobile.
+ */
+import type { PrayerTrackerLog, PrayerTrackerStore } from "@ummahlibrary/core";
+
+const LOG_KEY = "ul.prayerLog";
+
+export const webPrayerTrackerStore: PrayerTrackerStore = {
+  read: async () => {
+    try {
+      const raw = localStorage.getItem(LOG_KEY);
+      return raw ? (JSON.parse(raw) as PrayerTrackerLog) : {};
+    } catch {
+      return {};
+    }
+  },
+  write: async (log) => {
+    try {
+      localStorage.setItem(LOG_KEY, JSON.stringify(log));
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};

--- a/apps/web/src/lib/prayer-tracker.test.ts
+++ b/apps/web/src/lib/prayer-tracker.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  PRAYER_TRACKER_EVENT,
-  cyclePrayer,
-  readPrayerLog,
-  today,
-} from "./prayer-tracker";
+import { PRAYER_TRACKER_EVENT, cyclePrayer, readPrayerLog, today } from "./prayer-tracker";
 
 afterEach(() => {
   localStorage.clear();
@@ -17,33 +12,33 @@ describe("prayer-tracker store", () => {
     expect(today(new Date(2026, 11, 31))).toBe("2026-12-31");
   });
 
-  it("starts with an empty log", () => {
-    expect(readPrayerLog()).toEqual({});
+  it("starts with an empty log", async () => {
+    expect(await readPrayerLog()).toEqual({});
   });
 
-  it("cycles a prayer through none → ontime → late → none and persists", () => {
+  it("cycles a prayer through none → ontime → late → none and persists", async () => {
     const date = "2026-06-14";
 
-    expect(cyclePrayer(date, "fajr")[date]?.fajr).toBe("ontime");
-    expect(cyclePrayer(date, "fajr")[date]?.fajr).toBe("late");
+    expect((await cyclePrayer(date, "fajr"))[date]?.fajr).toBe("ontime");
+    expect((await cyclePrayer(date, "fajr"))[date]?.fajr).toBe("late");
     // Cycling back to "none" clears the entry (the absence is the "none" state).
-    expect(cyclePrayer(date, "fajr")[date]?.fajr ?? "none").toBe("none");
+    expect((await cyclePrayer(date, "fajr"))[date]?.fajr ?? "none").toBe("none");
 
     // The change survives a fresh read (kept in localStorage).
-    cyclePrayer(date, "dhuhr");
-    expect(readPrayerLog()[date]?.dhuhr).toBe("ontime");
+    await cyclePrayer(date, "dhuhr");
+    expect((await readPrayerLog())[date]?.dhuhr).toBe("ontime");
   });
 
-  it("emits a change event so subscribers can re-render", () => {
+  it("emits a change event so subscribers can re-render", async () => {
     const handler = vi.fn();
     window.addEventListener(PRAYER_TRACKER_EVENT, handler);
-    cyclePrayer("2026-06-14", "asr");
+    await cyclePrayer("2026-06-14", "asr");
     window.removeEventListener(PRAYER_TRACKER_EVENT, handler);
     expect(handler).toHaveBeenCalledOnce();
   });
 
-  it("falls back to an empty log when stored JSON is corrupt", () => {
+  it("falls back to an empty log when stored JSON is corrupt", async () => {
     localStorage.setItem("ul.prayerLog", "{not json");
-    expect(readPrayerLog()).toEqual({});
+    expect(await readPrayerLog()).toEqual({});
   });
 });

--- a/apps/web/src/lib/prayer-tracker.ts
+++ b/apps/web/src/lib/prayer-tracker.ts
@@ -1,8 +1,9 @@
 /**
  * Local-first prayer log (ADR 0006, 0020): which of the five obligatory prayers
- * you prayed each day, on time or late. All in `localStorage`; the stats live in
- * `@ummahlibrary/core`. A window event lets the tracker page re-render when the
- * log changes (and would let a home widget subscribe later).
+ * you prayed each day, on time or late. Persistence goes through the
+ * `PrayerTrackerStore` port (web adapter `webPrayerTrackerStore`, ADR 0024); the
+ * stats live in `@ummahlibrary/core`. A window event lets the tracker page
+ * re-render when the log changes.
  */
 
 import {
@@ -12,30 +13,15 @@ import {
   setPrayerStatus,
   statusFor,
 } from "@ummahlibrary/core";
+import { webPrayerTrackerStore as store } from "./prayer-tracker-store";
 
 export const PRAYER_TRACKER_EVENT = "ul.prayerTracker";
-const LOG_KEY = "ul.prayerLog";
 
 export function today(d = new Date()): string {
   const p = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
 
-function get<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-function set(key: string, value: unknown): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    /* storage unavailable */
-  }
-}
 function emit(): void {
   try {
     window.dispatchEvent(new CustomEvent(PRAYER_TRACKER_EVENT));
@@ -44,15 +30,15 @@ function emit(): void {
   }
 }
 
-export function readPrayerLog(): PrayerTrackerLog {
-  return get<PrayerTrackerLog>(LOG_KEY, {});
+export function readPrayerLog(): Promise<PrayerTrackerLog> {
+  return store.read();
 }
 
 /** Advance one prayer to its next status (none → ontime → late → none) and persist. */
-export function cyclePrayer(date: string, prayer: PrayerName): PrayerTrackerLog {
-  const log = readPrayerLog();
+export async function cyclePrayer(date: string, prayer: PrayerName): Promise<PrayerTrackerLog> {
+  const log = await store.read();
   const next = setPrayerStatus(log, date, prayer, nextPrayerStatus(statusFor(log[date], prayer)));
-  set(LOG_KEY, next);
+  await store.write(next);
   emit();
   return next;
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -17,6 +17,7 @@ import type {
   VerseKey,
 } from "./entities";
 import type { Collection } from "./collections";
+import type { PrayerTrackerLog } from "./prayer-tracker";
 import type { HifzCard } from "./hifz";
 import type { Coordinates, Madhab, PrayerTimings } from "./prayer";
 import type { ActivePlan, PlanTemplate } from "./reading-plans";
@@ -232,4 +233,15 @@ export interface LibraryStore {
   /** Per-ayah notes, `{ "sura:aya": text }`. */
   readNotes(): Promise<Record<string, string>>;
   writeNotes(notes: Record<string, string>): Promise<void>;
+}
+
+/**
+ * Persists the prayer tracker log on-device (ADR 0024): which of the five daily
+ * prayers were prayed (on time / late) each day. Web uses `localStorage`, mobile
+ * `AsyncStorage`; a synced adapter (#25) replaces either without touching the
+ * tracker logic.
+ */
+export interface PrayerTrackerStore {
+  read(): Promise<PrayerTrackerLog>;
+  write(log: PrayerTrackerLog): Promise<void>;
 }


### PR DESCRIPTION
## What

Sub-task 4a of the typed-storage-ports seam (#73, ADR 0024). The prayer tracker log now persists through a typed **`PrayerTrackerStore`** port instead of direct storage.

- **core:** `PrayerTrackerStore` in `ports.ts`.
- **web:** `webPrayerTrackerStore` adapter over the same `ul.prayerLog` key; the glue goes async; **PrayerTracker, HomePrayerCard, ProfileView** load through it.
- **mobile:** `mobilePrayerTrackerStore` adapter; `PrayerTrackerScreen` routes through it (no more inline `getJSON`/`setJSON`).

Same key, same behaviour — the backup is untouched.

## Testing

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (**419**) pass locally. The prayer-tracker test is updated for the async API (cycle none→ontime→late→none, persistence, event, corrupt-JSON fallback).
- Local `pnpm build` currently fails only on `next/font` fetching Google Fonts (blocked egress in my sandbox) — **not** a code error; CI/Vercel build with network. Relying on the CI build + E2E gate here.

Part of #73 (remaining: tasbih store, settings store, shared backup mechanism).