### PR TITLE
feat(core): TasbihStore port + migrate the tasbih counter (#73)

### DIFF
--- a/apps/mobile/src/screens/TasbihScreen.tsx
+++ b/apps/mobile/src/screens/TasbihScreen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, Vibration, View } from "../Type";
 import Svg, { Circle } from "react-native-svg";
 import { DHIKR_PHRASES, TASBIH_TARGETS, tasbihState } from "@ummahlibrary/core";
-import { KEYS, getJSON, setJSON } from "../storage";
+import { mobileTasbihStore as store } from "../tasbih-store";
 import { useTheme, type Palette } from "../theme";
 import { FONT } from "../fonts";
 
@@ -21,12 +21,12 @@ export function TasbihScreen() {
   const [state, setState] = useState<Stored>(DEFAULT);
 
   useEffect(() => {
-    void getJSON<Stored>(KEYS.tasbih, DEFAULT).then(setState);
+    void store.read().then((s) => setState(s ?? DEFAULT));
   }, []);
 
   function persist(next: Stored) {
     setState(next);
-    void setJSON(KEYS.tasbih, next);
+    void store.write(next);
   }
 
   const view = tasbihState(state.total, state.target);

--- a/apps/mobile/src/tasbih-store.ts
+++ b/apps/mobile/src/tasbih-store.ts
@@ -1,0 +1,13 @@
+/**
+ * Mobile `TasbihStore` adapter (ADR 0024): the tasbih counter in AsyncStorage
+ * under `ul.tasbih`. Persistence only — the counter maths is `tasbihState` in
+ * `@ummahlibrary/core` — so a synced adapter (#25) can replace it without
+ * touching the feature. Mirrors web.
+ */
+import type { TasbihRecord, TasbihStore } from "@ummahlibrary/core";
+import { KEYS, getJSON, setJSON } from "./storage";
+
+export const mobileTasbihStore: TasbihStore = {
+  read: () => getJSON<TasbihRecord | null>(KEYS.tasbih, null),
+  write: (record) => setJSON(KEYS.tasbih, record),
+};

--- a/apps/web/src/components/TasbihPageClient.test.tsx
+++ b/apps/web/src/components/TasbihPageClient.test.tsx
@@ -35,4 +35,17 @@ describe("TasbihPageClient", () => {
 
     expect(dial()).toHaveAccessibleName(/0 of 34/); // reset, target 34
   });
+
+  it("the Reset button clears the running count and persists it", async () => {
+    render(<TasbihPageClient />);
+
+    const d = await screen.findByRole("button", { name: /Count/ });
+    await userEvent.click(d);
+    await userEvent.click(d);
+    expect(dial()).toHaveAccessibleName(/2 of 33/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Reset" }));
+    expect(dial()).toHaveAccessibleName(/0 of 33/);
+    expect(JSON.parse(localStorage.getItem("ul.tasbih2") ?? "{}").total).toBe(0);
+  });
 });

--- a/apps/web/src/components/TasbihPageClient.test.tsx
+++ b/apps/web/src/components/TasbihPageClient.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -16,11 +16,13 @@ import { TasbihPageClient } from "./TasbihPageClient";
 
 const dial = () => screen.getByRole("button", { name: /Count/ });
 
+beforeEach(() => localStorage.clear());
+
 describe("TasbihPageClient", () => {
   it("counts up when the dial is tapped", async () => {
     render(<TasbihPageClient />);
 
-    expect(dial()).toHaveAccessibleName(/0 of 33/);
+    expect(await screen.findByRole("button", { name: /Count/ })).toHaveAccessibleName(/0 of 33/);
     await userEvent.click(dial());
     expect(dial()).toHaveAccessibleName(/1 of 33/);
   });
@@ -28,7 +30,7 @@ describe("TasbihPageClient", () => {
   it("switching the dhikr preset resets the count and its target", async () => {
     render(<TasbihPageClient />);
 
-    await userEvent.click(dial()); // count → 1
+    await userEvent.click(await screen.findByRole("button", { name: /Count/ })); // count → 1
     await userEvent.click(screen.getByRole("button", { name: "Allāhu Akbar" }));
 
     expect(dial()).toHaveAccessibleName(/0 of 34/); // reset, target 34

--- a/apps/web/src/components/TasbihPageClient.tsx
+++ b/apps/web/src/components/TasbihPageClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { DHIKR_PHRASES } from "@ummahlibrary/core";
+import { DHIKR_PHRASES, type TasbihRecord, tasbihState } from "@ummahlibrary/core";
 import { N } from "@ummahlibrary/ui";
 import { NoorPageFrame } from "./NoorPageFrame";
+import { DEFAULT_TASBIH, readTasbih, writeTasbih } from "../lib/tasbih";
 
 const PRESET_IDS = ["subhanallah", "alhamdulillah", "allahuakbar", "tahlil"] as const;
 
@@ -14,85 +15,53 @@ const PHRASE_TARGETS: Record<string, number> = {
   tahlil: 100,
 };
 
-const STORAGE_KEY = "ul.tasbih2";
-
-interface Stored {
-  phraseId: string;
-  count: number;
-  cycles: number;
-}
-
-function load(): Stored {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) return JSON.parse(raw) as Stored;
-  } catch {
-    /* ignore */
-  }
-  return { phraseId: DHIKR_PHRASES[0]!.id, count: 0, cycles: 0 };
-}
-
-function save(s: Stored) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
-  } catch {
-    /* ignore */
-  }
-}
-
 export function TasbihPageClient() {
   const [ready, setReady] = useState(false);
-  const [state, setState] = useState<Stored>({
-    phraseId: DHIKR_PHRASES[0]!.id,
-    count: 0,
-    cycles: 0,
-  });
+  const [state, setState] = useState<TasbihRecord>({ ...DEFAULT_TASBIH });
   const [pulse, setPulse] = useState(0);
 
   useEffect(() => {
-    const stored = load();
-    setState(stored);
-    setReady(true);
+    void readTasbih().then((stored) => {
+      setState(stored);
+      setReady(true);
+    });
   }, []);
 
   const presets = DHIKR_PHRASES.filter((p) => (PRESET_IDS as readonly string[]).includes(p.id));
   const phrase = DHIKR_PHRASES.find((p) => p.id === state.phraseId) ?? presets[0]!;
-  const target = PHRASE_TARGETS[state.phraseId] ?? 33;
+  const view = tasbihState(state.total, state.target);
+  const target = state.target;
 
-  function update(next: Stored) {
+  function update(next: TasbihRecord) {
     setState(next);
-    save(next);
+    void writeTasbih(next);
   }
 
   function tap() {
     setPulse((v) => v + 1);
     setState((prev) => {
-      const newCount = prev.count + 1;
-      const target = PHRASE_TARGETS[prev.phraseId] ?? 33;
-      const next: Stored =
-        newCount >= target
-          ? { ...prev, count: 0, cycles: prev.cycles + 1 }
-          : { ...prev, count: newCount };
-      save(next);
+      const next: TasbihRecord = { ...prev, total: prev.total + 1 };
+      void writeTasbih(next);
       if (typeof navigator !== "undefined" && "vibrate" in navigator) {
-        navigator.vibrate(newCount >= target ? 60 : 12);
+        // count wraps to 0 exactly when a round completes
+        navigator.vibrate(tasbihState(next.total, next.target).count === 0 ? 60 : 12);
       }
       return next;
     });
   }
 
   function selectPhrase(phraseId: string) {
-    update({ phraseId, count: 0, cycles: 0 });
+    update({ phraseId, total: 0, target: PHRASE_TARGETS[phraseId] ?? 33 });
   }
 
   function reset() {
-    update({ phraseId: state.phraseId, count: 0, cycles: 0 });
+    update({ ...state, total: 0 });
   }
 
-  const pct = target > 0 ? state.count / target : 0;
+  const pct = target > 0 ? view.count / target : 0;
   const R = 130;
   const C = 2 * Math.PI * R;
-  const totalToday = state.cycles * target + state.count;
+  const totalToday = view.total;
 
   const resetBtn = (
     <button
@@ -164,7 +133,7 @@ export function TasbihPageClient() {
           <div
             onClick={tap}
             role="button"
-            aria-label={`Count — ${state.count} of ${target}`}
+            aria-label={`Count — ${view.count} of ${target}`}
             tabIndex={0}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
@@ -250,7 +219,7 @@ export function TasbihPageClient() {
                     textAlign: "center",
                   }}
                 >
-                  {state.count}
+                  {view.count}
                 </div>
                 <div
                   style={{
@@ -271,7 +240,7 @@ export function TasbihPageClient() {
           <div style={{ display: "flex", justifyContent: "center", gap: 28, marginTop: 26 }}>
             {(
               [
-                { big: state.cycles, label: "Cycles complete" },
+                { big: view.rounds, label: "Cycles complete" },
                 { big: totalToday, label: "Total today" },
               ] as const
             ).map(({ big, label }) => (

--- a/apps/web/src/lib/tasbih-store.ts
+++ b/apps/web/src/lib/tasbih-store.ts
@@ -1,0 +1,31 @@
+/**
+ * Web `TasbihStore` adapter (ADR 0024): the tasbih counter in `localStorage`
+ * under `ul.tasbih2`. Persistence only — the counter maths is `tasbihState` in
+ * `@ummahlibrary/core` — so a synced adapter (#25) can replace it without
+ * touching the feature. Mirrors mobile.
+ */
+import type { TasbihRecord, TasbihStore } from "@ummahlibrary/core";
+
+const KEY = "ul.tasbih2";
+
+export const webTasbihStore: TasbihStore = {
+  read: async () => {
+    try {
+      const raw = localStorage.getItem(KEY);
+      if (!raw) return null;
+      const r = JSON.parse(raw) as Partial<TasbihRecord>;
+      return typeof r.total === "number" && typeof r.target === "number" && typeof r.phraseId === "string"
+        ? { phraseId: r.phraseId, total: r.total, target: r.target }
+        : null;
+    } catch {
+      return null;
+    }
+  },
+  write: async (record) => {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(record));
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};

--- a/apps/web/src/lib/tasbih.ts
+++ b/apps/web/src/lib/tasbih.ts
@@ -1,0 +1,22 @@
+/**
+ * Tasbih counter glue (ADR 0006): persistence through the `TasbihStore` port
+ * (web adapter `webTasbihStore`, ADR 0024). The counter maths (`tasbihState`)
+ * lives in `@ummahlibrary/core`; this layer only resolves the stored record or a
+ * sensible default.
+ */
+import { DHIKR_PHRASES, type TasbihRecord } from "@ummahlibrary/core";
+import { webTasbihStore as store } from "./tasbih-store";
+
+export const DEFAULT_TASBIH: TasbihRecord = {
+  phraseId: DHIKR_PHRASES[0]!.id,
+  total: 0,
+  target: 33,
+};
+
+export async function readTasbih(): Promise<TasbihRecord> {
+  return (await store.read()) ?? { ...DEFAULT_TASBIH };
+}
+
+export function writeTasbih(record: TasbihRecord): Promise<void> {
+  return store.write(record);
+}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -18,6 +18,7 @@ import type {
 } from "./entities";
 import type { Collection } from "./collections";
 import type { PrayerTrackerLog } from "./prayer-tracker";
+import type { TasbihRecord } from "./tasbih";
 import type { HifzCard } from "./hifz";
 import type { Coordinates, Madhab, PrayerTimings } from "./prayer";
 import type { ActivePlan, PlanTemplate } from "./reading-plans";
@@ -244,4 +245,15 @@ export interface LibraryStore {
 export interface PrayerTrackerStore {
   read(): Promise<PrayerTrackerLog>;
   write(log: PrayerTrackerLog): Promise<void>;
+}
+
+/**
+ * Persists the tasbih counter on-device (ADR 0024): the chosen phrase, a running
+ * total, and the round size. Web uses `localStorage`, mobile `AsyncStorage`; a
+ * synced adapter (#25) replaces either without touching the counter logic
+ * (`tasbihState`). `null` means the reader hasn't counted yet.
+ */
+export interface TasbihStore {
+  read(): Promise<TasbihRecord | null>;
+  write(record: TasbihRecord): Promise<void>;
 }

--- a/packages/core/src/tasbih.ts
+++ b/packages/core/src/tasbih.ts
@@ -41,3 +41,10 @@ export function tasbihState(total: number, target: number): TasbihState {
   const safeTotal = Math.max(0, Math.floor(total));
   return { count: safeTotal % t, rounds: Math.floor(safeTotal / t), total: safeTotal };
 }
+
+/** The persisted tasbih counter: the chosen phrase, a running total, the round size. */
+export interface TasbihRecord {
+  phraseId: string;
+  total: number;
+  target: number;
+}


### PR DESCRIPTION
## What

Sub-task 4b of the typed-storage-ports seam (#73, ADR 0024). The tasbih counter now persists through a typed **`TasbihStore`** port.

Web and mobile previously stored **different shapes** (`{phraseId,count,cycles}` on web `ul.tasbih2`, `{phraseId,total,target}` on mobile `ul.tasbih`). This unifies them on the canonical **`TasbihRecord`** `{phraseId,total,target}` — the shape core's `tasbihState(total,target)` already derives `count`/`rounds` from.

- **core:** `TasbihRecord` + `TasbihStore` in `ports.ts`.
- **web:** `webTasbihStore` adapter (`ul.tasbih2`) + a `tasbih.ts` glue; `TasbihPageClient` now tracks a running total and derives the dial via `tasbihState` — identical UX.
- **mobile:** `mobileTasbihStore` adapter (`ul.tasbih`); `TasbihScreen` routes through it (its shape already matched).

## Notes
- A live, mid-round count **resets once** on this change (web shape switch) — negligible for a bead counter.
- The legacy `TasbihCounter` component (uses `ul.tasbih`, **not mounted anywhere**) is left untouched.

## Testing
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (**419**) pass. `TasbihPageClient` test updated for the async load and validates count-up + preset-switch (reset + target change).
- Local `pnpm build` fails only on `next/font` Google-Fonts egress (sandbox) — not a code error; CI/Vercel build with network.

Part of #73 (remaining: settings store, shared backup mechanism).