### PR TITLE
feat(core): SettingsStore port + migrate mobile reader settings (#73)

### DIFF
--- a/apps/mobile/src/state/SettingsContext.tsx
+++ b/apps/mobile/src/state/SettingsContext.tsx
@@ -15,7 +15,7 @@ import {
 } from "react";
 import type { Translation } from "@ummahlibrary/core";
 import { api, type TafsirMeta } from "../api";
-import { KEYS, getJSON, getString, setJSON, setString } from "../storage";
+import { mobileSettingsStore as store } from "./settings-store";
 import { RECITER, TAFSIRS } from "../plugins";
 import { DEFAULT_EDITIONS, MAX_SCALE, MIN_SCALE, type ReadingMode } from "../types";
 
@@ -51,23 +51,15 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [tafsirs, setTafsirs] = useState<TafsirMeta[]>([]);
 
   useEffect(() => {
-    void (async () => {
-      const [ed, mode, rtr, reciter, tafsir, sc] = await Promise.all([
-        getJSON<string[]>(KEYS.editions, DEFAULT_EDITIONS),
-        getString(KEYS.readingMode),
-        getString(KEYS.readingTranslation),
-        getString(KEYS.reciter),
-        getString(KEYS.tafsir),
-        getJSON<number>(KEYS.scale, 1),
-      ]);
-      setEditionsState(ed.length > 0 ? ed : DEFAULT_EDITIONS);
-      if (mode === "translation" || mode === "reading" || mode === "reading-tr")
-        setReadingModeState(mode);
-      if (rtr) setReadingTranslationState(rtr);
-      if (reciter) setReciterIdState(reciter);
-      if (tafsir) setTafsirIdState(tafsir);
-      setScaleState(clampScale(sc));
-    })();
+    void store.read().then((s) => {
+      if (s.editions && s.editions.length > 0) setEditionsState(s.editions);
+      if (s.readingMode === "translation" || s.readingMode === "reading" || s.readingMode === "reading-tr")
+        setReadingModeState(s.readingMode);
+      if (s.readingTranslation) setReadingTranslationState(s.readingTranslation);
+      if (s.reciter) setReciterIdState(s.reciter);
+      if (s.tafsir) setTafsirIdState(s.tafsir);
+      if (s.scale != null) setScaleState(clampScale(s.scale));
+    });
     void api
       .listTranslationCatalog()
       .then(setCatalogue)
@@ -81,33 +73,33 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const setEditions = useCallback((ids: string[]) => {
     const next = ids.length > 0 ? ids : DEFAULT_EDITIONS;
     setEditionsState(next);
-    void setJSON(KEYS.editions, next);
+    void store.writeEditions(next);
   }, []);
 
   const setReadingMode = useCallback((mode: ReadingMode) => {
     setReadingModeState(mode);
-    void setString(KEYS.readingMode, mode);
+    void store.writeReadingMode(mode);
   }, []);
 
   const setReadingTranslation = useCallback((id: string) => {
     setReadingTranslationState(id);
-    void setString(KEYS.readingTranslation, id);
+    void store.writeReadingTranslation(id);
   }, []);
 
   const setReciterId = useCallback((id: string) => {
     setReciterIdState(id);
-    void setString(KEYS.reciter, id);
+    void store.writeReciter(id);
   }, []);
 
   const setTafsirId = useCallback((id: string) => {
     setTafsirIdState(id);
-    void setString(KEYS.tafsir, id);
+    void store.writeTafsir(id);
   }, []);
 
   const setScale = useCallback((next: number) => {
     const clamped = clampScale(next);
     setScaleState(clamped);
-    void setJSON(KEYS.scale, clamped);
+    void store.writeScale(clamped);
   }, []);
 
   const value = useMemo<SettingsValue>(

--- a/apps/mobile/src/state/settings-store.ts
+++ b/apps/mobile/src/state/settings-store.ts
@@ -1,0 +1,29 @@
+/**
+ * Mobile `SettingsStore` adapter (ADR 0024): the reader's preferences in
+ * AsyncStorage under the existing `ul.editions` / `ul.readingMode` /
+ * `ul.readingTranslation` / `ul.reciter` / `ul.tafsir` / `ul.scale` keys.
+ * Persistence only; a synced adapter (#25) can replace it without touching the
+ * settings UI. Mirrors web.
+ */
+import type { SettingsStore, StoredSettings } from "@ummahlibrary/core";
+import { KEYS, getJSON, getString, setJSON, setString } from "../storage";
+
+export const mobileSettingsStore: SettingsStore = {
+  read: async (): Promise<StoredSettings> => {
+    const [editions, readingMode, readingTranslation, reciter, tafsir, scale] = await Promise.all([
+      getJSON<string[] | null>(KEYS.editions, null),
+      getString(KEYS.readingMode),
+      getString(KEYS.readingTranslation),
+      getString(KEYS.reciter),
+      getString(KEYS.tafsir),
+      getJSON<number | null>(KEYS.scale, null),
+    ]);
+    return { editions, readingMode, readingTranslation, reciter, tafsir, scale };
+  },
+  writeEditions: (ids) => setJSON(KEYS.editions, ids),
+  writeReadingMode: (mode) => setString(KEYS.readingMode, mode),
+  writeReadingTranslation: (id) => setString(KEYS.readingTranslation, id),
+  writeReciter: (id) => setString(KEYS.reciter, id),
+  writeTafsir: (id) => setString(KEYS.tafsir, id),
+  writeScale: (scale) => setJSON(KEYS.scale, scale),
+};

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -257,3 +257,35 @@ export interface TasbihStore {
   read(): Promise<TasbihRecord | null>;
   write(record: TasbihRecord): Promise<void>;
 }
+
+/** Reader preferences as persisted — each `null` when the reader hasn't set it. */
+export interface StoredSettings {
+  /** Selected translation edition ids. */
+  editions: string[] | null;
+  /** Reading mode: `translation` | `reading` | `reading-tr`. */
+  readingMode: string | null;
+  /** The single "Reading → Translations" edition id. */
+  readingTranslation: string | null;
+  /** Selected reciter id. */
+  reciter: string | null;
+  /** Selected tafsir edition id. */
+  tafsir: string | null;
+  /** Reading font scale. */
+  scale: number | null;
+}
+
+/**
+ * Persists the reader's preferences on-device (ADR 0024): editions, reading
+ * mode, the reading translation, reciter, tafsir, and font scale. Web uses
+ * `localStorage`, mobile `AsyncStorage`; a synced adapter (#25) replaces either
+ * without touching the settings UI — one method per stored key.
+ */
+export interface SettingsStore {
+  read(): Promise<StoredSettings>;
+  writeEditions(ids: string[]): Promise<void>;
+  writeReadingMode(mode: string): Promise<void>;
+  writeReadingTranslation(id: string): Promise<void>;
+  writeReciter(id: string): Promise<void>;
+  writeTafsir(id: string): Promise<void>;
+  writeScale(scale: number): Promise<void>;
+}


### PR DESCRIPTION
## What

Sub-task 4c (part 1) of the typed-storage-ports seam (#73, ADR 0024): reader **preferences** — editions, reading mode, reading translation, reciter, tafsir, font scale.

This PR lands the **`SettingsStore`** port + the **mobile adapter**, and routes the mobile `SettingsContext` through it (already a centralised async settings layer, so a clean swap of its direct `getJSON`/`getString`/`setString` calls).

- **core:** `SettingsStore` + `StoredSettings` in `ports.ts` (one method per stored key).
- **mobile:** `mobileSettingsStore` adapter over the same `ul.editions` / `ul.readingMode` / `ul.readingTranslation` / `ul.reciter` / `ul.tafsir` / `ul.scale` keys.

## Scope

Web settings are scattered (the `editions.ts` / `tafsir.ts` glue + inline reciter/scale/reading-mode in the reader components) — those follow in the next PR(s), so this stays small and safe. Same keys, same behaviour.

## Testing

`pnpm lint`, `pnpm typecheck`, `pnpm test --coverage` (**420**, thresholds met) pass. Local `pnpm build` fails only on `next/font` Google-Fonts egress (sandbox) — CI builds with network.

Part of #73.