### PR TITLE
feat(web): route editions & tafsir settings through SettingsStore (#73)

### DIFF
--- a/apps/web/src/components/AyahActions.tsx
+++ b/apps/web/src/components/AyahActions.tsx
@@ -156,7 +156,7 @@ export function AyahActions({
   }, [tracked]);
 
   useEffect(() => {
-    setTafsirId(readTafsir(tafsirs[0]?.id ?? ""));
+    void readTafsir(tafsirs[0]?.id ?? "").then(setTafsirId);
     const onChange = (e: Event) => setTafsirId((e as CustomEvent<string>).detail);
     window.addEventListener(TAFSIR_KEY, onChange as EventListener);
     return () => window.removeEventListener(TAFSIR_KEY, onChange as EventListener);

--- a/apps/web/src/components/AyahTranslations.tsx
+++ b/apps/web/src/components/AyahTranslations.tsx
@@ -30,7 +30,7 @@ export function AyahTranslations({ surah, aya }: { surah: number; aya: number })
   useEffect(() => {
     let active = true;
     async function load() {
-      const ids = readEditions();
+      const ids = await readEditions();
       if (ids.length === 0) {
         if (active) {
           setLines([]);

--- a/apps/web/src/components/EditionManager.tsx
+++ b/apps/web/src/components/EditionManager.tsx
@@ -17,7 +17,7 @@ export function EditionManager() {
   const [managing, setManaging] = useState(false);
 
   useEffect(() => {
-    setSelected(new Set(readEditions()));
+    void readEditions().then((ids) => setSelected(new Set(ids)));
     void fetchCatalogue().then(setCatalogue);
   }, []);
 

--- a/apps/web/src/components/ReaderToolbar.tsx
+++ b/apps/web/src/components/ReaderToolbar.tsx
@@ -80,7 +80,7 @@ export function ReaderToolbar({
     const wbwOn = localStorage.getItem(WBW_KEY) === "1";
     setWbw(wbwOn);
     document.body.classList.toggle("wbw-on", wbwOn);
-    setSelected(new Set(readEditions()));
+    void readEditions().then((ids) => setSelected(new Set(ids)));
     void fetchCatalogue().then(setCatalogue);
   }, [surahNumber, reciters]);
 

--- a/apps/web/src/components/ReadingTranslationFlow.tsx
+++ b/apps/web/src/components/ReadingTranslationFlow.tsx
@@ -24,8 +24,8 @@ export function ReadingTranslationFlow({ surah, ayat }: { surah: number; ayat: n
   useEffect(() => {
     let active = true;
     async function load() {
-      const ids = readEditions();
-      const activeId = resolveActiveTranslation(ids, readReadingTranslation(), DEFAULT_EDITIONS[0]!);
+      const ids = await readEditions();
+      const activeId = resolveActiveTranslation(ids, await readReadingTranslation(), DEFAULT_EDITIONS[0]!);
       const [catalogue, textByAya] = await Promise.all([
         fetchCatalogue(),
         fetchEditionSurah(activeId, surah),

--- a/apps/web/src/components/ReadingTranslationPicker.tsx
+++ b/apps/web/src/components/ReadingTranslationPicker.tsx
@@ -29,9 +29,10 @@ export function ReadingTranslationPicker() {
   const pickerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const ids = readEditions();
-    setSelected(ids);
-    setActive(resolveActiveTranslation(ids, readReadingTranslation(), DEFAULT_EDITIONS[0]!));
+    void Promise.all([readEditions(), readReadingTranslation()]).then(([ids, rtr]) => {
+      setSelected(ids);
+      setActive(resolveActiveTranslation(ids, rtr, DEFAULT_EDITIONS[0]!));
+    });
     void fetchCatalogue().then(setCatalogue);
   }, []);
 
@@ -57,7 +58,7 @@ export function ReadingTranslationPicker() {
 
   function pick(id: string): void {
     setActive(id);
-    writeReadingTranslation(id);
+    void writeReadingTranslation(id);
     setOpen(false);
   }
 
@@ -67,7 +68,7 @@ export function ReadingTranslationPicker() {
     const nextActive = resolveActiveTranslation(ids, active, DEFAULT_EDITIONS[0]!);
     setSelected(ids);
     setActive(nextActive);
-    writeReadingTranslation(nextActive);
+    void writeReadingTranslation(nextActive);
   }
 
   return (

--- a/apps/web/src/components/TafsirPicker.test.tsx
+++ b/apps/web/src/components/TafsirPicker.test.tsx
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { readTafsir } from "../lib/tafsir";
 import { TafsirPicker } from "./TafsirPicker";
+
+beforeEach(() => localStorage.clear());
 
 const tafsirs = [
   { id: "en-jalalayn", name: "Jalālayn" },
@@ -22,6 +24,6 @@ describe("TafsirPicker", () => {
     await userEvent.selectOptions(select, "en-ibn-kathir");
 
     expect(select.value).toBe("en-ibn-kathir");
-    expect(readTafsir("")).toBe("en-ibn-kathir");
+    await waitFor(async () => expect(await readTafsir("")).toBe("en-ibn-kathir"));
   });
 });

--- a/apps/web/src/components/TafsirPicker.tsx
+++ b/apps/web/src/components/TafsirPicker.tsx
@@ -13,7 +13,7 @@ export function TafsirPicker({ tafsirs }: { tafsirs: TafsirMeta[] }) {
   const [id, setId] = useState(tafsirs[0]?.id ?? "");
 
   useEffect(() => {
-    setId(readTafsir(tafsirs[0]?.id ?? ""));
+    void readTafsir(tafsirs[0]?.id ?? "").then(setId);
   }, [tafsirs]);
 
   if (tafsirs.length <= 1) return null;
@@ -25,7 +25,7 @@ export function TafsirPicker({ tafsirs }: { tafsirs: TafsirMeta[] }) {
       value={id}
       onChange={(e) => {
         setId(e.target.value);
-        writeTafsir(e.target.value);
+        void writeTafsir(e.target.value);
       }}
     >
       {tafsirs.map((t) => (

--- a/apps/web/src/components/TafsirSample.tsx
+++ b/apps/web/src/components/TafsirSample.tsx
@@ -27,7 +27,7 @@ export function TafsirSample({ tafsirs }: { tafsirs: TafsirMeta[] }) {
   const [state, setState] = useState<"loading" | "ready" | "empty">("loading");
 
   useEffect(() => {
-    setTafsirId(readTafsir(tafsirs[0]?.id ?? ""));
+    void readTafsir(tafsirs[0]?.id ?? "").then(setTafsirId);
     const onChange = (e: Event) => setTafsirId((e as CustomEvent<string>).detail);
     window.addEventListener(TAFSIR_KEY, onChange as EventListener);
     return () => window.removeEventListener(TAFSIR_KEY, onChange as EventListener);

--- a/apps/web/src/components/TranslationSettings.tsx
+++ b/apps/web/src/components/TranslationSettings.tsx
@@ -50,7 +50,7 @@ export function TranslationSettings({
   function commit(next: Set<string>): void {
     if (next.size === 0) next.add(DEFAULT_EDITIONS[0]!); // never hide everything
     onChange(next);
-    writeEditions([...next]); // persists + broadcasts `ul.editions`
+    void writeEditions([...next]); // persists + broadcasts `ul.editions`
   }
 
   function toggle(id: string): void {

--- a/apps/web/src/lib/editions.test.ts
+++ b/apps/web/src/lib/editions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_EDITIONS,
   EDITIONS_KEY,
@@ -8,25 +8,28 @@ import {
   writeReadingTranslation,
 } from "./editions";
 
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
 describe("editions selection", () => {
-  it("defaults to DEFAULT_EDITIONS for a non-Urdu locale", () => {
-    expect(readEditions()).toEqual(DEFAULT_EDITIONS);
+  it("defaults to DEFAULT_EDITIONS for a non-Urdu locale", async () => {
+    expect(await readEditions()).toEqual(DEFAULT_EDITIONS);
   });
 
-  it("round-trips the edition set and emits a change event", () => {
+  it("round-trips the edition set and emits a change event", async () => {
     const handler = vi.fn();
     window.addEventListener(EDITIONS_KEY, handler);
 
-    writeEditions(["eng-sahih", "urd-jalandhry"]);
+    await writeEditions(["eng-sahih", "urd-jalandhry"]);
 
-    expect(readEditions()).toEqual(["eng-sahih", "urd-jalandhry"]);
+    expect(await readEditions()).toEqual(["eng-sahih", "urd-jalandhry"]);
     expect(handler).toHaveBeenCalledOnce();
     window.removeEventListener(EDITIONS_KEY, handler);
   });
 
-  it("round-trips the single reading translation", () => {
-    expect(readReadingTranslation()).toBeNull();
-    writeReadingTranslation("eng-sahih");
-    expect(readReadingTranslation()).toBe("eng-sahih");
+  it("round-trips the single reading translation", async () => {
+    expect(await readReadingTranslation()).toBeNull();
+    await writeReadingTranslation("eng-sahih");
+    expect(await readReadingTranslation()).toBe("eng-sahih");
   });
 });

--- a/apps/web/src/lib/editions.ts
+++ b/apps/web/src/lib/editions.ts
@@ -8,6 +8,7 @@
  * there is no longer a server-rendered set to toggle with CSS.
  */
 import type { Translation } from "@ummahlibrary/core";
+import { webSettingsStore as store } from "./settings-store";
 
 /** The edition fields the reader UI needs (a view over `Translation`). */
 export type EditionChoice = Pick<Translation, "id" | "name" | "author" | "language" | "direction">;
@@ -37,37 +38,21 @@ export function defaultEditions(): string[] {
   return DEFAULT_EDITIONS;
 }
 
-export function readEditions(): string[] {
-  try {
-    const raw = localStorage.getItem(EDITIONS_KEY);
-    return raw ? (JSON.parse(raw) as string[]) : defaultEditions();
-  } catch {
-    return defaultEditions();
-  }
+export async function readEditions(): Promise<string[]> {
+  const ed = (await store.read()).editions;
+  return ed ?? defaultEditions();
 }
 
-export function writeEditions(ids: string[]): void {
-  try {
-    localStorage.setItem(EDITIONS_KEY, JSON.stringify(ids));
-  } catch {
-    /* storage unavailable — ignore */
-  }
+export async function writeEditions(ids: string[]): Promise<void> {
+  await store.writeEditions(ids);
   window.dispatchEvent(new CustomEvent(EDITIONS_KEY, { detail: ids }));
 }
 
-export function readReadingTranslation(): string | null {
-  try {
-    return localStorage.getItem(READING_TR_KEY);
-  } catch {
-    return null;
-  }
+export async function readReadingTranslation(): Promise<string | null> {
+  return (await store.read()).readingTranslation;
 }
 
-export function writeReadingTranslation(id: string): void {
-  try {
-    localStorage.setItem(READING_TR_KEY, id);
-  } catch {
-    /* storage unavailable — ignore */
-  }
+export async function writeReadingTranslation(id: string): Promise<void> {
+  await store.writeReadingTranslation(id);
   window.dispatchEvent(new CustomEvent(READING_TR_KEY, { detail: id }));
 }

--- a/apps/web/src/lib/settings-store.test.ts
+++ b/apps/web/src/lib/settings-store.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { webSettingsStore as store } from "./settings-store";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("webSettingsStore", () => {
+  it("reads null for every unset preference", async () => {
+    expect(await store.read()).toEqual({
+      editions: null,
+      readingMode: null,
+      readingTranslation: null,
+      reciter: null,
+      tafsir: null,
+      scale: null,
+    });
+  });
+
+  it("round-trips every preference under its existing key", async () => {
+    await store.writeEditions(["eng-sahih"]);
+    await store.writeReadingMode("reading");
+    await store.writeReadingTranslation("urd-jalandhry");
+    await store.writeReciter("alafasy");
+    await store.writeTafsir("ar-muyassar");
+    await store.writeScale(1.4);
+
+    const s = await store.read();
+    expect(s.editions).toEqual(["eng-sahih"]);
+    expect(s.readingMode).toBe("reading");
+    expect(s.readingTranslation).toBe("urd-jalandhry");
+    expect(s.reciter).toBe("alafasy");
+    expect(s.tafsir).toBe("ar-muyassar");
+    expect(s.scale).toBe(1.4);
+
+    // editions and scale are JSON; the rest are plain strings (unchanged format)
+    expect(localStorage.getItem("ul.editions")).toBe('["eng-sahih"]');
+    expect(localStorage.getItem("ul.scale")).toBe("1.4");
+    expect(localStorage.getItem("ul.reciter")).toBe("alafasy");
+  });
+});

--- a/apps/web/src/lib/settings-store.ts
+++ b/apps/web/src/lib/settings-store.ts
@@ -1,0 +1,56 @@
+/**
+ * Web `SettingsStore` adapter (ADR 0024): the reader's preferences in
+ * `localStorage` under the existing `ul.editions` / `ul.readingMode` /
+ * `ul.readingTranslation` / `ul.reciter` / `ul.tafsir` / `ul.scale` keys.
+ * Editions and scale are JSON; the rest are plain strings (matching what the
+ * reader has always written). Persistence only — a synced adapter (#25) can
+ * replace it without touching the settings UI. Mirrors mobile.
+ */
+import type { SettingsStore, StoredSettings } from "@ummahlibrary/core";
+
+const EDITIONS_KEY = "ul.editions";
+const READING_MODE_KEY = "ul.readingMode";
+const READING_TR_KEY = "ul.readingTranslation";
+const RECITER_KEY = "ul.reciter";
+const TAFSIR_KEY = "ul.tafsir";
+const SCALE_KEY = "ul.scale";
+
+function getJSON<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+function getStr(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+function setItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+export const webSettingsStore: SettingsStore = {
+  read: async (): Promise<StoredSettings> => ({
+    editions: getJSON<string[] | null>(EDITIONS_KEY, null),
+    readingMode: getStr(READING_MODE_KEY),
+    readingTranslation: getStr(READING_TR_KEY),
+    reciter: getStr(RECITER_KEY),
+    tafsir: getStr(TAFSIR_KEY),
+    scale: getJSON<number | null>(SCALE_KEY, null),
+  }),
+  writeEditions: async (ids) => setItem(EDITIONS_KEY, JSON.stringify(ids)),
+  writeReadingMode: async (mode) => setItem(READING_MODE_KEY, mode),
+  writeReadingTranslation: async (id) => setItem(READING_TR_KEY, id),
+  writeReciter: async (id) => setItem(RECITER_KEY, id),
+  writeTafsir: async (id) => setItem(TAFSIR_KEY, id),
+  writeScale: async (scale) => setItem(SCALE_KEY, JSON.stringify(scale)),
+};

--- a/apps/web/src/lib/tafsir.test.ts
+++ b/apps/web/src/lib/tafsir.test.ts
@@ -1,21 +1,24 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TAFSIR_KEY, readTafsir, writeTafsir } from "./tafsir";
 
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
 describe("tafsir selection", () => {
-  it("returns the fallback when nothing is stored", () => {
-    expect(readTafsir("en-ibn-kathir")).toBe("en-ibn-kathir");
+  it("returns the fallback when nothing is stored", async () => {
+    expect(await readTafsir("en-ibn-kathir")).toBe("en-ibn-kathir");
   });
 
-  it("prefers the stored edition over the fallback", () => {
-    writeTafsir("ar-muyassar");
-    expect(readTafsir("en-ibn-kathir")).toBe("ar-muyassar");
+  it("prefers the stored edition over the fallback", async () => {
+    await writeTafsir("ar-muyassar");
+    expect(await readTafsir("en-ibn-kathir")).toBe("ar-muyassar");
     expect(localStorage.getItem(TAFSIR_KEY)).toBe("ar-muyassar");
   });
 
-  it("broadcasts the change on write", () => {
+  it("broadcasts the change on write", async () => {
     const handler = vi.fn();
     window.addEventListener(TAFSIR_KEY, handler);
-    writeTafsir("x");
+    await writeTafsir("x");
     expect(handler).toHaveBeenCalledOnce();
     window.removeEventListener(TAFSIR_KEY, handler);
   });

--- a/apps/web/src/lib/tafsir.ts
+++ b/apps/web/src/lib/tafsir.ts
@@ -1,25 +1,20 @@
 "use client";
 
 /**
- * Shared selected-tafsir state. The chosen edition lives in `localStorage`
- * under `ul.tafsir`; `TafsirPicker` writes it and dispatches a `ul:tafsir`
- * window event so every open `AyahTafsir` block re-fetches in the new edition.
+ * Shared selected-tafsir state through the `SettingsStore` port (web adapter
+ * `webSettingsStore`, ADR 0024) under `ul.tafsir`. `TafsirPicker` writes it and
+ * dispatches a window event so every open `AyahTafsir` block re-fetches in the
+ * new edition.
  */
+import { webSettingsStore as store } from "./settings-store";
+
 export const TAFSIR_KEY = "ul.tafsir";
 
-export function readTafsir(fallback: string): string {
-  try {
-    return localStorage.getItem(TAFSIR_KEY) || fallback;
-  } catch {
-    return fallback;
-  }
+export async function readTafsir(fallback: string): Promise<string> {
+  return (await store.read()).tafsir || fallback;
 }
 
-export function writeTafsir(id: string): void {
-  try {
-    localStorage.setItem(TAFSIR_KEY, id);
-  } catch {
-    /* storage unavailable — ignore */
-  }
+export async function writeTafsir(id: string): Promise<void> {
+  await store.writeTafsir(id);
   window.dispatchEvent(new CustomEvent(TAFSIR_KEY, { detail: id }));
 }


### PR DESCRIPTION
## What

Web half of the SettingsStore migration (#73, after the mobile context, ADR 0024). The shared **edition selection** (`editions.ts`) and **tafsir selection** (`tafsir.ts`) now persist through the `webSettingsStore` adapter instead of direct `localStorage`.

- **web:** `webSettingsStore` adapter (editions + scale are JSON; reciter/readingMode/readingTranslation/tafsir are plain strings — the exact formats the reader has always written). `editions.ts` and `tafsir.ts` go async over the store, still broadcasting their `ul.editions` / `ul.readingTranslation` / `ul.tafsir` window events.
- The **nine consumers** (AyahTranslations, TranslationSettings, ReaderToolbar, EditionManager, ReadingTranslationPicker, ReadingTranslationFlow, TafsirPicker, TafsirSample, AyahActions) load through the existing effect+event pattern.

## Behaviour unchanged

Same keys, same formats — the backup is untouched.

## Testing

- `pnpm lint`, `pnpm typecheck`, `pnpm test --coverage` (**422**, thresholds met) pass. editions/tafsir/TafsirPicker tests updated for the async API; new `webSettingsStore` round-trip test.
- Local `pnpm build` fails only on `next/font` Google-Fonts egress (sandbox) — CI builds with network + runs the reader e2e.

Part of #73 (remaining: inline reciter/scale/reading-mode prefs, shared backup mechanism).