### PR TITLE
feat(web): route reciter, scale & reading mode through SettingsStore (#73)

### DIFF
--- a/apps/web/src/components/ReaderControls.tsx
+++ b/apps/web/src/components/ReaderControls.tsx
@@ -4,20 +4,11 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { EditionManager } from "./EditionManager";
 import { readBookmarks, toggleBookmark as toggleBm } from "../lib/bookmarks";
+import { readScale, writeScale } from "../lib/reader-prefs";
 
 const LAST_READ_KEY = "ul.lastRead";
-const SCALE_KEY = "ul.scale";
 const SCALE_MIN = 0.8;
 const SCALE_MAX = 1.8;
-
-function read<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
 
 function write(key: string, value: unknown): void {
   try {
@@ -44,15 +35,16 @@ export function ReaderControls({
     void readBookmarks().then((list) => setBookmarked(list.includes(surahNumber)));
     write(LAST_READ_KEY, { surah: surahNumber });
 
-    const savedScale = read<number>(SCALE_KEY, 1);
-    setScale(savedScale);
-    document.documentElement.style.setProperty("--reading-scale", String(savedScale));
+    void readScale().then((s) => {
+      setScale(s);
+      document.documentElement.style.setProperty("--reading-scale", String(s));
+    });
   }, [surahNumber]);
 
   function changeScale(delta: number): void {
     const next = Math.min(SCALE_MAX, Math.max(SCALE_MIN, Math.round((scale + delta) * 10) / 10));
     setScale(next);
-    write(SCALE_KEY, next);
+    void writeScale(next);
     document.documentElement.style.setProperty("--reading-scale", String(next));
   }
 

--- a/apps/web/src/components/ReaderToolbar.tsx
+++ b/apps/web/src/components/ReaderToolbar.tsx
@@ -7,24 +7,16 @@ import type { IconName } from "@ummahlibrary/ui";
 import { type EditionChoice, DEFAULT_EDITIONS, readEditions } from "../lib/editions";
 import { fetchCatalogue } from "../lib/catalogue";
 import { readBookmarks, toggleBookmark as toggleBm } from "../lib/bookmarks";
+import { readReciter, readScale, writeReciter, writeScale } from "../lib/reader-prefs";
 import { TranslationSettings } from "./TranslationSettings";
 import { TafsirPicker } from "./TafsirPicker";
 import { WBW_KEY } from "./WordByWord";
 
-const SCALE_KEY = "ul.scale";
 const SCALE_MIN = 0.8;
 const SCALE_MAX = 1.8;
 const LAST_READ_KEY = "ul.lastRead";
 const RECITER_KEY = "ul.reciter";
 
-function read<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
 function write(key: string, value: unknown): void {
   try {
     localStorage.setItem(key, JSON.stringify(value));
@@ -70,13 +62,15 @@ export function ReaderToolbar({
   const [selected, setSelected] = useState<Set<string>>(() => new Set(DEFAULT_EDITIONS));
 
   useEffect(() => {
-    const savedScale = read<number>(SCALE_KEY, 1);
-    setScale(savedScale);
-    document.documentElement.style.setProperty("--reading-scale", String(savedScale));
+    void readScale().then((s) => {
+      setScale(s);
+      document.documentElement.style.setProperty("--reading-scale", String(s));
+    });
     void readBookmarks().then((list) => setBookmarked(list.includes(surahNumber)));
     write(LAST_READ_KEY, { surah: surahNumber });
-    const r = localStorage.getItem(RECITER_KEY);
-    if (r && reciters.some((x) => x.id === r)) setReciterId(r);
+    void readReciter().then((r) => {
+      if (r && reciters.some((x) => x.id === r)) setReciterId(r);
+    });
     const wbwOn = localStorage.getItem(WBW_KEY) === "1";
     setWbw(wbwOn);
     document.body.classList.toggle("wbw-on", wbwOn);
@@ -99,7 +93,7 @@ export function ReaderToolbar({
   function changeScale(delta: number) {
     const next = Math.min(SCALE_MAX, Math.max(SCALE_MIN, Math.round((scale + delta) * 10) / 10));
     setScale(next);
-    write(SCALE_KEY, next);
+    void writeScale(next);
     document.documentElement.style.setProperty("--reading-scale", String(next));
   }
   function toggleBookmark() {
@@ -107,12 +101,8 @@ export function ReaderToolbar({
   }
   function chooseReciter(id: string) {
     setReciterId(id);
-    try {
-      localStorage.setItem(RECITER_KEY, id);
-      window.dispatchEvent(new CustomEvent(RECITER_KEY, { detail: id }));
-    } catch {
-      /* ignore */
-    }
+    void writeReciter(id);
+    window.dispatchEvent(new CustomEvent(RECITER_KEY, { detail: id }));
     setPanel(null);
   }
 

--- a/apps/web/src/components/ReadingAudio.tsx
+++ b/apps/web/src/components/ReadingAudio.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { type ReciterPlugin, quranComAudioUrl, reciterAudioUrl } from "@ummahlibrary/core";
 import { N, Icon } from "@ummahlibrary/ui";
+import { readReciter, writeReciter } from "../lib/reader-prefs";
 
 const RECITER_KEY = "ul.reciter";
 const LOOP_KEY = "ul.loop";
@@ -83,8 +84,9 @@ export function ReadingAudio({
   });
 
   useEffect(() => {
-    const saved = localStorage.getItem(RECITER_KEY);
-    if (saved && reciters.some((r) => r.id === saved)) setReciterId(saved);
+    void readReciter().then((saved) => {
+      if (saved && reciters.some((r) => r.id === saved)) setReciterId(saved);
+    });
     const savedLoop = localStorage.getItem(LOOP_KEY) === "1";
     setLoop(savedLoop);
     loopRef.current = savedLoop;
@@ -327,7 +329,7 @@ export function ReadingAudio({
             value={reciterId}
             onChange={(e) => {
               setReciterId(e.target.value);
-              localStorage.setItem(RECITER_KEY, e.target.value);
+              void writeReciter(e.target.value);
               stop();
             }}
             style={{
@@ -376,7 +378,7 @@ export function ReadingAudio({
           value={reciterId}
           onChange={(e) => {
             setReciterId(e.target.value);
-            localStorage.setItem(RECITER_KEY, e.target.value);
+            void writeReciter(e.target.value);
             stop();
           }}
         >

--- a/apps/web/src/components/ReadingModeToggle.tsx
+++ b/apps/web/src/components/ReadingModeToggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { writeReadingMode } from "../lib/reader-prefs";
 
 /**
  * Reading mode, mirroring Quran.com's two-level control:
@@ -24,11 +25,7 @@ export function ReadingModeToggle() {
   function choose(next: Mode) {
     setMode(next);
     document.documentElement.dataset.readingMode = next;
-    try {
-      localStorage.setItem("ul.readingMode", next);
-    } catch {
-      /* ignore */
-    }
+    void writeReadingMode(next);
   }
 
   const isReading = mode === "reading" || mode === "reading-tr";

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -17,6 +17,7 @@ import { ReaderShortcuts } from "./ReaderShortcuts";
 import { ReadingTracker } from "./ReadingTracker";
 import { PlanReaderChip } from "./PlanReaderChip";
 import { recordMushafPage } from "../lib/reading-goals";
+import { writeReadingMode } from "../lib/reader-prefs";
 
 type ReadingMode = "translation" | "reading" | "reading-tr";
 
@@ -112,32 +113,19 @@ export function SurahReaderClient({
   const pages = useMemo(() => pagesOf(surah.number, ayahs), [surah.number, ayahs]);
   const lastPageRef = useRef(0);
 
-  // Restore persisted reading mode on mount
+  // Restore persisted reading mode on mount. The mode is restored pre-paint into
+  // `data-reading-mode` by the layout bootstrap (the sole sync read, for FOUC).
   useEffect(() => {
     const saved = document.documentElement.dataset.readingMode as ReadingMode | undefined;
     if (saved && SEG_TO_MODE[MODE_TO_SEG[saved] ?? ""] !== undefined) {
       setMode(saved);
-    } else {
-      try {
-        const ls = localStorage.getItem("ul.readingMode") as ReadingMode | null;
-        if (ls && ls in MODE_TO_SEG) {
-          setMode(ls);
-          document.documentElement.dataset.readingMode = ls;
-        }
-      } catch {
-        /* ignore */
-      }
     }
   }, []);
 
-  // Sync mode to DOM (for CSS-based mode switching used by existing components)
+  // Sync mode to the DOM (CSS-based switching) and persist it through the store.
   useEffect(() => {
     document.documentElement.dataset.readingMode = mode;
-    try {
-      localStorage.setItem("ul.readingMode", mode);
-    } catch {
-      /* ignore */
-    }
+    void writeReadingMode(mode);
   }, [mode]);
 
   const chooseMode = (seg: string) => {

--- a/apps/web/src/lib/reader-prefs.test.ts
+++ b/apps/web/src/lib/reader-prefs.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readReciter, readScale, writeReadingMode, writeReciter, writeScale } from "./reader-prefs";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("reader-prefs", () => {
+  it("round-trips the reciter under ul.reciter", async () => {
+    expect(await readReciter()).toBeNull();
+    await writeReciter("alafasy");
+    expect(await readReciter()).toBe("alafasy");
+    expect(localStorage.getItem("ul.reciter")).toBe("alafasy");
+  });
+
+  it("round-trips the font scale, defaulting to 1", async () => {
+    expect(await readScale()).toBe(1);
+    await writeScale(1.4);
+    expect(await readScale()).toBe(1.4);
+  });
+
+  it("persists the reading mode", async () => {
+    await writeReadingMode("reading-tr");
+    expect(localStorage.getItem("ul.readingMode")).toBe("reading-tr");
+  });
+});

--- a/apps/web/src/lib/reader-prefs.ts
+++ b/apps/web/src/lib/reader-prefs.ts
@@ -1,0 +1,28 @@
+/**
+ * The reader's inline display preferences — reciter, font scale, reading mode —
+ * persisted through the `SettingsStore` port (web adapter `webSettingsStore`,
+ * ADR 0024) instead of direct `localStorage` in the reader components.
+ *
+ * Note: the `data-reading-mode` bootstrap in `layout.tsx` still reads
+ * `localStorage` synchronously before paint (FOUC prevention) — the one place
+ * that can't go through an async store, the same exception theme bootstrap uses.
+ */
+import { webSettingsStore as store } from "./settings-store";
+
+export async function readReciter(): Promise<string | null> {
+  return (await store.read()).reciter;
+}
+export function writeReciter(id: string): Promise<void> {
+  return store.writeReciter(id);
+}
+
+export async function readScale(): Promise<number> {
+  return (await store.read()).scale ?? 1;
+}
+export function writeScale(scale: number): Promise<void> {
+  return store.writeScale(scale);
+}
+
+export function writeReadingMode(mode: string): Promise<void> {
+  return store.writeReadingMode(mode);
+}


### PR DESCRIPTION
## What

Completes the SettingsStore migration (#73, ADR 0024). The last web reader prefs that were read/written **inline** in the reader components now go through the `webSettingsStore` adapter via a small `reader-prefs.ts` glue.

- **reciter** — ReaderToolbar + ReadingAudio (the cross-component `ul.reciter` event is preserved).
- **font scale** — ReaderToolbar + ReaderControls.
- **reading mode** — ReadingModeToggle + SurahReaderClient writes.

## The one documented sync exception

The `data-reading-mode` bootstrap in `layout.tsx` reads `localStorage` **synchronously before paint** to prevent a flash — it can't go through an async store (the same exception the theme bootstrap uses). SurahReaderClient now reads the restored mode from that `data-reading-mode` attribute instead of `localStorage` directly, so no reader *component* touches storage for these prefs anymore.

## Testing

- `pnpm lint`, `pnpm typecheck`, `pnpm test --coverage` (**425**, thresholds met) pass. New `reader-prefs` round-trip test.
- Local `pnpm build` fails only on `next/font` Google-Fonts egress (sandbox) — CI builds with network + runs the reader/audio e2e.

With this, **#73's settings sub-task is complete** (mobile context + web editions/tafsir + inline reciter/scale/mode). Remaining for #73: the shared backup mechanism.