### PR TITLE
feat(core): backup discovers keys via a shared prefix mechanism (#73)

### DIFF
--- a/apps/web/src/lib/backup.ts
+++ b/apps/web/src/lib/backup.ts
@@ -4,17 +4,21 @@
  * merge logic is pure in `@ummahlibrary/core`.
  */
 
-import { type MergeStrategy, buildBackup, mergeBackups, validateBackup } from "@ummahlibrary/core";
+import {
+  type MergeStrategy,
+  buildBackup,
+  isBackupKey,
+  mergeBackups,
+  validateBackup,
+} from "@ummahlibrary/core";
 
-const PREFIX = "ul.";
-
-/** Every `ul.*` key currently in localStorage, with its raw string value. */
+/** Every local-first (`ul.*`) key in localStorage, with its raw string value. */
 export function collectLocalData(): Record<string, string> {
   const out: Record<string, string> = {};
   try {
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key && key.startsWith(PREFIX)) {
+      if (key && isBackupKey(key)) {
         const value = localStorage.getItem(key);
         if (value !== null) out[key] = value;
       }

--- a/packages/core/src/backup.test.ts
+++ b/packages/core/src/backup.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
   BACKUP_APP,
+  BACKUP_KEY_PREFIX,
   BACKUP_VERSION,
   buildBackup,
+  isBackupKey,
   mergeBackups,
   validateBackup,
 } from "./backup";
+
+describe("isBackupKey", () => {
+  it("matches only the shared local-first prefix", () => {
+    expect(BACKUP_KEY_PREFIX).toBe("ul.");
+    expect(isBackupKey("ul.readingPlan")).toBe(true);
+    expect(isBackupKey("ul.editions")).toBe(true);
+    expect(isBackupKey("theme")).toBe(false);
+    expect(isBackupKey("other.key")).toBe(false);
+  });
+});
 
 describe("buildBackup", () => {
   it("wraps data in a versioned, timestamped envelope", () => {

--- a/packages/core/src/backup.ts
+++ b/packages/core/src/backup.ts
@@ -8,6 +8,20 @@
 export const BACKUP_VERSION = 1;
 export const BACKUP_APP = "ummah-library";
 
+/**
+ * The shared namespace every local-first key lives under (`ul.readingPlan`,
+ * `ul.editions`, …). It's the single mechanism the backup uses to discover the
+ * data the typed stores persist (ADR 0024): every store adapter writes under
+ * this prefix, and the backup collects exactly the keys that match it, so a new
+ * store is captured automatically with no backup change.
+ */
+export const BACKUP_KEY_PREFIX = "ul.";
+
+/** Whether a storage key belongs to the app's local-first data (and the backup). */
+export function isBackupKey(key: string): boolean {
+  return key.startsWith(BACKUP_KEY_PREFIX);
+}
+
 /** A portable snapshot of the user's local data (keys → their stored strings). */
 export interface BackupFile {
   app: typeof BACKUP_APP;


### PR DESCRIPTION
## What

**Final sub-task of #73** (typed-storage-ports seam, ADR 0024). The backup already captured every store because they all persist under the `ul.*` namespace; this makes that mechanism the **single shared source of truth** instead of a local constant in the web glue.

- **core:** `BACKUP_KEY_PREFIX` + `isBackupKey(key)` — the one rule for which keys are local-first data. Every store adapter writes under this prefix, so a **new store is backed up automatically** with no backup change.
- **web:** `collectLocalData` uses `isBackupKey` instead of its own `"ul."` constant.

## #73 complete

Every listed local-first feature — reading plans, goals/streaks, bookmarks/collections/notes, the prayer log, tasbih, and reader settings — now persists through a typed store port on both platforms:

| Store | PR |
|---|---|
| PlanStore | (earlier, #61) |
| ReadingGoalsStore | #89 |
| LibraryStore (bookmarks/collections/notes) | #90 |
| PrayerTrackerStore | #91 |
| TasbihStore | #92 |
| SettingsStore (mobile + web glue + inline) | #93, #94, #95 |
| Backup shared mechanism | this PR |

No direct storage in the migrated glue, behaviour unchanged, backup intact — a synced adapter (#25) can replace any of them with **zero feature-logic changes**.

## Testing

`pnpm lint`, `pnpm typecheck`, `pnpm test --coverage` (**426**, thresholds met) pass; `isBackupKey` unit-tested. Local `pnpm build` fails only on `next/font` Google-Fonts egress (sandbox) — CI builds with network.

Closes #73.