### PR TITLE
fix(mobile): single audio player + auto-scroll + snappier play/pause

### DIFF
--- a/apps/mobile/src/audio/useSurahAudio.ts
+++ b/apps/mobile/src/audio/useSurahAudio.ts
@@ -5,12 +5,18 @@
  * current word from `player.currentTime`; otherwise we fall back to the
  * reciter's own per-ayah MP3 (no word sync). A stall watchdog skips an ayah that
  * makes no progress within STALL_MS so a flaky connection degrades gracefully.
+ *
+ * A single AudioPlayer is kept for the hook's lifetime and re-sourced with
+ * `replace()` for each āyah. Because there is only ever one player, two
+ * recitations can never sound in parallel (a rapid re-tap just re-sources the
+ * same player), and we avoid allocating/freeing a native player every āyah.
  */
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createAudioPlayer, setAudioModeAsync, type AudioPlayer } from "expo-audio";
 import { reciterAudioUrl, type ReciterPlugin, type VerseKey } from "@ummahlibrary/core";
 
 const STALL_MS = 8000;
+const POLL_MS = 60;
 
 /** quran.com word-timing segment: [wordIndex, position, startMs, endMs]. */
 type Segment = [number, number, number, number];
@@ -75,34 +81,31 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
     setLoopState(on);
   }, []);
 
-  const release = useCallback((player: AudioPlayer | null) => {
-    if (player) {
-      // Pause first: remove() tears the player down but does not always silence
-      // it synchronously, so a rapid re-tap could otherwise stack overlapping
-      // recitations. Pausing stops the sound immediately.
-      try {
-        player.pause();
-      } catch {
-        /* already released */
-      }
-      try {
-        player.remove();
-      } catch {
-        /* already released */
-      }
+  // The one persistent player, created lazily and re-sourced with replace().
+  const ensurePlayer = useCallback((src: string): AudioPlayer => {
+    if (!playerRef.current) {
+      playerRef.current = createAudioPlayer({ uri: src });
+    } else {
+      playerRef.current.replace({ uri: src });
     }
+    return playerRef.current;
   }, []);
 
   const stop = useCallback(() => {
+    // Bump the token and settle the in-flight āyah loop so it halts at once,
+    // then pause the single player — pausing is immediate, so the audio stops
+    // the instant the button is tapped.
     tokenRef.current += 1;
     settleRef.current?.();
     setPlayingKey(null);
     setBuffering(false);
     setActiveWord(-1);
-    const player = playerRef.current;
-    playerRef.current = null;
-    release(player);
-  }, [release]);
+    try {
+      playerRef.current?.pause();
+    } catch {
+      /* not playing */
+    }
+  }, []);
 
   const playFrom = useCallback(
     (verses: VerseKey[], start: VerseKey, advance: boolean) => {
@@ -111,109 +114,130 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
       const queue = advance ? verses.slice(startIdx) : [verses[startIdx]!];
       const token = ++tokenRef.current;
       // Settle any in-flight āyah loop now so its poll/listener tear down at
-      // once (a stale loop would otherwise linger until its stall timeout).
+      // once, and flip the UI to "playing" immediately (the audio itself still
+      // has to fetch timings/buffer, but the button responds instantly).
       settleRef.current?.();
+      setPlayingKey(verseKeyOf(start));
+      setBuffering(true);
+      setActiveWord(-1);
 
       void (async () => {
         setAudioModeAsync({ playsInSilentMode: true }).catch(() => {});
-        release(playerRef.current);
-        playerRef.current = null;
 
         do {
-        for (const v of queue) {
-          if (tokenRef.current !== token) return;
-          const key = verseKeyOf(v);
-          setPlayingKey(key);
-          setBuffering(true);
-          setActiveWord(-1);
-
-          let src: string | undefined;
-          let segments: Segment[] | null = null;
-          if (reciter.quranComId) {
-            const timing = await fetchTiming(reciter.quranComId, key);
+          for (const v of queue) {
             if (tokenRef.current !== token) return;
-            if (timing) {
-              src = timing.url;
-              segments = timing.segments;
+            const key = verseKeyOf(v);
+            setPlayingKey(key);
+            setBuffering(true);
+            setActiveWord(-1);
+
+            let src: string | undefined;
+            let segments: Segment[] | null = null;
+            if (reciter.quranComId) {
+              const timing = await fetchTiming(reciter.quranComId, key);
+              if (tokenRef.current !== token) return;
+              if (timing) {
+                src = timing.url;
+                segments = timing.segments;
+              }
             }
-          }
-          src ??= reciterAudioUrl(reciter, v);
+            src ??= reciterAudioUrl(reciter, v);
 
-          const player = createAudioPlayer({ uri: src });
-          playerRef.current = player;
-          player.play();
+            const player = ensurePlayer(src);
+            if (tokenRef.current !== token) return;
 
-          await new Promise<void>((resolve) => {
-            let settled = false;
-            let lastTime = -1;
-            let lastWord = -1;
-            let timer: ReturnType<typeof setTimeout>;
-            const done = () => {
-              if (settled) return;
-              settled = true;
-              clearTimeout(timer);
-              clearInterval(poll);
-              sub.remove();
-              settleRef.current = null;
-              resolve();
-            };
-            const arm = () => {
-              clearTimeout(timer);
-              timer = setTimeout(done, STALL_MS);
-            };
-            // End-of-āyah advance comes from the status event; the word
-            // highlight and stall detection are driven by a tight poll of the
-            // real playback position so the highlight tracks the audio instead
-            // of lagging behind the coarse status-update cadence.
-            const sub = player.addListener("playbackStatusUpdate", (status) => {
-              if (status.didJustFinish) done();
-            });
-            const poll = setInterval(() => {
-              let t: number;
-              try {
-                t = player.currentTime;
-              } catch {
-                return;
-              }
-              if (typeof t !== "number" || Number.isNaN(t) || t <= 0) return;
-              setBuffering(false);
-              if (t !== lastTime) {
-                lastTime = t;
-                arm();
-              }
-              if (segments) {
-                const ms = t * 1000;
-                let index = -1;
-                for (const seg of segments) {
-                  if (ms >= seg[2] && ms < seg[3]) {
-                    index = seg[0];
-                    break;
+            await new Promise<void>((resolve) => {
+              let settled = false;
+              let lastTime = -1;
+              let lastWord = -1;
+              let timer: ReturnType<typeof setTimeout>;
+              const done = () => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timer);
+                clearInterval(poll);
+                sub.remove();
+                settleRef.current = null;
+                resolve();
+              };
+              const arm = () => {
+                clearTimeout(timer);
+                timer = setTimeout(done, STALL_MS);
+              };
+              // End-of-āyah advance comes from the status event; the word
+              // highlight and stall detection are driven by a tight poll of the
+              // real playback position so the highlight tracks the audio
+              // instead of lagging behind the coarse status-update cadence.
+              const sub = player.addListener("playbackStatusUpdate", (status) => {
+                if (status.didJustFinish) done();
+              });
+              const poll = setInterval(() => {
+                let t: number;
+                try {
+                  t = player.currentTime;
+                } catch {
+                  return;
+                }
+                if (typeof t !== "number" || Number.isNaN(t) || t <= 0) return;
+                setBuffering(false);
+                if (t !== lastTime) {
+                  lastTime = t;
+                  arm();
+                }
+                if (segments) {
+                  const ms = t * 1000;
+                  let index = -1;
+                  for (const seg of segments) {
+                    if (ms >= seg[2] && ms < seg[3]) {
+                      index = seg[0];
+                      break;
+                    }
+                  }
+                  if (index !== lastWord) {
+                    lastWord = index;
+                    setActiveWord(index);
                   }
                 }
-                if (index !== lastWord) {
-                  lastWord = index;
-                  setActiveWord(index);
-                }
-              }
-            }, 60);
-            settleRef.current = done;
-            arm();
-          });
+              }, POLL_MS);
+              settleRef.current = done;
+              player.play();
+              arm();
+            });
 
-          release(player);
-          if (tokenRef.current !== token) return;
-        }
-        // Repeat the whole range while loop is on (read live via the ref).
+            if (tokenRef.current !== token) return;
+          }
+          // Repeat the whole range while loop is on (read live via the ref).
         } while (loopRef.current && tokenRef.current === token);
+
         if (tokenRef.current === token) {
+          try {
+            playerRef.current?.pause();
+          } catch {
+            /* already paused */
+          }
           setPlayingKey(null);
           setBuffering(false);
           setActiveWord(-1);
         }
       })();
     },
-    [reciter, release],
+    [reciter, ensurePlayer],
   );
+
+  // Tear the player down when the screen leaves so no poll/interval lingers.
+  useEffect(() => {
+    return () => {
+      tokenRef.current += 1;
+      settleRef.current?.();
+      try {
+        playerRef.current?.remove();
+      } catch {
+        /* already gone */
+      }
+      playerRef.current = null;
+    };
+  }, []);
 
   return { playingKey, buffering, activeWord, loop, setLoop, playFrom, stop };
 }

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -220,6 +220,26 @@ export function SurahReaderScreen({ navigation, route }: Props) {
   }).current;
   const viewabilityConfig = useRef({ itemVisiblePercentThreshold: 10 }).current;
 
+  // Auto-scroll: keep the playing āyah in view as the recitation advances. Only
+  // applies to the virtualized translation list; the index may not be measured
+  // yet (it's off-screen) so onScrollToIndexFailed retries after a beat.
+  const listRef = useRef<FlatList<(typeof rows)[number]>>(null);
+  const indexOfKey = useMemo(() => {
+    const m = new Map<string, number>();
+    rows.forEach((r, i) => m.set(r.key, i));
+    return m;
+  }, [rows]);
+  useEffect(() => {
+    if (readingMode !== "translation" || !playingKey) return;
+    const index = indexOfKey.get(playingKey);
+    if (index == null) return;
+    try {
+      listRef.current?.scrollToIndex({ index, animated: true, viewPosition: 0.3 });
+    } catch {
+      /* list not ready */
+    }
+  }, [playingKey, readingMode, indexOfKey]);
+
   const shortlist = useMemo(
     () => editions.map((id) => metaById.get(id)).filter((x): x is Translation => Boolean(x)),
     [editions, metaById],
@@ -328,6 +348,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         // with the stable callbacks above, a word-tick re-renders just the
         // playing āyah instead of the whole list.
         <FlatList
+          ref={listRef}
           data={rows}
           keyExtractor={(r) => r.key}
           renderItem={renderItem}
@@ -335,6 +356,20 @@ export function SurahReaderScreen({ navigation, route }: Props) {
           contentContainerStyle={styles.content}
           onViewableItemsChanged={onViewable}
           viewabilityConfig={viewabilityConfig}
+          onScrollToIndexFailed={(info) => {
+            // Target āyah isn't measured yet — settle, then retry once.
+            setTimeout(() => {
+              try {
+                listRef.current?.scrollToIndex({
+                  index: info.index,
+                  animated: true,
+                  viewPosition: 0.3,
+                });
+              } catch {
+                /* give up quietly */
+              }
+            }, 350);
+          }}
           initialNumToRender={8}
           maxToRenderPerBatch={8}
           windowSize={11}


### PR DESCRIPTION
Second round of reader fixes from on-device testing (vc4): parallel recitations still happened intermittently, the reader didn't follow the recitation, and play/pause felt laggy.

## Root cause
The hook created a **new native `AudioPlayer` for every āyah** and relied on `remove()` to stop the previous one — that's the parallel-audio race, and constant native allocate/free churn (plus any lingering poll intervals) drove app-wide lag.

## Fix — one persistent player
- **Single `AudioPlayer`** re-sourced per āyah with `replace()`. One player physically cannot play two streams, so a fast re-tap just re-sources it — **parallel recitation is now structurally impossible**.
- **Optimistic play/pause** — tapping flips the UI and pauses the player immediately, instead of waiting on async teardown.
- **Auto-scroll** — the reader follows the playing āyah (`FlatList.scrollToIndex`, `viewPosition: 0.3`, with an `onScrollToIndexFailed` retry for off-screen āyāt).
- **No leaks** — the player is removed on unmount so no poll/interval lingers between visits.

## Verification
- `lint`, `typecheck`, `test` (426) pass; reader renders in Expo Web (FlatList + new hook, no crash).
- ⚠️ Audio playback/sync/auto-scroll-during-recitation need the device + network — to re-test on the next internal-testing build.