### PR TITLE
fix(mobile): continue-reading progress bar (design parity)

### DIFF
--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -18,6 +18,7 @@ import { useTheme, type Palette } from "../theme";
 import { useLibrary } from "../state/LibraryContext";
 import { AyahBadge } from "../components/AyahBadge";
 import { verseOfToday } from "../verses";
+import { readReadingState } from "../reading-goals";
 import { KEYS, getJSON, getString } from "../storage";
 import { fmtCountdown, fmtTime, localISODate } from "../utils";
 import type { HomeStackParamList } from "../navigation/types";
@@ -31,10 +32,15 @@ export function HomeScreen({ navigation }: Props) {
   const [surahs, setSurahs] = useState<Surah[] | null>(null);
   const [timings, setTimings] = useState<PrayerTimings | null>(null);
   const [now, setNow] = useState(() => new Date());
+  // Reading progress (daily pages / goal) for the continue-reading progress bar.
+  const [readPct, setReadPct] = useState(0);
 
   useEffect(() => {
     let active = true;
     void api.listSurahs().then((s) => active && setSurahs(s)).catch(() => undefined);
+    void readReadingState().then((s) => {
+      if (active) setReadPct(Math.min(1, s.goal > 0 ? s.pagesToday / s.goal : 0));
+    });
     return () => {
       active = false;
     };
@@ -126,6 +132,10 @@ export function HomeScreen({ navigation }: Props) {
                 </Text>
               </View>
               <Text style={styles.continueAr}>{last.name}</Text>
+            </View>
+            {/* Progress bar (design: h6 · radius3, gold) — daily reading progress */}
+            <View style={styles.progressTrack}>
+              <View style={[styles.progressFill, { width: `${Math.round(readPct * 100)}%` }]} />
             </View>
           </Pressable>
         )}
@@ -221,6 +231,14 @@ function makeStyles(c: Palette) {
     continueName: { color: c.fg, fontSize: 17, fontFamily: FONT.bold },
     continueSub: { color: c.muted, fontSize: 13.5, marginTop: 2 },
     continueAr: { color: c.accentHi, fontSize: 24, writingDirection: "rtl", fontFamily: FONT.ar },
+    progressTrack: {
+      height: 6,
+      borderRadius: 3,
+      backgroundColor: c.bg,
+      marginTop: 16,
+      overflow: "hidden",
+    },
+    progressFill: { height: "100%", borderRadius: 3, backgroundColor: c.accent },
     prayerStrip: {
       flexDirection: "row",
       alignItems: "center",


### PR DESCRIPTION
Design-parity pass against **docs/design/noor-prototype-mobile** (the mobile reference — not the web app).

## Finding
Diffed app screens against the prototype frames. The app already follows the mobile design closely (Home, Surah-list rows, Tasbih, Adhkar all match the spec). The one genuine missing specced element on Home:

- The Home·Today frame specs a gold **progress bar** (`h6 · radius3`) under the continue-reading card; the app had none. Added it, bound to daily reading progress (pages/goal).

(My earlier perception that mobile "didn't follow the design" came from comparing against the *web* app, which is a different, richer reference. Against the correct mobile prototype, the gaps are minor polish.)

## Verification
- `typecheck` passes; rendered in Expo Web against the prototype frame — Home now matches.

## Documented (not changed — judgment calls)
- Surah-list: design uses a `Surah/Juzʾ/Revelation` segmented control; app uses juz-chips (feature difference).
- Tasbih: design title "Tasbih Counter" + dhikr chips above the dial; app is functionally richer (target chips).
- Bottom tabs: design `Search/Dhikr`; app keeps `Tools/Memorize` (user's choice).