### PR TITLE
fix(mobile): native crash on Read/Plans tabs (shared Seg → inline control)

### DIFF
--- a/apps/mobile/src/screens/PlansScreen.tsx
+++ b/apps/mobile/src/screens/PlansScreen.tsx
@@ -3,7 +3,7 @@ import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "../Typ
 import Svg, { Circle } from "react-native-svg";
 import { useFocusEffect } from "@react-navigation/native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { Icon, Khatam, Seg } from "@ummahlibrary/ui";
+import { Icon, Khatam } from "@ummahlibrary/ui";
 import { useTheme, type Palette } from "../theme";
 import { FONT } from "../fonts";
 import {
@@ -290,15 +290,20 @@ export function PlansScreen({ navigation }: Props) {
         </Pressable>
       ) : (
         <View style={styles.customCard}>
-          <Seg
-            options={[
-              { value: "pace", label: "Pages a day" },
-              { value: "duration", label: "Finish in…" },
-            ]}
-            value={mode}
-            onChange={(v) => setMode(v as "pace" | "duration")}
-            size="sm"
-          />
+          <View style={styles.seg}>
+            {([
+              { v: "pace", l: "Pages a day" },
+              { v: "duration", l: "Finish in…" },
+            ] as const).map((o) => (
+              <Pressable
+                key={o.v}
+                onPress={() => setMode(o.v)}
+                style={[styles.segItem, mode === o.v && styles.segItemOn]}
+              >
+                <Text style={[styles.segText, mode === o.v && styles.segTextOn]}>{o.l}</Text>
+              </Pressable>
+            ))}
+          </View>
           <Text style={styles.customLabel}>{mode === "pace" ? "Pages a day" : "Days to finish"}</Text>
           <TextInput
             value={mode === "pace" ? perDay : days}
@@ -510,6 +515,18 @@ function makeStyles(c: Palette) {
       backgroundColor: c.bgElev,
     },
     customLabel: { color: c.muted, fontSize: 13, marginTop: 14 },
+    seg: {
+      flexDirection: "row",
+      backgroundColor: c.bgElev,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 10,
+      padding: 3,
+    },
+    segItem: { flex: 1, paddingVertical: 7, borderRadius: 8, alignItems: "center" },
+    segItemOn: { backgroundColor: c.accent },
+    segText: { color: c.muted, fontSize: 13, fontFamily: FONT.semibold },
+    segTextOn: { color: c.ink, fontFamily: FONT.bold },
     input: {
       marginTop: 6,
       paddingVertical: 11,

--- a/apps/mobile/src/screens/SurahListScreen.tsx
+++ b/apps/mobile/src/screens/SurahListScreen.tsx
@@ -11,7 +11,6 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { TOTAL_JUZ, type Surah } from "@ummahlibrary/core";
-import { Seg } from "@ummahlibrary/ui";
 import { api } from "../api";
 import { FONT } from "../fonts";
 import { useTheme, type Palette } from "../theme";
@@ -100,17 +99,20 @@ export function SurahListScreen({ navigation }: Props) {
               onChangeText={setQuery}
               autoCorrect={false}
             />
-            <View style={styles.segWrap}>
-              <Seg
-                options={[
-                  { value: "surah", label: "Surah" },
-                  { value: "juz", label: "Juzʾ" },
-                  { value: "rev", label: "Revelation" },
-                ]}
-                value={tab}
-                onChange={(v) => setTab(v as Tab)}
-                size="sm"
-              />
+            <View style={styles.seg}>
+              {([
+                { v: "surah", l: "Surah" },
+                { v: "juz", l: "Juzʾ" },
+                { v: "rev", l: "Revelation" },
+              ] as const).map((o) => (
+                <Pressable
+                  key={o.v}
+                  style={[styles.segItem, tab === o.v && styles.segItemOn]}
+                  onPress={() => setTab(o.v)}
+                >
+                  <Text style={[styles.segText, tab === o.v && styles.segTextOn]}>{o.l}</Text>
+                </Pressable>
+              ))}
             </View>
             {error && <Text style={styles.error}>Couldn’t load surahs. Check your connection.</Text>}
             {!surahs && !error && <ActivityIndicator color={colors.accent} style={styles.spinner} />}
@@ -174,7 +176,19 @@ function makeStyles(c: Palette) {
       fontSize: 15,
       marginBottom: 14,
     },
-    segWrap: { marginBottom: 6 },
+    seg: {
+      flexDirection: "row",
+      backgroundColor: c.bgElev,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 10,
+      padding: 3,
+      marginBottom: 6,
+    },
+    segItem: { flex: 1, paddingVertical: 7, borderRadius: 8, alignItems: "center" },
+    segItemOn: { backgroundColor: c.accent },
+    segText: { color: c.muted, fontSize: 13, fontFamily: FONT.semibold },
+    segTextOn: { color: c.ink, fontFamily: FONT.bold },
     sectionLabel: {
       color: c.faint,
       fontSize: 12,


### PR DESCRIPTION
**Caught by testing on a real Android emulator** — not visible in Expo Web.

## The crash
Tapping the **Read** tab crashed the app (`Ummah Library keeps stopping`). Logcat:
```
useNoorTheme  ←  Seg  ←  renderWithHooks ...
Error: useNoorTheme must be used inside NoorThemeProvider
```
The shared `@ummahlibrary/ui` `Seg` resolves to **`Seg.native.tsx`** on device, which calls `useNoorTheme()`. That context isn't delivered to it in the RN bundle, so it throws. **Every prior verification was Expo Web**, which uses `Seg.tsx` (no `useNoorTheme`) — so the native path was never exercised. `PlansScreen` used `Seg` too → same latent crash (Plans is rarely opened, so nobody hit it).

## Fix
Replace the shared `Seg` with an **inline segmented control** built on the app's own `useTheme` (the pattern `ReaderControls` already uses) — in `SurahList` (the new Surah/Juzʾ/Revelation control) and `Plans` (the pace/duration toggle). No mobile screen imports the shared `Seg` anymore.

## Verified on emulator (Android 14)
- Read tab + Plans no longer crash (after this fix, rebuilt).
- Also confirmed natively in the same session: audio **plays**, word-highlight **syncs**, **auto-scroll** works, and **no overlap** (single audio `session:225` even under rapid taps); status-bar safe-area fix holds on Home/More.
- `lint`, `typecheck`, `test` (426) pass.