### PR TITLE
fix(mobile): guard invalid surah/juz refs + lighter āyah rendering

### DIFF
--- a/apps/mobile/src/components/AyahView.tsx
+++ b/apps/mobile/src/components/AyahView.tsx
@@ -88,12 +88,17 @@ function AyahViewImpl({
         style={[styles.arabic, { fontSize: 26 * scale, lineHeight: 50 * scale }]}
         onPress={() => onPlayFrom(aya)}
       >
-        {words.map((w, i) => (
-          <Text key={i} style={playing && i === activeWord ? styles.wordActive : undefined}>
-            {w}
-            {i < words.length - 1 ? " " : ""}
-          </Text>
-        ))}
+        {/* Only the playing āyah splits into per-word spans (for highlighting);
+            every other āyah renders as a single text node, which keeps long
+            surahs cheap to scroll. */}
+        {playing
+          ? words.map((w, i) => (
+              <Text key={i} style={i === activeWord ? styles.wordActive : undefined}>
+                {w}
+                {i < words.length - 1 ? " " : ""}
+              </Text>
+            ))
+          : arabic}
       </Text>
 
       {translations.map((t) => (

--- a/apps/mobile/src/screens/JuzReaderScreen.tsx
+++ b/apps/mobile/src/screens/JuzReaderScreen.tsx
@@ -53,7 +53,14 @@ export function JuzReaderScreen({ route }: Props) {
     let active = true;
     setLines(null);
     setError(false);
-    const parts = juzRange(juz);
+    if (!Number.isInteger(Number(juz)) || Number(juz) < 1 || Number(juz) > TOTAL_JUZ) {
+      setError(true);
+      return () => {
+        active = false;
+        audio.stop();
+      };
+    }
+    const parts = juzRange(Number(juz));
     Promise.all(
       parts.map(async (p) => {
         const [surah, tr] = await Promise.all([

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -126,6 +126,15 @@ export function SurahReaderScreen({ navigation, route }: Props) {
 
   useEffect(() => {
     setError(false);
+    // Clear the previous surah's data immediately so a rapid surah→surah
+    // navigation never pairs a new `n` with stale `ayahs` (which would feed an
+    // out-of-range ref to pageNumberOf and throw).
+    setMeta(null);
+    setAyahs(null);
+    if (!Number.isInteger(n) || n < 1 || n > TOTAL_SURAHS) {
+      setError(true);
+      return;
+    }
     api
       .getSurah(n)
       .then((d) => {


### PR DESCRIPTION
Found via emulator brute-force testing. (1) Rapid surah→surah deep-link nav crashed with `RangeError: Invalid verse reference` (stale ayahs + new sura → out-of-range pageNumberOf); fixed by clearing data on n-change + range-validating surah/juz. (2) Perf: āyāt split into per-word Text spans even when not playing; now only the playing āyah splits. lint/typecheck/426 tests pass.