### PR TITLE
fix(mobile/core): stale-fetch crash + Hermes-safe search

### DIFF
--- a/apps/mobile/src/screens/SurahListScreen.tsx
+++ b/apps/mobile/src/screens/SurahListScreen.tsx
@@ -19,13 +19,30 @@ import type { ReadStackParamList } from "../navigation/types";
 
 type Props = NativeStackScreenProps<ReadStackParamList, "SurahList">;
 
-/** Lowercase + strip diacritics for accent-insensitive search. */
+/**
+ * Normalise surah names for forgiving search. The dataset uses ASCII phonetic
+ * spellings with doubled long vowels ("Al-Faatiha", "An-Nisaa"), so a user
+ * typing "fatiha" / "nisa" wouldn't match. Lowercase, map any diacritics,
+ * drop hamza/ʿayn/apostrophes, and collapse repeated vowels — all without
+ * String.normalize (Hermes doesn't implement NFD).
+ */
 const fold = (s: string): string =>
   s
-    .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
-    .trim()
-    .toLowerCase();
+    .toLowerCase()
+    .replace(/[āáàâ]/g, "a")
+    .replace(/[īíìî]/g, "i")
+    .replace(/[ūúùû]/g, "u")
+    .replace(/[ēéè]/g, "e")
+    .replace(/[ōóò]/g, "o")
+    .replace(/ḥ/g, "h")
+    .replace(/ḍ/g, "d")
+    .replace(/ṣ/g, "s")
+    .replace(/ṭ/g, "t")
+    .replace(/ẓ/g, "z")
+    .replace(/ṇ/g, "n")
+    .replace(/[ʿʾʼʻ'’]/g, "")
+    .replace(/([aeiou])\1+/g, "$1")
+    .trim();
 
 type Tab = "surah" | "juz" | "rev";
 type Row =

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -103,7 +103,9 @@ export function SurahReaderScreen({ navigation, route }: Props) {
 
   // Count the opening page so short sūrahs (no scroll) still register.
   useEffect(() => {
-    if (ayahs?.length) recordPage(pageNumberOf({ sura: n, aya: ayahs[0]?.aya ?? 1 }));
+    if (ayahs?.length && n >= 1 && n <= TOTAL_SURAHS) {
+      recordPage(pageNumberOf({ sura: n, aya: ayahs[0]?.aya ?? 1 }));
+    }
   }, [ayahs, n, recordPage]);
 
   useLayoutEffect(() => {
@@ -135,13 +137,20 @@ export function SurahReaderScreen({ navigation, route }: Props) {
       setError(true);
       return;
     }
+    // `active` guards against an in-flight fetch for a previous surah resolving
+    // after `n` has already changed and writing its ayahs onto the new surah.
+    let active = true;
     api
       .getSurah(n)
       .then((d) => {
+        if (!active) return;
         setMeta(d.surah);
         setAyahs(d.ayahs);
       })
-      .catch(() => setError(true));
+      .catch(() => active && setError(true));
+    return () => {
+      active = false;
+    };
   }, [n]);
 
   // Fetch every selected edition's text for this surah.
@@ -222,9 +231,10 @@ export function SurahReaderScreen({ navigation, route }: Props) {
   // auto-advance. Kept in a ref because RN forbids changing the handler.
   const onViewable = useRef(({ viewableItems }: { viewableItems: ViewToken[] }) => {
     const aya = (viewableItems[0]?.item as { aya?: number } | undefined)?.aya;
-    if (aya != null) {
+    const s = nRef.current;
+    if (aya != null && s >= 1 && s <= TOTAL_SURAHS) {
       topAyaRef.current = aya;
-      recordPage(pageNumberOf({ sura: nRef.current, aya }));
+      recordPage(pageNumberOf({ sura: s, aya }));
     }
   }).current;
   const viewabilityConfig = useRef({ itemVisiblePercentThreshold: 10 }).current;

--- a/packages/core/src/translations.ts
+++ b/packages/core/src/translations.ts
@@ -24,9 +24,22 @@ export interface LanguageGroup {
 /** Lowercase and strip diacritics so "Jalāl" matches a search for "jalal". */
 export function normalize(value: string): string {
   return value
+    .toLowerCase()
+    .replace(/[\u0101\u00e1\u00e0\u00e2\u00e4]/g, "a")
+    .replace(/[\u012b\u00ed\u00ec\u00ee]/g, "i")
+    .replace(/[\u016b\u00fa\u00f9\u00fb]/g, "u")
+    .replace(/[\u0113\u00e9\u00e8\u00ea]/g, "e")
+    .replace(/[\u014d\u00f3\u00f2\u00f4]/g, "o")
+    .replace(/\u1e25/g, "h")
+    .replace(/\u1e0d/g, "d")
+    .replace(/[\u1e63\u0161]/g, "s")
+    .replace(/\u1e6d/g, "t")
+    .replace(/\u1e93/g, "z")
+    .replace(/\u1e47/g, "n")
+    .replace(/\u0121/g, "g")
+    .replace(/[\u02bf\u02be\u02bc\u02bb]/g, "")
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
     .trim();
 }
 


### PR DESCRIPTION
Three device-only fixes from emulator re-testing: (1) stale getSurah fetch could still throw Invalid verse reference on rapid nav — added active-flag + range guards at all pageNumberOf sites; (2) surah search was broken on Hermes (String.normalize is a no-op there) and the data uses doubled-vowel spellings — Hermes-safe fold + vowel collapse so 'fatiha'→Al-Faatiha; (3) same Hermes normalize issue in core search/edition filtering — fixed. lint/typecheck/all tests pass.