### PR TITLE
fix(web): surface Ramadan, Duʿās & Reading Plans in the Tools hub

### DIFF
--- a/apps/web/src/app/tools/page.tsx
+++ b/apps/web/src/app/tools/page.tsx
@@ -5,7 +5,10 @@ import { ToolsPrayerCard } from "../../components/ToolsPrayerCard";
 
 const TOOLS = [
   { key: "/prayer-times", label: "Prayer Times", glyph: "🕌", note: "Daily salah times" },
+  { key: "/ramadan", label: "Ramadan", glyph: "🌙", note: "Suḥūr & iftār times" },
   { key: "/tracker", label: "Prayer Tracker", glyph: "📿", note: "Log & build streaks" },
+  { key: "/duas", label: "Duʿās", glyph: "🤲", note: "Fortress of the Muslim" },
+  { key: "/plans", label: "Reading Plans", glyph: "🗺", note: "Structured journeys" },
   { key: "/qibla", label: "Qibla", glyph: "🧭", note: "118° SE · Direction to Makkah" },
   { key: "/hifz", label: "Hifz Review", glyph: "✦", note: "Spaced repetition" },
   { key: "/calendar", label: "Hijri Calendar", glyph: "☾", note: "Islamic dates" },


### PR DESCRIPTION
## What

The **Worship & Tools** grid (`/tools`) was missing three tools that already
exist as routes and that the Noor design prototype includes:

- **Ramadan** → `/ramadan`
- **Duʿās** → `/duas`
- **Reading Plans** → `/plans`

They were only reachable from the sidebar, so the Tools hub was out of sync
with the design. This adds them to the grid in the design's order, giving the
hub all 13 tiles the prototype shows.

## Why

Found during a full per-screen comparison of the live web app against the
`docs/design/noor-prototype/` web design. Every other screen matched; this was
the one genuine design-sync gap (the remaining differences were content/state,
e.g. the plan catalog coming from `core` or empty-vs-seeded states).

## Verification

- All ~22 screens compared proto-vs-app at desktop width — Tools is the only fix.
- Location-gated features (Prayer Times, Qibla, Ramadan, Tracker) regression-tested
  live with geolocation granted — all working.
- `eslint` clean · `tsc --noEmit` passes · `next build` succeeds (all routes
  prerendered) · 426/426 unit tests pass.

## Screenshot

Tools grid now renders: Prayer Times · Ramadan · Prayer Tracker · Duʿās ·
Reading Plans · Qibla · Hifz Review · Hijri Calendar · 99 Names · Tasbih ·
Adhkār · Zakat · Hadith.