### PR TITLE
chore(web): make ummahlibrary.org the canonical origin

### DIFF
--- a/apps/web/src/app/api/v1/openapi.json/route.ts
+++ b/apps/web/src/app/api/v1/openapi.json/route.ts
@@ -1,4 +1,5 @@
 import { apiJson } from "../../../../lib/api-response";
+import { SITE_URL } from "../../../../lib/site";
 
 export const dynamic = "force-static";
 
@@ -10,7 +11,7 @@ const spec = {
     description: "Read-only public API for the Quran text and translations.",
     license: { name: "AGPL-3.0-only" },
   },
-  servers: [{ url: "https://app.ummahlibrary.org/api/v1" }],
+  servers: [{ url: `${SITE_URL}/api/v1` }],
   paths: {
     "/surahs": {
       get: {

--- a/apps/web/src/app/juz/[number]/page.tsx
+++ b/apps/web/src/app/juz/[number]/page.tsx
@@ -17,6 +17,7 @@ import { AyahTranslations } from "../../../components/AyahTranslations";
 import { AyahStar } from "../../../components/AyahStar";
 import { ReadingTranslationFlow } from "../../../components/ReadingTranslationFlow";
 import { ReaderShortcuts } from "../../../components/ReaderShortcuts";
+import { SITE_URL } from "../../../lib/site";
 import { WordByWord } from "../../../components/WordByWord";
 
 const RECITERS = pluginRegistry.byKind("reciter");
@@ -107,7 +108,7 @@ export default async function JuzReaderPage({ params }: { params: Promise<{ numb
     inLanguage: "ar",
     position: n,
     isPartOf: { "@type": "Book", name: "The Holy Quran" },
-    url: `https://app.ummahlibrary.org/juz/${n}`,
+    url: `${SITE_URL}/juz/${n}`,
     license: "https://www.gnu.org/licenses/agpl-3.0.html",
   };
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { AdhkarReminderBanner } from "../components/AdhkarReminderBanner";
 import { PrayerReminderScheduler } from "../components/PrayerReminderScheduler";
 import { PlanReminderScheduler } from "../components/PlanReminderScheduler";
 import { AppShellWrapper } from "../components/AppShellWrapper";
+import { SITE_URL } from "../lib/site";
 import "./globals.css";
 
 /* ── Noor fonts ── */
@@ -32,7 +33,7 @@ const amiri = Amiri({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://app.ummahlibrary.org"),
+  metadataBase: new URL(SITE_URL),
   title: { default: "Ummah Library", template: "%s · Ummah Library" },
   description:
     "An open-source Quran reader — read the Quran with translations, recitations, tafsir and Islamic tools.",

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "../lib/site";
 
-const BASE = "https://app.ummahlibrary.org";
+const BASE = SITE_URL;
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,7 +1,8 @@
 import type { MetadataRoute } from "next";
 import { TOTAL_JUZ, TOTAL_PAGES_MADANI, TOTAL_SURAHS } from "@ummahlibrary/core";
+import { SITE_URL } from "../lib/site";
 
-const BASE = "https://app.ummahlibrary.org";
+const BASE = SITE_URL;
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes = [

--- a/apps/web/src/app/surah/[number]/page.tsx
+++ b/apps/web/src/app/surah/[number]/page.tsx
@@ -4,6 +4,7 @@ import { N } from "@ummahlibrary/ui";
 import { SurahReaderClient } from "../../../components/SurahReaderClient";
 import { TOTAL_SURAHS, isValidSurahNumber } from "@ummahlibrary/core";
 import { pluginRegistry, quranRepository } from "@ummahlibrary/api";
+import { SITE_URL } from "../../../lib/site";
 
 const RECITERS = pluginRegistry.byKind("reciter");
 const TAFSIRS = pluginRegistry.byKind("tafsir").map((t) => ({ id: t.id, name: t.name }));
@@ -68,7 +69,7 @@ export default async function SurahPage({ params }: { params: Promise<{ number: 
     inLanguage: "ar",
     position: surah.number,
     isPartOf: { "@type": "Book", name: "The Holy Quran" },
-    url: `https://app.ummahlibrary.org/surah/${surah.number}`,
+    url: `${SITE_URL}/surah/${surah.number}`,
     license: "https://www.gnu.org/licenses/agpl-3.0.html",
   };
 

--- a/apps/web/src/lib/share-image.ts
+++ b/apps/web/src/lib/share-image.ts
@@ -4,6 +4,8 @@
  * (independent of the app theme) so the image looks right wherever it's shared.
  */
 
+import { SITE_HOST } from "./site";
+
 const WIDTH = 1080;
 const PAD = 88;
 const BG = "#0b1f17";
@@ -105,7 +107,7 @@ export async function renderAyahImage(input: AyahImageInput): Promise<Blob | nul
   ctx.textAlign = "right";
   ctx.fillStyle = MUTED;
   ctx.font = "26px system-ui, sans-serif";
-  ctx.fillText("app.ummahlibrary.org", WIDTH - PAD, height - PAD + 10);
+  ctx.fillText(SITE_HOST, WIDTH - PAD, height - PAD + 10);
 
   return new Promise((resolve) => canvas.toBlob((b) => resolve(b), "image/png"));
 }
@@ -181,7 +183,7 @@ export async function renderPlanCardImage(input: PlanCardInput): Promise<Blob | 
 
   ctx.fillStyle = MUTED;
   ctx.font = "28px system-ui, sans-serif";
-  ctx.fillText("app.ummahlibrary.org", cx, SIZE - 90);
+  ctx.fillText(SITE_HOST, cx, SIZE - 90);
 
   return new Promise((resolve) => canvas.toBlob((b) => resolve(b), "image/png"));
 }

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -1,0 +1,13 @@
+/**
+ * The canonical public origin of the web app — the single source of truth for
+ * every absolute URL we emit (metadataBase, sitemap, robots, OpenGraph URLs,
+ * the OpenAPI server, and the share-image watermark).
+ *
+ * Override per environment with `NEXT_PUBLIC_SITE_URL` (e.g. a preview deploy);
+ * defaults to production. `NEXT_PUBLIC_` is inlined at build time, so this is
+ * safe to read from both server and client (canvas) code.
+ */
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://ummahlibrary.org";
+
+/** Host without the scheme — for display (e.g. the share-image watermark). */
+export const SITE_HOST = SITE_URL.replace(/^https?:\/\//, "");


### PR DESCRIPTION
## What

Moves the web app's primary origin from **`app.ummahlibrary.org`** to the apex
**`ummahlibrary.org`**, and centralises the origin into a single source of truth.

- New `src/lib/site.ts` exports `SITE_URL` (from `NEXT_PUBLIC_SITE_URL`, default
  `https://ummahlibrary.org`) and `SITE_HOST` (scheme-less, for display).
- Every absolute URL now routes through it: `metadataBase`, `sitemap.ts`,
  `robots.ts`, the surah/juz OpenGraph + JSON-LD `url`, the OpenAPI server URL,
  and the share-image watermark (×2).

## Why

The app *is* the site — there's no separate marketing host or login portal
(local-first, no accounts per ADR 0006), so an `app.` subdomain only adds
friction. The apex is shorter, more memorable, more shareable, and consolidates
SEO/canonical authority on one host.

Centralising also means future origin changes (or a preview-deploy override via
`NEXT_PUBLIC_SITE_URL`) touch exactly one file.

## DNS / hosting follow-up (not code)

Point apex `ummahlibrary.org` as primary; keep **`www.` and `app.` as 301
redirects** to it so existing shared links and already-installed PWAs don't 404.

> Note: local-first data is origin-scoped — bookmarks/hifz/settings saved on
> `app.` won't carry to the apex. Worth switching before there's a real user base.

## Verification

- `eslint` clean · `tsc --noEmit` passes · `next build` succeeds (1599 static
  pages) · 426/426 tests pass.
- Built `robots.txt` now emits `Host: https://ummahlibrary.org` and the matching
  sitemap URL; no `app.` subdomain remains anywhere in the build output.