### PR TITLE
fix(mobile): point web URLs at the apex domain

### DIFF
--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -16,7 +16,7 @@ import type {
 } from "@ummahlibrary/core";
 
 const BASE =
-  (process.env.EXPO_PUBLIC_API_BASE_URL ?? "https://app.ummahlibrary.org/api/v1").replace(
+  (process.env.EXPO_PUBLIC_API_BASE_URL ?? "https://ummahlibrary.org/api/v1").replace(
     /\/$/,
     "",
   );

--- a/apps/mobile/src/components/AyahView.tsx
+++ b/apps/mobile/src/components/AyahView.tsx
@@ -58,7 +58,7 @@ function AyahViewImpl({
     const block = [arabic, ...translations.map((t) => t.text), `— ${sura}:${aya}`]
       .filter(Boolean)
       .join("\n");
-    const link = `https://app.ummahlibrary.org/surah/${sura}#${sura}:${aya}`;
+    const link = `https://ummahlibrary.org/surah/${sura}#${sura}:${aya}`;
     void Share.share({ message: `${block}\n${link}` });
   };
 


### PR DESCRIPTION
## What

Updates the two places the mobile app still referenced the old
`app.ummahlibrary.org` subdomain:

- **`src/api.ts`** — API base URL fallback → `https://ummahlibrary.org/api/v1`
  (still overridable via `EXPO_PUBLIC_API_BASE_URL`)
- **`src/components/AyahView.tsx`** — the share-an-ayah link → apex

## Why

Both worked only via the 308 redirect from `app.` → apex — an extra redirect
hop on every API request and an old-domain URL embedded in every shared verse.
Pointing them straight at the apex removes the redirect dependency and keeps
shared links clean. Follows the web change in #107.

## Note

Not in the current `vc8` build (which ships fine via the redirect) — this rides
into the next Android build.

## Verification

- `eslint` clean · mobile `tsc --noEmit` passes
- No `app.ummahlibrary.org` references remain in `apps/mobile`