### PR TITLE
perf(web): code-split share-image renderer + parallelize build loaders

### DIFF
--- a/apps/web/src/app/api/v1/search/corpus/route.ts
+++ b/apps/web/src/app/api/v1/search/corpus/route.ts
@@ -7,10 +7,15 @@ import { apiJson } from "../../../../../lib/api-response";
 export const dynamic = "force-static";
 
 export async function GET() {
-  const verses: { s: number; a: number; t: string }[] = [];
-  for (let s = 1; s <= TOTAL_SURAHS; s++) {
-    const ayahs = await quranRepository.getSurahAyahs(s);
-    for (const ayah of ayahs) verses.push({ s, a: ayah.aya, t: ayah.text });
-  }
+  // Read all 114 suras concurrently (independent local reads), then flatten in
+  // sura order — same payload as a sequential loop, without the round-trips.
+  const perSurah = await Promise.all(
+    Array.from({ length: TOTAL_SURAHS }, (_, i) =>
+      quranRepository
+        .getSurahAyahs(i + 1)
+        .then((ayahs) => ayahs.map((ayah) => ({ s: i + 1, a: ayah.aya, t: ayah.text }))),
+    ),
+  );
+  const verses = perSurah.flat();
   return apiJson({ count: verses.length, verses });
 }

--- a/apps/web/src/app/juz/[number]/page.tsx
+++ b/apps/web/src/app/juz/[number]/page.tsx
@@ -47,18 +47,31 @@ async function loadJuz(numberParam: string) {
   const n = Number(numberParam);
   if (!isValidJuzNumber(n)) return null;
   const { start, end } = juzRange(n);
-  const bismillah = await quranRepository.getBismillah();
+
+  // Fetch the bismillah and every sura in the juzʾ concurrently (independent
+  // local reads), then assemble sections in sura order — same output, no
+  // sequential round-trips.
+  const suraNums: number[] = [];
+  for (let sura = start.sura; sura <= end.sura; sura++) suraNums.push(sura);
+  const [bismillah, perSura] = await Promise.all([
+    quranRepository.getBismillah(),
+    Promise.all(
+      suraNums.map(async (sura) => {
+        const [surah, allAyahs] = await Promise.all([
+          quranRepository.getSurah(sura),
+          quranRepository.getSurahAyahs(sura),
+        ]);
+        return { sura, surah, allAyahs };
+      }),
+    ),
+  ]);
 
   const sections = [];
   const verses: VerseKey[] = [];
-  for (let sura = start.sura; sura <= end.sura; sura++) {
+  for (const { sura, surah, allAyahs } of perSura) {
+    if (!surah) continue;
     const ayaStart = sura === start.sura ? start.aya : 1;
     const ayaEnd = sura === end.sura ? end.aya : ayahCountOf(sura);
-    const [surah, allAyahs] = await Promise.all([
-      quranRepository.getSurah(sura),
-      quranRepository.getSurahAyahs(sura),
-    ]);
-    if (!surah) continue;
     const ayahs = allAyahs
       .filter((a) => a.aya >= ayaStart && a.aya <= ayaEnd)
       .map((a) => ({ aya: a.aya, text: a.text }));

--- a/apps/web/src/components/AyahActions.tsx
+++ b/apps/web/src/components/AyahActions.tsx
@@ -11,7 +11,6 @@ import {
 import { N, Icon } from "@ummahlibrary/ui";
 import type { IconName } from "@ummahlibrary/ui";
 import { newId, readCollections, readNote, writeCollections, writeNote } from "../lib/collections";
-import { renderAyahImage, shareOrDownload } from "../lib/share-image";
 import { isTracked, removeCard, setCard } from "../lib/hifz-store";
 import { TAFSIR_KEY, readTafsir } from "../lib/tafsir";
 
@@ -253,6 +252,9 @@ export function AyahActions({
     try {
       const { arabic, translations } = readAyahText();
       if (!arabic) return;
+      // Loaded on demand so the canvas image-renderer stays out of the reader's
+      // initial bundle — it's only needed when "share as image" is pressed.
+      const { renderAyahImage, shareOrDownload } = await import("../lib/share-image");
       const blob = await renderAyahImage({ arabic, translations, reference: `${surah}:${aya}` });
       if (blob) await shareOrDownload(blob, `${surah}:${aya}`);
     } finally {

--- a/apps/web/src/components/PlanCompletionCard.tsx
+++ b/apps/web/src/components/PlanCompletionCard.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import Link from "next/link";
 import { type ActivePlan, PLAN_TEMPLATES, planDuration, totalUnits, unitWord } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
-import { renderPlanCardImage, shareOrDownload } from "../lib/share-image";
 
 /**
  * Completion milestone for a finished plan (#63): a celebration, a shareable
@@ -23,6 +22,9 @@ export function PlanCompletionCard({ plan }: { plan: ActivePlan }) {
   async function share() {
     setBusy(true);
     try {
+      // Loaded on demand so the canvas image-renderer stays out of the
+      // initial bundle — it's only needed when this button is pressed.
+      const { renderPlanCardImage, shareOrDownload } = await import("../lib/share-image");
       const blob = await renderPlanCardImage({
         heading: "Quran journey complete",
         arabic: "ٱلْحَمْدُ لِلّٰهِ",


### PR DESCRIPTION
From a pass against the Vercel React best-practices rules. Two
behaviour-preserving improvements; no functional change.

## 1. `bundle-conditional` — lazy-load the canvas image renderer
`src/lib/share-image.ts` (~210 lines of Canvas drawing) was a **static** import
in `AyahActions` — which renders on **every āyah** in the reader — and in
`PlanCompletionCard`. But `renderAyahImage` / `renderPlanCardImage` only run
inside the "share as image" click handlers. Moved to a dynamic `import()` inside
those handlers, so the canvas code no longer ships in the initial reader/plan
bundles (only fetched when a user taps share).

## 2. `async-parallel` — parallelize the build-time loaders
The juzʾ loader and `/api/v1/search/corpus` read their suras with sequential
`await` in a loop. Now read concurrently with `Promise.all` and assembled in
sura order. These run at **build time over local data**, so the win is build
speed + cleaner code — but the output is identical.

## Equivalence verification
- **Corpus**: the locally-built payload is **byte-for-byte equal to production**
  — 6236 āyāt, same order, same `s/a/t` values (diffed element-by-element).
- **Juzʾ**: `Promise.all` preserves input order; sections/verses assembled in the
  same sura order as before.
- `eslint` clean · `tsc --noEmit` passes · 426/426 tests · `next build` generates
  all 1599 static pages.

No CRITICAL issues were found in the audit — the app's static-first architecture
already avoids runtime server waterfalls. These were the only genuinely
applicable wins.