### PR TITLE
fix(mobile): reader-audio robustness — silent skips, screen-off playback, highlight re-sync

### DIFF
--- a/apps/mobile/src/audio/useSurahAudio.ts
+++ b/apps/mobile/src/audio/useSurahAudio.ts
@@ -122,7 +122,13 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
       setActiveWord(-1);
 
       void (async () => {
-        setAudioModeAsync({ playsInSilentMode: true }).catch(() => {});
+        // Keep the audio session alive when the app backgrounds (the screen
+        // turns off, the user switches away) so recitation keeps playing
+        // instead of expo-audio auto-pausing it. `playsInSilentMode` is the
+        // iOS counterpart.
+        setAudioModeAsync({ playsInSilentMode: true, shouldPlayInBackground: true }).catch(
+          () => {},
+        );
 
         do {
           for (const v of queue) {
@@ -181,8 +187,25 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
               // real playback position so the highlight tracks the audio
               // instead of lagging behind the coarse status-update cadence.
               const sub = player.addListener("playbackStatusUpdate", (status) => {
-                if (status.playing) started = true;
-                if (status.didJustFinish && started) done();
+                if (status.didJustFinish && started) {
+                  done();
+                  return;
+                }
+                if (status.playing) {
+                  // Genuinely playing: mark this āyah started and (re)start the
+                  // stall countdown.
+                  started = true;
+                  arm();
+                } else if (started && status.isLoaded && !status.isBuffering) {
+                  // Paused after it had been playing, and not mid-buffer — the
+                  // screen went off, a call came in, or the system took audio
+                  // focus. Freeze the stall watchdog so we hold on this āyah and
+                  // its highlight instead of skipping ahead; playback (and the
+                  // poll below) resumes us when audio comes back. A stuck
+                  // *load* (started/buffering) deliberately keeps the watchdog
+                  // armed so it still degrades a flaky connection gracefully.
+                  clearTimeout(timer);
+                }
               });
               const poll = setInterval(() => {
                 let t: number;

--- a/apps/mobile/src/audio/useSurahAudio.ts
+++ b/apps/mobile/src/audio/useSurahAudio.ts
@@ -149,6 +149,17 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
 
             await new Promise<void>((resolve) => {
               let settled = false;
+              // The one reused player lingers in the previous āyah's STATE_ENDED
+              // until replace()+prepare() finishes asynchronously, and expo-audio
+              // reports didJustFinish as a *level* (playbackState === ENDED), not
+              // a one-shot edge. So a freshly-attached listener can observe the
+              // *previous* āyah's leftover "finished" and skip this one in
+              // silence. Gate every advance on this āyah having actually begun:
+              // honour didJustFinish (and the word/stall poll) only once we have
+              // seen real playback — the player report `playing`, or the position
+              // genuinely move forward (a single leaked end-position stays
+              // constant, so it never trips the progress check).
+              let started = false;
               let lastTime = -1;
               let lastWord = -1;
               let timer: ReturnType<typeof setTimeout>;
@@ -170,7 +181,8 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
               // real playback position so the highlight tracks the audio
               // instead of lagging behind the coarse status-update cadence.
               const sub = player.addListener("playbackStatusUpdate", (status) => {
-                if (status.didJustFinish) done();
+                if (status.playing) started = true;
+                if (status.didJustFinish && started) done();
               });
               const poll = setInterval(() => {
                 let t: number;
@@ -180,6 +192,14 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
                   return;
                 }
                 if (typeof t !== "number" || Number.isNaN(t) || t <= 0) return;
+                if (!started) {
+                  // Two increasing samples confirm the new source is really
+                  // advancing (not a stale end-position leaked from the last
+                  // āyah). Until then, ignore the position entirely.
+                  if (lastTime >= 0 && t > lastTime) started = true;
+                  lastTime = t;
+                  if (!started) return;
+                }
                 setBuffering(false);
                 if (t !== lastTime) {
                   lastTime = t;


### PR DESCRIPTION
## The bug

When playing a surah, recitation intermittently goes **silent for 4–5 āyāt** while the highlight and auto-scroll keep advancing, then audio resumes on its own.

## Root cause (native, not JS-visible)

`expo-audio`'s Android player reports `didJustFinish` as a **level**, not an edge:

```kotlin
// AudioPlayer.kt:217
"didJustFinish" to (ref.playbackState == Player.STATE_ENDED),
```

It is `true` on **every** status update while ExoPlayer sits in `STATE_ENDED`.

We keep one reused `AudioPlayer` and re-source it with `replace()` per āyah — but `replace()` → `setMediaSource()` + `prepare()` is **asynchronous**. For a brief window after advancing, the player is *still* in `STATE_ENDED` from the āyah that just finished. The freshly-attached `playbackStatusUpdate` listener (fired immediately by `onMediaItemTransition`) sees that **leftover `didJustFinish: true`** and advances again — skipping the new āyah before it ever plays.

It cascades through several āyāt until a slow quran.com word-timing fetch delays the next `replace()` long enough for the prior `prepare()` to leave `STATE_ENDED`. That race is why it's intermittent, and why it never showed up in web/emulator testing (Expo Web uses HTML `<audio>`, a different path; the race depends on real network timing).

## The fix

Gate every advance on the current āyah having **genuinely started**: honour `didJustFinish` only after the player reports `playing`, or the playback position actually moves forward across two samples (a single leaked end-position stays constant, so it never trips the check). The 8s stall watchdog still skips a truly unloadable āyah.

Covers both the surah and juzʾ readers (shared `useSurahAudio` hook).

## Verification

- `tsc --noEmit` (mobile) — clean
- `eslint` on the changed file — clean
- Native root-cause traced to `AudioPlayer.kt:217` + async `setMediaSource`/`prepare` (`AudioPlayer.kt:97-101`)

Ships in the **next** Android build, alongside #108 (apex domain).
