### PR TITLE
chore(mobile): bump versionName to 1.0.1

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Ummah Library",
     "slug": "ummah-library",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "scheme": "ummahlibrary",
     "userInterfaceStyle": "dark",


### PR DESCRIPTION
Marks the Play Store release that carries:

- #110 — reader-audio robustness (silent skips, screen-off playback, highlight re-sync)
- #108 — apex-domain switch for in-app web links

versionCode auto-increments remotely via EAS (this build: **vc9**). EAS production AAB build kicked off from this commit.