### PR TITLE
chore(mobile): iOS build-readiness — background-audio capability

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -31,7 +31,12 @@
       ]
     },
     "ios": {
-      "bundleIdentifier": "org.ummahlibrary.app"
+      "bundleIdentifier": "org.ummahlibrary.app",
+      "supportsTablet": true,
+      "infoPlist": {
+        "UIBackgroundModes": ["audio"],
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Config-only prep to make the existing managed Expo app iOS-ready. No Android behaviour change.

- **`UIBackgroundModes: ["audio"]`** — **critical**: without it iOS suspends audio on lock/background, so the background recitation + lock-screen controls (just shipped for Android) would be dead on iOS. expo-audio's `setActiveForLockScreen` then lights up the iOS Now-Playing / Control Center via the same JS path.
- **`ITSAppUsesNonExemptEncryption: false`** — standard-HTTPS only ⇒ export-compliance exempt; skips the manual question on every submission.
- **`supportsTablet: true`** — App Store default.

Verified `expo config --type public` resolves the iOS Info.plist with these values.

Still gated on (yours): Apple Developer Program ($99/yr), App Store Connect app record, and a device/TestFlight for verification. No build run here.