### PR TITLE
feat(extension): theme picker — all eight Noor themes

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -11,6 +11,9 @@ The popup shows:
 - **Quick sūra jump** — fetches and caches the sūra list, filters by name/number,
   opens the web reader.
 - **Translation edition** — chosen from `/api/v1/editions`, remembered.
+- **Themes** — all eight Noor palettes via a swatch picker (the generated
+  `@ummahlibrary/ui/noor-themes.css`, ADR 0027); the choice syncs across the
+  browser profile via `chrome.storage.sync`.
 
 It reuses `@ummahlibrary/core` (logic) and `@ummahlibrary/ui` (the Noor look). It
 needs **no backend**: content comes from the live API (`https://ummahlibrary.org`,

--- a/apps/extension/src/Popup.test.tsx
+++ b/apps/extension/src/Popup.test.tsx
@@ -33,6 +33,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   localStorage.clear();
+  delete document.documentElement.dataset.theme;
   vi.restoreAllMocks();
 });
 
@@ -58,5 +59,15 @@ describe("Popup", () => {
 
     const result = await screen.findByText("Ya-Sin");
     expect(result.closest("a")?.getAttribute("href")).toBe("https://ummahlibrary.org/surah/36");
+  });
+
+  it("switches the theme via the swatch picker", async () => {
+    render(<Popup />);
+    await waitFor(() => expect(screen.getByText("ARABIC_VERSE_TEXT")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("radio", { name: "emerald" }));
+
+    expect(document.documentElement.dataset.theme).toBe("emerald");
+    expect(localStorage.getItem("ul.ext.themeMirror")).toBe("emerald");
   });
 });

--- a/apps/extension/src/Popup.tsx
+++ b/apps/extension/src/Popup.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { formatHijri, gregorianToHijri, verseOfDay } from "@ummahlibrary/core";
 import type { Surah, Translation } from "@ummahlibrary/core";
-import { Logo, N } from "@ummahlibrary/ui";
+import { Logo, N, noorThemes } from "@ummahlibrary/ui";
+import type { ThemeKey } from "@ummahlibrary/ui";
 import { fetchVerse, getEditions, getSurahs } from "./lib/api";
 import type { VerseData } from "./lib/api";
 import { DEFAULT_EDITION } from "./lib/config";
@@ -9,16 +10,31 @@ import { todayGregorian, todayISO } from "./lib/date";
 import { homeUrl, openUrl, settingsUrl, surahUrl } from "./lib/links";
 import { getPref, setPref } from "./lib/storage";
 import { filterSurahs } from "./lib/surah-filter";
+import { applyTheme, getStoredTheme, readThemeSync, setStoredTheme, THEME_KEYS } from "./lib/theme";
 
 const PAD = 16;
 
 export function Popup() {
+  const [theme, setTheme] = useState<ThemeKey>(readThemeSync());
+
+  useEffect(() => {
+    void getStoredTheme().then((key) => {
+      setTheme(key);
+      applyTheme(key);
+    });
+  }, []);
+
+  function changeTheme(key: ThemeKey) {
+    setTheme(key);
+    void setStoredTheme(key);
+  }
+
   return (
     <main style={{ padding: PAD, display: "flex", flexDirection: "column", gap: 14 }}>
       <Header />
       <VerseOfDay />
       <SurahJump />
-      <Footer />
+      <Footer theme={theme} onTheme={changeTheme} />
     </main>
   );
 }
@@ -249,7 +265,7 @@ function SurahJump() {
   );
 }
 
-function Footer() {
+function Footer({ theme, onTheme }: { theme: ThemeKey; onTheme: (key: ThemeKey) => void }) {
   const link = { color: N.muted, fontSize: 12, textDecoration: "none", fontFamily: N.ui } as const;
   return (
     <footer
@@ -257,16 +273,54 @@ function Footer() {
         borderTop: `1px solid ${N.borderSoft}`,
         paddingTop: 10,
         display: "flex",
-        gap: 16,
-        justifyContent: "center",
+        flexDirection: "column",
+        gap: 10,
       }}
     >
-      <a href={homeUrl()} target="_blank" rel="noreferrer" style={link}>
-        Open Ummah Library
-      </a>
-      <a href={settingsUrl()} target="_blank" rel="noreferrer" style={link}>
-        Settings
-      </a>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={LABEL_STYLE}>Theme</span>
+        <ThemePicker value={theme} onChange={onTheme} />
+      </div>
+      <div style={{ display: "flex", gap: 16, justifyContent: "center" }}>
+        <a href={homeUrl()} target="_blank" rel="noreferrer" style={link}>
+          Open Ummah Library
+        </a>
+        <a href={settingsUrl()} target="_blank" rel="noreferrer" style={link}>
+          Settings
+        </a>
+      </div>
     </footer>
+  );
+}
+
+function ThemePicker({ value, onChange }: { value: ThemeKey; onChange: (key: ThemeKey) => void }) {
+  return (
+    <div role="radiogroup" aria-label="Theme" style={{ display: "flex", gap: 5 }}>
+      {THEME_KEYS.map((key) => {
+        const palette = noorThemes[key];
+        const active = key === value;
+        return (
+          <button
+            key={key}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={key}
+            title={key}
+            onClick={() => onChange(key)}
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: "50%",
+              background: palette.bg,
+              boxShadow: `inset 0 0 0 4px ${palette.accent}`,
+              border: active ? `2px solid ${N.fg}` : `1px solid ${N.border}`,
+              cursor: "pointer",
+              padding: 0,
+            }}
+          />
+        );
+      })}
+    </div>
   );
 }

--- a/apps/extension/src/lib/theme.test.ts
+++ b/apps/extension/src/lib/theme.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { applyTheme, getStoredTheme, readThemeSync, setStoredTheme, THEME_KEYS } from "./theme";
+
+afterEach(() => {
+  localStorage.clear();
+  delete document.documentElement.dataset.theme;
+});
+
+describe("theme", () => {
+  it("exposes all eight Noor themes", () => {
+    expect(THEME_KEYS).toContain("obsidian");
+    expect(THEME_KEYS).toContain("ivory");
+    expect(THEME_KEYS).toHaveLength(8);
+  });
+
+  it("defaults to obsidian when nothing is stored or the value is invalid", () => {
+    expect(readThemeSync()).toBe("obsidian");
+    localStorage.setItem("ul.ext.themeMirror", "not-a-theme");
+    expect(readThemeSync()).toBe("obsidian");
+  });
+
+  it("applyTheme sets data-theme on <html>", () => {
+    applyTheme("emerald");
+    expect(document.documentElement.dataset.theme).toBe("emerald");
+  });
+
+  it("setStoredTheme applies, mirrors synchronously, and persists", async () => {
+    await setStoredTheme("ocean");
+    expect(document.documentElement.dataset.theme).toBe("ocean");
+    expect(readThemeSync()).toBe("ocean"); // synchronous mirror written
+    expect(await getStoredTheme()).toBe("ocean"); // authoritative read agrees
+  });
+
+  it("getStoredTheme falls back to the default for unknown values", async () => {
+    expect(await getStoredTheme()).toBe("obsidian");
+  });
+});

--- a/apps/extension/src/lib/theme.ts
+++ b/apps/extension/src/lib/theme.ts
@@ -1,0 +1,51 @@
+import { noorThemes } from "@ummahlibrary/ui";
+import type { ThemeKey } from "@ummahlibrary/ui";
+import { getPref, setPref } from "./storage";
+
+/** All Noor themes, in palette order — the single source (ADR 0023/0027). */
+export const THEME_KEYS = Object.keys(noorThemes) as ThemeKey[];
+
+const DEFAULT_THEME: ThemeKey = "obsidian";
+
+/** Synchronous mirror of the chosen theme, read before paint to avoid a flash.
+ *  (chrome.storage.sync is async; localStorage is synchronous.) Distinct from the
+ *  `getPref`/`setPref` namespace so the two writes never alias. */
+const MIRROR_KEY = "ul.ext.themeMirror";
+
+function isThemeKey(value: unknown): value is ThemeKey {
+  return typeof value === "string" && (THEME_KEYS as string[]).includes(value);
+}
+
+/** Apply a theme by setting `data-theme` on <html>; the generated
+ *  `noor-themes.css` recolours everything from there. */
+export function applyTheme(key: ThemeKey): void {
+  document.documentElement.dataset.theme = key;
+}
+
+/** Best-effort synchronous read for pre-paint. Falls back to the default. */
+export function readThemeSync(): ThemeKey {
+  try {
+    const v = localStorage.getItem(MIRROR_KEY);
+    return isThemeKey(v) ? v : DEFAULT_THEME;
+  } catch {
+    return DEFAULT_THEME;
+  }
+}
+
+/** Authoritative read from synced storage (follows the user across devices),
+ *  falling back to the synchronous mirror, then the default. */
+export async function getStoredTheme(): Promise<ThemeKey> {
+  const v = await getPref<string>("theme", readThemeSync());
+  return isThemeKey(v) ? v : DEFAULT_THEME;
+}
+
+/** Persist + apply: synced pref (cross-device) + the synchronous mirror. */
+export async function setStoredTheme(key: ThemeKey): Promise<void> {
+  applyTheme(key);
+  try {
+    localStorage.setItem(MIRROR_KEY, key);
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
+  await setPref("theme", key);
+}

--- a/apps/extension/src/main.tsx
+++ b/apps/extension/src/main.tsx
@@ -1,8 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "@ummahlibrary/ui/noor-tokens.css";
+// All Noor themes (generated from packages/ui/src/themes.ts — ADR 0027).
+import "@ummahlibrary/ui/noor-themes.css";
 import "./styles.css";
 import { Popup } from "./Popup";
+import { applyTheme, readThemeSync } from "./lib/theme";
+
+// Apply the saved theme before the first paint to avoid a flash; the Popup
+// reconciles with synced storage on mount.
+applyTheme(readThemeSync());
 
 const root = document.getElementById("root");
 if (root) {

--- a/docs/adr/0026-browser-extension.md
+++ b/docs/adr/0026-browser-extension.md
@@ -60,9 +60,10 @@ and a **translation-edition selector**.
   surah list (the list is cached after first load; both fail soft to an offline
   message). The deployed app is a hard dependency — schema changes to
   `/api/v1` must keep the extension in mind, the same as any API consumer.
-- **Theme:** v1 ships the default Obsidian palette only (the full eight-theme set
-  lives in the web app's `globals.css`, not in `ui`); theme switching in the popup
-  is a later enhancement, not a blocker.
+- **Theme:** the popup imports the generated `@ummahlibrary/ui/noor-themes.css`
+  (ADR 0027) and offers all eight Noor themes via a swatch picker; the choice
+  persists in `chrome.storage.sync` (cross-device) with a synchronous
+  `localStorage` mirror applied before paint to avoid a flash.
 - **Distribution:** store submission (Chrome Web Store / AMO listing, screenshots,
   privacy declarations) is operational follow-up, like the iOS app (#115); the
   build itself is reproducible via `pnpm --filter @ummahlibrary/extension build`.


### PR DESCRIPTION
Adds full theme support to the browser-extension popup: a swatch picker for all eight Noor themes, persisted across the browser profile.

> Rebased onto `main` now that #117 and #118 have merged — this is now a clean single-commit delta (just the theme picker).

## What's new
- **Swatch picker** in the popup footer — one circle per theme (its `bg` + `accent`), the active one ringed. Renders straight from `noorThemes` (the single source).
- **All eight themes** come from the generated `@ummahlibrary/ui/noor-themes.css` (ADR 0027); `main.tsx` switches the import from the obsidian-only `noor-tokens.css` to the full set.
- **Persistence + no flash:** the choice is written to `chrome.storage.sync` (follows the user across their browser profile — no server we run) with a synchronous `localStorage` mirror applied *before paint* so a returning user doesn't see a theme flash.
- `lib/theme.ts`: `applyTheme`, `readThemeSync` (pre-paint), `getStoredTheme` (authoritative), `setStoredTheme` (apply + mirror + synced pref).

## Verification
- `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm --filter @ummahlibrary/extension test` ✅ (32 tests; +6 theme/picker) · extension build ✅
- **End-to-end:** built `dist/`, loaded the popup against the live API, and confirmed the swatch picker switches the whole popup (obsidian → ivory verified) with all 8 `[data-theme]` blocks bundled.
