### PR TITLE
fix(extension): translation dropdown unusable in the popup

### DIFF
--- a/apps/extension/src/Dropdown.test.tsx
+++ b/apps/extension/src/Dropdown.test.tsx
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Dropdown } from "./Dropdown";
+
+const OPTIONS = [
+  { value: "eng-khattab", label: "The Clear Quran" },
+  { value: "eng-sahih", label: "Saheeh International" },
+];
+
+afterEach(cleanup);
+
+describe("Dropdown", () => {
+  it("shows the current selection on the trigger", () => {
+    render(<Dropdown options={OPTIONS} value="eng-sahih" onChange={() => {}} ariaLabel="Translation" />);
+    expect(screen.getByRole("button", { name: "Translation" })).toHaveTextContent("Saheeh International");
+  });
+
+  it("opens on click and reports the chosen value", () => {
+    const onChange = vi.fn();
+    render(<Dropdown options={OPTIONS} value="eng-khattab" onChange={onChange} ariaLabel="Translation" />);
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Translation" }));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: "Saheeh International" }));
+    expect(onChange).toHaveBeenCalledWith("eng-sahih");
+    expect(screen.queryByRole("listbox")).toBeNull(); // closes after choosing
+  });
+
+  it("closes when clicking outside", () => {
+    render(
+      <div>
+        <Dropdown options={OPTIONS} value="eng-khattab" onChange={() => {}} ariaLabel="Translation" />
+        <button>outside</button>
+      </div>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Translation" }));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole("button", { name: "outside" }));
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+});

--- a/apps/extension/src/Dropdown.tsx
+++ b/apps/extension/src/Dropdown.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from "react";
+import { N } from "@ummahlibrary/ui";
+
+export interface DropdownOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * A small custom dropdown. Native `<select>` popups are unreliable inside
+ * browser-extension action popups (the OS menu can fail to open or steals focus
+ * and closes the popup), so we render our own button + listbox instead.
+ */
+export function Dropdown({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  options: readonly DropdownOption[];
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const current = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocPointer(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) setOpen(false);
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} style={{ position: "relative" }}>
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          maxWidth: 160,
+          background: N.bg2,
+          color: N.muted,
+          border: `1px solid ${N.border}`,
+          borderRadius: 8,
+          fontSize: 11,
+          padding: "3px 8px",
+          cursor: "pointer",
+          fontFamily: N.ui,
+        }}
+      >
+        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {current?.label ?? ariaLabel}
+        </span>
+        <span aria-hidden style={{ color: N.faint, fontSize: 9 }}>{open ? "▲" : "▼"}</span>
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          aria-label={ariaLabel}
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "calc(100% + 4px)",
+            zIndex: 20,
+            listStyle: "none",
+            margin: 0,
+            padding: 4,
+            minWidth: 160,
+            maxHeight: 220,
+            overflowY: "auto",
+            background: N.card,
+            border: `1px solid ${N.border}`,
+            borderRadius: 10,
+            boxShadow: "0 8px 24px rgba(0,0,0,0.35)",
+          }}
+        >
+          {options.map((option) => {
+            const selected = option.value === value;
+            return (
+              <li
+                key={option.value}
+                role="option"
+                aria-selected={selected}
+                onClick={() => {
+                  onChange(option.value);
+                  setOpen(false);
+                }}
+                style={{
+                  padding: "6px 8px",
+                  borderRadius: 6,
+                  fontSize: 12,
+                  cursor: "pointer",
+                  color: selected ? N.gold : N.fg,
+                  fontWeight: selected ? 700 : 400,
+                  fontFamily: N.ui,
+                }}
+              >
+                {option.label}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/extension/src/Popup.tsx
+++ b/apps/extension/src/Popup.tsx
@@ -3,6 +3,7 @@ import { formatHijri, gregorianToHijri, verseOfDay } from "@ummahlibrary/core";
 import type { Surah, Translation } from "@ummahlibrary/core";
 import { Logo, N, noorThemes } from "@ummahlibrary/ui";
 import type { ThemeKey } from "@ummahlibrary/ui";
+import { Dropdown } from "./Dropdown";
 import { fetchVerse, getEditions, getSurahs } from "./lib/api";
 import type { VerseData } from "./lib/api";
 import { DEFAULT_EDITION } from "./lib/config";
@@ -134,26 +135,12 @@ function VerseOfDay() {
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <span style={LABEL_STYLE}>Verse of the day</span>
         {editions.length > 0 && (
-          <select
-            aria-label="Translation"
+          <Dropdown
+            ariaLabel="Translation"
             value={edition}
-            onChange={(e) => onEdition(e.target.value)}
-            style={{
-              background: N.bg2,
-              color: N.muted,
-              border: `1px solid ${N.border}`,
-              borderRadius: 8,
-              fontSize: 11,
-              padding: "2px 4px",
-              maxWidth: 150,
-            }}
-          >
-            {editions.map((e) => (
-              <option key={e.id} value={e.id}>
-                {e.name}
-              </option>
-            ))}
-          </select>
+            onChange={onEdition}
+            options={editions.map((e) => ({ value: e.id, label: e.name }))}
+          />
         )}
       </div>
 


### PR DESCRIPTION
The extension popup's **translation selector** used a native `<select>`, whose dropdown is unreliable inside a browser-extension action popup (the OS menu can fail to open or steals focus and closes the popup). It shipped in `main` and is currently broken there.

> Context: this fix was authored on the #119 branch but pushed *after* #119 had already merged, so it never made it into `main`. Re-landing it here as its own PR.

## Fix
Replace the native `<select>` with a small custom **`Dropdown`** (button + listbox): renders inside the popup, closes on click-outside/Escape, proper ARIA roles, Noor-styled.

## Verification
- `pnpm lint` ✅ · `pnpm typecheck` ✅ · extension tests ✅ (35; +3 `Dropdown` tests: open, choose, click-outside) · build ✅
- **End-to-end:** loaded the built popup against the live API — the dropdown opens, lists all editions, and selecting one re-fetches the verse in that translation.
