### PR TITLE
chore(eslint): enforce core purity (ADR 0001 #1/#3)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -112,4 +112,79 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // Check A — core purity (ADR 0001 rules #1 & #3). `core` is pure and
+    // deterministic: no platform globals, no I/O, no nondeterminism, no Node
+    // built-ins. The clock is injected (see hifz.ts), so a bare `new Date()`
+    // *default parameter* stays allowed; `Date.now()`/`Math.random()` do not.
+    // boundaries already blocks workspace imports from core — this closes the
+    // global/builtin holes it can't see.
+    files: ["packages/core/src/**/*.ts"],
+    ignores: ["packages/core/src/**/*.test.ts"],
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        ...[
+          "window",
+          "document",
+          "localStorage",
+          "sessionStorage",
+          "navigator",
+          "fetch",
+          "XMLHttpRequest",
+          "indexedDB",
+          "caches",
+          "process",
+        ].map((name) => ({
+          name,
+          message:
+            "core is pure (ADR 0001 #1/#3): no platform access — put it behind a port in core/src/ports.ts and implement it in an adapter.",
+        })),
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "CallExpression[callee.object.name='Date'][callee.property.name='now']",
+          message: "core is deterministic (ADR 0001 #3) — inject the clock (see hifz.ts), don't read wall-clock time.",
+        },
+        {
+          selector: "CallExpression[callee.object.name='Math'][callee.property.name='random']",
+          message: "core is deterministic (ADR 0001 #3) — inject randomness, don't call Math.random().",
+        },
+      ],
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "node:*",
+                "fs",
+                "path",
+                "os",
+                "crypto",
+                "http",
+                "https",
+                "stream",
+                "child_process",
+                "util",
+                "events",
+                "url",
+                "zlib",
+                "net",
+                "tls",
+                "dns",
+                "assert",
+                "buffer",
+                "querystring",
+                "readline",
+                "worker_threads",
+              ],
+              message: "core imports nothing (ADR 0001 #1) — no Node built-ins; wrap external access in an adapter.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 );


### PR DESCRIPTION
## What

Adds ESLint enforcement for `packages/core/src/**` so the architectural rule that **core is pure and deterministic** (ADR 0001 rules #1 & #3) fails the build instead of relying on review:

- `no-restricted-globals` — no `window`/`document`/`localStorage`/`fetch`/`process`/etc.
- `no-restricted-syntax` — no `Date.now()` / `Math.random()` (inject the clock/RNG, see `hifz.ts`).
- `no-restricted-imports` — no Node built-ins (`node:*`, `fs`, `path`, …).

A bare `new Date()` **default parameter** stays allowed — that's the existing injected-clock idiom (`now: Date = new Date()`).

## Why

`eslint-plugin-boundaries` already enforces *import direction*, but it can't see global usage, nondeterminism, or Node built-ins. This closes those holes. Until now rule #3 was convention-only.

## Risk

**Zero churn** — `core` was already clean; `pnpm lint` + `pnpm typecheck` pass with no changes to `core` source. Pure tooling addition.