### PR TITLE
feat(core): reminder ports + shared orchestration (#71)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export * from "./adhkar";
 export * from "./duas";
 export * from "./reading-goals";
 export * from "./reading-plans";
+export * from "./reminders";
 export * from "./backup";
 export * from "./collections";
 export * from "./tasbih";

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -20,7 +20,7 @@ import type { Collection } from "./collections";
 import type { PrayerTrackerLog } from "./prayer-tracker";
 import type { TasbihRecord } from "./tasbih";
 import type { HifzCard } from "./hifz";
-import type { Coordinates, Madhab, PrayerTimings } from "./prayer";
+import type { Coordinates, Madhab, PrayerName, PrayerTimings } from "./prayer";
 import type { ActivePlan, PlanTemplate } from "./reading-plans";
 import type { KhatmaPlan } from "./reading-goals";
 
@@ -288,4 +288,70 @@ export interface SettingsStore {
   writeReciter(id: string): Promise<void>;
   writeTafsir(id: string): Promise<void>;
   writeScale(scale: number): Promise<void>;
+}
+
+/** The reader's prayer-times location and calculation config as persisted. */
+export interface PrayerSettings {
+  /** Saved location, or `null` until the reader uses prayer times / qibla. */
+  coords: Coordinates | null;
+  /** Calculation method id (e.g. `"MuslimWorldLeague"`). */
+  method: string;
+  /** Juristic madhab for the ʿAsr time. */
+  madhab: Madhab;
+}
+
+/**
+ * Persists the reader's prayer-times location and calculation config on-device
+ * (ADR 0024): coordinates, calculation method, and madhab — shared by prayer
+ * times, qibla, Ramadan, and reminders. Web uses `localStorage`, mobile
+ * `AsyncStorage`; a synced adapter (#25) replaces either without touching the
+ * prayer-times UI. `read()` applies the defaults; one method per stored key.
+ */
+export interface PrayerSettingsStore {
+  read(): Promise<PrayerSettings>;
+  writeCoords(coords: Coordinates | null): Promise<void>;
+  writeMethod(method: string): Promise<void>;
+  writeMadhab(madhab: Madhab): Promise<void>;
+}
+
+/**
+ * Supplies today's prayer timings for the stored location, hiding *how* they're
+ * obtained and cached behind the port: the web adapter fetches the prayer-times
+ * function and caches the day; a mobile adapter can compute them on-device via
+ * a {@link PrayerTimesCalculator}. Returns `null` when no location is stored or
+ * the lookup fails. This keeps the reminder orchestration in `core` free of I/O.
+ */
+export interface PrayerTimingsProvider {
+  getTodaysTimings(): Promise<PrayerTimings | null>;
+}
+
+/** A reading-plan daily-reminder preference. */
+export interface PlanReminderPref {
+  on: boolean;
+  /** Local wall-clock time, `HH:MM`. */
+  time: string;
+}
+
+/** The reader's reminder preferences as persisted (ADR 0024). */
+export interface ReminderPrefs {
+  /** Reading-plan daily nudge (#71). */
+  plan: PlanReminderPref;
+  /** Per-prayer reminder toggles. */
+  prayers: Partial<Record<PrayerName, boolean>>;
+  /** Morning/evening adhkar reminder on/off. */
+  adhkarOn: boolean;
+}
+
+/**
+ * Persists the reader's reminder preferences on-device (ADR 0024): the plan
+ * daily nudge, the per-prayer toggles, and the adhkar on/off. Web uses
+ * `localStorage`, mobile `AsyncStorage`; a synced adapter (#25) replaces either
+ * without touching the reminder orchestration in `core`. `read()` applies the
+ * defaults; one method per stored key.
+ */
+export interface ReminderStore {
+  read(): Promise<ReminderPrefs>;
+  writePlan(pref: PlanReminderPref): Promise<void>;
+  writePrayers(prefs: Partial<Record<PrayerName, boolean>>): Promise<void>;
+  writeAdhkarOn(on: boolean): Promise<void>;
 }

--- a/packages/core/src/reminders.test.ts
+++ b/packages/core/src/reminders.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AppNotification,
+  Notifier,
+  NotifyPermission,
+  PlanStore,
+  PrayerTimingsProvider,
+  ReminderPrefs,
+  ReminderStore,
+} from "./ports";
+import type { PrayerTimings } from "./prayer";
+import { type ActivePlan, activatePlan, templateById } from "./reading-plans";
+import {
+  PLAN_REMINDER_ID,
+  adhkarReminderId,
+  prayerReminderId,
+  syncAdhkarReminder,
+  syncPlanReminder,
+  syncPrayerReminders,
+} from "./reminders";
+
+function fakeNotifier(permission: NotifyPermission = "granted") {
+  const scheduled = new Map<string, AppNotification>();
+  const cancelled: string[] = [];
+  const notifier: Notifier = {
+    isSupported: () => true,
+    permission: () => permission,
+    requestPermission: async () => permission,
+    schedule: async (n) => void scheduled.set(n.id, n),
+    cancel: async (id) => {
+      cancelled.push(id);
+      scheduled.delete(id);
+    },
+    cancelAll: async () => {
+      for (const id of scheduled.keys()) cancelled.push(id);
+      scheduled.clear();
+    },
+  };
+  return { notifier, scheduled, cancelled };
+}
+
+function fakeReminders(prefs: Partial<ReminderPrefs> = {}): ReminderStore {
+  const state: ReminderPrefs = { plan: { on: false, time: "20:00" }, prayers: {}, adhkarOn: false, ...prefs };
+  return {
+    read: async () => state,
+    writePlan: async (p) => void (state.plan = p),
+    writePrayers: async (p) => void (state.prayers = p),
+    writeAdhkarOn: async (o) => void (state.adhkarOn = o),
+  };
+}
+
+const fakePlans = (plan: ActivePlan | null): PlanStore => ({
+  read: async () => plan,
+  write: async () => {},
+  clear: async () => {},
+});
+
+const provider = (t: PrayerTimings | null): PrayerTimingsProvider => ({ getTodaysTimings: async () => t });
+
+const TIMINGS: PrayerTimings = {
+  fajr: "2026-06-21T03:00:00.000Z",
+  sunrise: "2026-06-21T04:30:00.000Z",
+  dhuhr: "2026-06-21T12:00:00.000Z",
+  asr: "2026-06-21T15:30:00.000Z",
+  maghrib: "2026-06-21T19:00:00.000Z",
+  isha: "2026-06-21T20:30:00.000Z",
+};
+// 10:00Z: fajr/sunrise have passed; dhuhr → isha are still ahead.
+const NOW = new Date("2026-06-21T10:00:00.000Z");
+const now = () => NOW;
+const activePlan = (): ActivePlan => activatePlan(templateById("ramadan-khatm")!, "2026-06-21");
+
+describe("syncPlanReminder", () => {
+  it("schedules the plan reminder when enabled, granted, and a plan is active", async () => {
+    const { notifier, scheduled, cancelled } = fakeNotifier();
+    await syncPlanReminder({
+      notifier,
+      reminders: fakeReminders({ plan: { on: true, time: "20:00" } }),
+      plans: fakePlans(activePlan()),
+      now,
+    });
+    expect(cancelled).toContain(PLAN_REMINDER_ID); // cancels before scheduling (idempotent)
+    expect(scheduled.has(PLAN_REMINDER_ID)).toBe(true);
+  });
+
+  it("is a no-op when off, denied, plan paused, no plan, or a bad time", async () => {
+    const cases: Array<[Partial<ReminderPrefs>, NotifyPermission, ActivePlan | null]> = [
+      [{ plan: { on: false, time: "20:00" } }, "granted", activePlan()],
+      [{ plan: { on: true, time: "20:00" } }, "denied", activePlan()],
+      [{ plan: { on: true, time: "20:00" } }, "granted", { ...activePlan(), pausedOn: "2026-06-20" }],
+      [{ plan: { on: true, time: "20:00" } }, "granted", null],
+      [{ plan: { on: true, time: "99:99" } }, "granted", activePlan()],
+    ];
+    for (const [prefs, perm, plan] of cases) {
+      const { notifier, scheduled } = fakeNotifier(perm);
+      await syncPlanReminder({ notifier, reminders: fakeReminders(prefs), plans: fakePlans(plan), now });
+      expect(scheduled.has(PLAN_REMINDER_ID)).toBe(false);
+    }
+  });
+});
+
+describe("syncAdhkarReminder", () => {
+  it("schedules the next occasion and clears both occasion ids", async () => {
+    const { notifier, scheduled, cancelled } = fakeNotifier();
+    await syncAdhkarReminder({ notifier, reminders: fakeReminders({ adhkarOn: true }), timings: provider(TIMINGS), now });
+    expect(cancelled).toEqual(expect.arrayContaining([adhkarReminderId("morning"), adhkarReminderId("evening")]));
+    // morning (fajr 03:00Z) has passed → next is evening (asr 15:30Z).
+    expect(scheduled.has(adhkarReminderId("evening"))).toBe(true);
+    expect(scheduled.has(adhkarReminderId("morning"))).toBe(false);
+  });
+
+  it("is a no-op when off or without a location", async () => {
+    const off = fakeNotifier();
+    await syncAdhkarReminder({ notifier: off.notifier, reminders: fakeReminders({ adhkarOn: false }), timings: provider(TIMINGS), now });
+    expect(off.scheduled.size).toBe(0);
+
+    const noLoc = fakeNotifier();
+    await syncAdhkarReminder({ notifier: noLoc.notifier, reminders: fakeReminders({ adhkarOn: true }), timings: provider(null), now });
+    expect(noLoc.scheduled.size).toBe(0);
+  });
+});
+
+describe("syncPrayerReminders", () => {
+  it("schedules only enabled prayers still ahead of now", async () => {
+    const { notifier, scheduled, cancelled } = fakeNotifier();
+    await syncPrayerReminders({
+      notifier,
+      reminders: fakeReminders({ prayers: { fajr: true, dhuhr: true } }),
+      timings: provider(TIMINGS),
+      now,
+    });
+    // every obligatory id is cleared first
+    expect(cancelled).toContain(prayerReminderId("fajr"));
+    expect(cancelled).toContain(prayerReminderId("isha"));
+    // fajr already passed; dhuhr is upcoming
+    expect(scheduled.has(prayerReminderId("fajr"))).toBe(false);
+    expect(scheduled.has(prayerReminderId("dhuhr"))).toBe(true);
+  });
+
+  it("is a no-op when no prayer is enabled", async () => {
+    const { notifier, scheduled } = fakeNotifier();
+    await syncPrayerReminders({ notifier, reminders: fakeReminders({ prayers: {} }), timings: provider(TIMINGS), now });
+    expect(scheduled.size).toBe(0);
+  });
+});
+
+describe("reminder families are independent (cancel-by-id, not cancelAll)", () => {
+  it("syncing adhkar leaves a scheduled prayer reminder intact", async () => {
+    const { notifier, scheduled } = fakeNotifier();
+    const reminders = fakeReminders({ prayers: { dhuhr: true }, adhkarOn: true });
+    await syncPrayerReminders({ notifier, reminders, timings: provider(TIMINGS), now });
+    expect(scheduled.has(prayerReminderId("dhuhr"))).toBe(true);
+
+    await syncAdhkarReminder({ notifier, reminders, timings: provider(TIMINGS), now });
+    expect(scheduled.has(prayerReminderId("dhuhr"))).toBe(true); // not wiped by adhkar's cancels
+    expect(scheduled.has(adhkarReminderId("evening"))).toBe(true);
+  });
+});

--- a/packages/core/src/reminders.ts
+++ b/packages/core/src/reminders.ts
@@ -1,0 +1,131 @@
+/**
+ * Reminder orchestration (#71, ADR 0017/0019). The *decision* of what to remind
+ * and when is the pure core helpers (`nextDailyReminder`, `nextAdhkarReminder`,
+ * `prayerReminders`); this module is the platform-neutral glue that reads the
+ * stored preferences, asks the timings provider, and drives the {@link Notifier}
+ * port. Every external concern is injected as a port and the clock is a
+ * parameter, so web and mobile share one implementation behind their own
+ * adapters — no reminder logic lives in an app.
+ *
+ * Cancellation is always by explicit id (never `cancelAll()`), so a single
+ * shared notifier can serve the plan, adhkar, and prayer reminder families
+ * without one family clearing another's pending notifications.
+ */
+import type { AdhkarOccasion } from "./entities";
+import type { Notifier, PlanStore, PrayerTimingsProvider, ReminderStore } from "./ports";
+import { nextAdhkarReminder } from "./adhkar";
+import { OBLIGATORY_PRAYERS, PRAYER_LABELS, type PrayerName, prayerReminders } from "./prayer";
+import { nextDailyReminder, planReminderContent } from "./reading-plans";
+
+export const DEFAULT_PLAN_REMINDER_TIME = "20:00";
+export const PLAN_REMINDER_ID = "plan:daily";
+
+const ADHKAR_OCCASION_LIST: readonly AdhkarOccasion[] = ["morning", "evening"];
+const ADHKAR_LABEL: Record<AdhkarOccasion, string> = { morning: "morning", evening: "evening" };
+const ADHKAR_EMOJI: Record<AdhkarOccasion, string> = { morning: "🌅", evening: "🌆" };
+
+/** Stable notification id for an adhkar occasion (rescheduling replaces it). */
+export const adhkarReminderId = (occasion: AdhkarOccasion): string => `adhkar:${occasion}`;
+/** Stable notification id for a prayer reminder (rescheduling replaces it). */
+export const prayerReminderId = (prayer: PrayerName): string => `prayer:${prayer}`;
+
+/** `YYYY-MM-DD` for the given instant in local time (deterministic given `now`). */
+function localDateStr(now: Date): string {
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}`;
+}
+
+/** Shared dependencies — every external concern is a port; the clock is injected. */
+export interface ReminderSyncDeps {
+  notifier: Notifier;
+  reminders: ReminderStore;
+  /** The clock — injected so orchestration stays deterministic and testable. */
+  now: () => Date;
+}
+
+/**
+ * (Re)schedule the reading-plan daily reminder (#71). Idempotent: cancels the
+ * plan reminder, then schedules the next occurrence of the chosen time with copy
+ * reflecting today's progress. A no-op when the reminder is off, permission
+ * isn't granted, there's no active plan (or it's paused, #68), or the time is
+ * malformed.
+ */
+export async function syncPlanReminder(deps: ReminderSyncDeps & { plans: PlanStore }): Promise<void> {
+  const { notifier, reminders, plans, now } = deps;
+  await notifier.cancel(PLAN_REMINDER_ID);
+
+  const { plan: pref } = await reminders.read();
+  if (!pref.on || notifier.permission() !== "granted") return;
+
+  const plan = await plans.read();
+  if (!plan || plan.pausedOn) return;
+
+  const at = nextDailyReminder(pref.time, now());
+  if (!at) return;
+
+  const { title, body } = planReminderContent(plan, localDateStr(now()));
+  await notifier.schedule({
+    id: PLAN_REMINDER_ID,
+    title,
+    body,
+    at: at.toISOString(),
+    tag: PLAN_REMINDER_ID,
+  });
+}
+
+/**
+ * (Re)schedule the next morning/evening adhkar reminder (ADR 0017/0019).
+ * Idempotent: clears both occasion ids, then schedules the next window's
+ * opening. A no-op when off, without permission, or with no stored location.
+ */
+export async function syncAdhkarReminder(
+  deps: ReminderSyncDeps & { timings: PrayerTimingsProvider },
+): Promise<void> {
+  const { notifier, reminders, timings, now } = deps;
+  for (const occasion of ADHKAR_OCCASION_LIST) await notifier.cancel(adhkarReminderId(occasion));
+
+  const { adhkarOn } = await reminders.read();
+  if (!adhkarOn || notifier.permission() !== "granted") return;
+
+  const today = await timings.getTodaysTimings();
+  if (!today) return;
+
+  const next = nextAdhkarReminder(today, now());
+  if (!next) return;
+
+  await notifier.schedule({
+    id: adhkarReminderId(next.occasion),
+    title: `Time for ${ADHKAR_LABEL[next.occasion]} adhkar ${ADHKAR_EMOJI[next.occasion]}`,
+    body: "Tap to open your remembrances on Ummah Library.",
+    at: next.at.toISOString(),
+    tag: adhkarReminderId(next.occasion),
+  });
+}
+
+/**
+ * (Re)schedule today's enabled prayer reminders (ADR 0019). Idempotent: clears
+ * every obligatory-prayer id, then schedules each enabled prayer still ahead of
+ * `now`. A no-op without permission, a location, or any reminder enabled.
+ */
+export async function syncPrayerReminders(
+  deps: ReminderSyncDeps & { timings: PrayerTimingsProvider },
+): Promise<void> {
+  const { notifier, reminders, timings, now } = deps;
+  for (const prayer of OBLIGATORY_PRAYERS) await notifier.cancel(prayerReminderId(prayer));
+
+  const { prayers } = await reminders.read();
+  if (!OBLIGATORY_PRAYERS.some((p) => prayers[p]) || notifier.permission() !== "granted") return;
+
+  const today = await timings.getTodaysTimings();
+  if (!today) return;
+
+  for (const reminder of prayerReminders(today, prayers, now())) {
+    await notifier.schedule({
+      id: prayerReminderId(reminder.prayer),
+      title: `${PRAYER_LABELS[reminder.prayer]} — time to pray`,
+      body: "It’s time for prayer. Tap to open Ummah Library.",
+      at: reminder.at,
+      tag: prayerReminderId(reminder.prayer),
+    });
+  }
+}


### PR DESCRIPTION
## What

Introduces the platform-neutral foundation for reminders so the logic can be shared by web **and** mobile (unblocking the native ExpoNotifier, #71):

- **Three new ports** in `core/src/ports.ts`:
  - `ReminderStore` — reminder prefs (plan nudge, per-prayer toggles, adhkar on/off)
  - `PrayerSettingsStore` — coords / method / madhab (shared by prayer times, qibla, Ramadan, reminders)
  - `PrayerTimingsProvider` — today's timings, hiding fetch-vs-compute + caching behind the port
- **`core/src/reminders.ts`** — shared `syncPlanReminder` / `syncAdhkarReminder` / `syncPrayerReminders`. Every external concern is injected (notifier, stores, provider) and the clock is a parameter, so it's pure and unit-tested.

## Why

The reminder *orchestration* previously lived in `apps/web` and read `localStorage` directly, so it couldn't be reused by mobile or sit behind the ADR-0024 store-port pattern. This moves the decision-glue into `core` behind ports.

## Design note

Cancels by **explicit id-space** (`plan:daily`, `adhkar:*`, `prayer:*`) instead of `cancelAll()`, so a single shared notifier can serve all three families without one wiping another's pending notifications (the web previously needed a separate `WebNotifier` per feature to avoid this). A test guards it.

## Follow-up

Web adapters (`webReminderStore`, `webPrayerSettingsStore`, `webPrayerTimingsProvider`) + consumer rewiring land in the next PR. This PR is additive (new ports + tested orchestration); no existing behavior changes.

## Checks
`pnpm lint` + `pnpm typecheck` green; 7 new core tests pass.