### PR TITLE
refactor(web): route reminders through core ports + adapters (#71)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ Thumbs.db
 .vscode/*
 !.vscode/extensions.json
 
+# Claude Code personal overrides
+.claude/settings.local.json
+
 # Playwright
 /test-results
 /playwright-report

--- a/apps/web/src/components/AdhkarReminderBanner.tsx
+++ b/apps/web/src/components/AdhkarReminderBanner.tsx
@@ -11,38 +11,12 @@ import {
   remindersEnabled,
   syncAdhkarReminder,
 } from "../lib/adhkar-reminders";
+import { dismissAdhkar, readAdhkarSeen } from "../lib/reminder-store";
 import { WebNotifier } from "../lib/web-notifier";
 
-const SEEN_KEY = "ul.adhkarReminderSeen";
-
-// This feature's own notifier — its cancelAll() must not touch prayer reminders,
-// which run on a separate WebNotifier instance.
+// This feature's own notifier — a per-instance timer map, so its scheduling is
+// independent of the prayer/plan schedulers' notifiers.
 const notifier = new WebNotifier();
-
-function localDate(d = new Date()): string {
-  const p = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
-}
-
-function readSeen(): string[] {
-  try {
-    const raw = localStorage.getItem(SEEN_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as { date: string; dismissed: string[] };
-    return parsed.date === localDate() ? parsed.dismissed : [];
-  } catch {
-    return [];
-  }
-}
-
-function dismiss(occasion: AdhkarOccasion): void {
-  const dismissed = Array.from(new Set([...readSeen(), occasion]));
-  try {
-    localStorage.setItem(SEEN_KEY, JSON.stringify({ date: localDate(), dismissed }));
-  } catch {
-    /* ignore */
-  }
-}
 
 /**
  * Surfaces the active adhkar reminder while the app is open, and — when the user
@@ -58,7 +32,7 @@ export function AdhkarReminderBanner() {
     const timings = timingsRef.current;
     if (!timings) return;
     const occ = activeAdhkarReminder(timings, new Date());
-    setActive(occ && !readSeen().includes(occ) ? occ : null);
+    setActive(occ && !readAdhkarSeen().includes(occ) ? occ : null);
   }, []);
 
   useEffect(() => {
@@ -73,7 +47,7 @@ export function AdhkarReminderBanner() {
     };
 
     async function start() {
-      if (!remindersEnabled()) {
+      if (!(await remindersEnabled())) {
         setActive(null);
         timingsRef.current = null;
         void notifier.cancelAll();
@@ -117,7 +91,7 @@ export function AdhkarReminderBanner() {
           className="adhkar-reminder-close"
           aria-label="Dismiss"
           onClick={() => {
-            dismiss(active);
+            dismissAdhkar(active);
             setActive(null);
           }}
         >

--- a/apps/web/src/components/AdhkarReminderToggle.tsx
+++ b/apps/web/src/components/AdhkarReminderToggle.tsx
@@ -20,9 +20,11 @@ export function AdhkarReminderToggle() {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    setEnabled(remindersEnabled());
-    setHasCoords(readCoords() !== null);
-    setReady(true);
+    void Promise.all([remindersEnabled(), readCoords()]).then(([on, coords]) => {
+      setEnabled(on);
+      setHasCoords(coords !== null);
+      setReady(true);
+    });
   }, []);
 
   useEffect(() => {
@@ -54,11 +56,11 @@ export function AdhkarReminderToggle() {
         // Ask through the port; the in-app banner still works if it's declined.
         await notifier.requestPermission();
       }
-      setRemindersEnabled(true);
+      await setRemindersEnabled(true);
       setEnabled(true);
-      setHasCoords(readCoords() !== null);
+      setHasCoords((await readCoords()) !== null);
     } else {
-      setRemindersEnabled(false);
+      await setRemindersEnabled(false);
       setEnabled(false);
     }
   }

--- a/apps/web/src/components/PlanReminderToggle.tsx
+++ b/apps/web/src/components/PlanReminderToggle.tsx
@@ -28,28 +28,29 @@ export function PlanReminderToggle() {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    const p = readPlanReminderPref();
-    setOn(p.on);
-    setTime(p.time);
-    setDenied(notifier.permission() === "denied");
-    setReady(true);
+    void readPlanReminderPref().then((p) => {
+      setOn(p.on);
+      setTime(p.time);
+      setDenied(notifier.permission() === "denied");
+      setReady(true);
+    });
   }, []);
 
   async function toggle() {
     if (!on) {
       if (notifier.permission() === "default") await notifier.requestPermission();
       setDenied(notifier.permission() === "denied");
-      setPlanReminderPref({ on: true, time });
+      await setPlanReminderPref({ on: true, time });
       setOn(true);
     } else {
-      setPlanReminderPref({ on: false, time });
+      await setPlanReminderPref({ on: false, time });
       setOn(false);
     }
   }
 
   function changeTime(next: string) {
     setTime(next);
-    setPlanReminderPref({ on, time: next });
+    void setPlanReminderPref({ on, time: next });
   }
 
   if (!ready) return null;

--- a/apps/web/src/components/PrayerTimesView.tsx
+++ b/apps/web/src/components/PrayerTimesView.tsx
@@ -141,7 +141,7 @@ export function PrayerTimesView() {
     const saved = read<Coordinates | null>(COORDS_KEY, null);
     setMethod(m);
     setMadhab(mad);
-    setReminders(readPrayerReminderPrefs());
+    void readPrayerReminderPrefs().then(setReminders);
     setPermission(getNotifier().permission());
     if (saved) {
       setCoords(saved);
@@ -195,7 +195,7 @@ export function PrayerTimesView() {
     if (turningOn && getNotifier().permission() === "default") {
       setPermission(await getNotifier().requestPermission());
     }
-    setReminders({ ...setPrayerReminder(name, turningOn) });
+    setReminders({ ...(await setPrayerReminder(name, turningOn)) });
   }
 
   const upcoming = timings ? nextPrayer(timings, now) : null;

--- a/apps/web/src/lib/adhkar-reminders.ts
+++ b/apps/web/src/lib/adhkar-reminders.ts
@@ -1,116 +1,19 @@
 /**
- * Adhkar reminders, wired off the prayer-times module (ADR 0017). All local:
- * the on/off preference and a per-day cache of the day's timings live in
- * `localStorage`; the reminder logic itself is the pure core helpers. There is
- * no server push — reminders surface in-app and as a local notification while a
- * tab is open (the honest limit of a no-backend, local-first app). Delivery goes
- * through the {@link Notifier} port, the same as prayer reminders (ADR 0019).
+ * Adhkar reminders — web wiring (ADR 0017/0019). The on/off preference goes
+ * through the {@link webReminderStore} (`ReminderStore` port), the location and
+ * cached timings through the {@link webPrayerSettingsStore} /
+ * {@link webPrayerTimingsProvider}, and the scheduling decision is the shared
+ * `syncAdhkarReminder` in `@ummahlibrary/core`. Delivery is the {@link Notifier}
+ * port (fires while a tab is open); no server push.
  */
+import type { AdhkarOccasion, Coordinates, Notifier } from "@ummahlibrary/core";
+import { syncAdhkarReminder as coreSyncAdhkarReminder } from "@ummahlibrary/core";
+import { webPrayerSettingsStore } from "./prayer-settings-store";
+import { webPrayerTimingsProvider } from "./prayer-timings-provider";
+import { webReminderStore } from "./reminder-store";
 
-import {
-  type AdhkarOccasion,
-  type Notifier,
-  type PrayerTimings,
-  nextAdhkarReminder,
-} from "@ummahlibrary/core";
-
+/** Event dispatched on a preference change so the banner re-syncs. */
 export const REMINDERS_KEY = "ul.adhkarReminders";
-const TIMINGS_KEY = "ul.adhkarTimings";
-const COORDS_KEY = "ul.prayerCoords"; // shared with prayer-times / qibla
-const METHOD_KEY = "ul.prayerMethod";
-const MADHAB_KEY = "ul.prayerMadhab";
-
-interface Coordinates {
-  latitude: number;
-  longitude: number;
-}
-
-function localDate(d = new Date()): string {
-  const p = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
-}
-
-export function remindersEnabled(): boolean {
-  try {
-    return localStorage.getItem(REMINDERS_KEY) === "on";
-  } catch {
-    return false;
-  }
-}
-
-export function setRemindersEnabled(on: boolean): void {
-  try {
-    localStorage.setItem(REMINDERS_KEY, on ? "on" : "off");
-  } catch {
-    /* storage unavailable */
-  }
-  window.dispatchEvent(new CustomEvent(REMINDERS_KEY, { detail: on }));
-}
-
-export function readCoords(): Coordinates | null {
-  try {
-    const raw = localStorage.getItem(COORDS_KEY);
-    return raw ? (JSON.parse(raw) as Coordinates) : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Today's prayer timings — from the per-day cache, otherwise fetched once from
- * the existing `/api/v1/prayer-times` function and cached. Returns `null` if no
- * location is stored (the user hasn't used prayer times/qibla yet).
- */
-export async function ensureTodaysTimings(): Promise<PrayerTimings | null> {
-  const coords = readCoords();
-  if (!coords) return null;
-
-  try {
-    const raw = localStorage.getItem(TIMINGS_KEY);
-    if (raw) {
-      const cached = JSON.parse(raw) as { date: string; timings: PrayerTimings };
-      if (cached.date === localDate()) return cached.timings;
-    }
-  } catch {
-    /* fall through to refetch */
-  }
-
-  const method = (() => {
-    try {
-      return localStorage.getItem(METHOD_KEY) ?? "MuslimWorldLeague";
-    } catch {
-      return "MuslimWorldLeague";
-    }
-  })();
-  const madhab = (() => {
-    try {
-      return localStorage.getItem(MADHAB_KEY) ?? "shafi";
-    } catch {
-      return "shafi";
-    }
-  })();
-
-  const params = new URLSearchParams({
-    lat: String(coords.latitude),
-    lng: String(coords.longitude),
-    date: localDate(),
-    method,
-    madhab,
-  });
-  try {
-    const res = await fetch(`/api/v1/prayer-times?${params}`);
-    if (!res.ok) return null;
-    const data = (await res.json()) as { timings: PrayerTimings };
-    try {
-      localStorage.setItem(TIMINGS_KEY, JSON.stringify({ date: localDate(), timings: data.timings }));
-    } catch {
-      /* ignore */
-    }
-    return data.timings;
-  } catch {
-    return null;
-  }
-}
 
 export const ADHKAR_LABEL: Record<AdhkarOccasion, string> = {
   morning: "morning",
@@ -118,27 +21,30 @@ export const ADHKAR_LABEL: Record<AdhkarOccasion, string> = {
 };
 export const ADHKAR_EMOJI: Record<AdhkarOccasion, string> = { morning: "🌅", evening: "🌆" };
 
-/**
- * (Re)schedule the next adhkar notification through the given notifier — the
- * same {@link Notifier} port prayer reminders use (ADR 0019). Idempotent:
- * cancels first, then schedules the next window's opening. A no-op when the
- * reminder is off, permission isn't granted, or no location is stored.
- */
-export async function syncAdhkarReminder(notifier: Notifier): Promise<void> {
-  await notifier.cancelAll();
-  if (!remindersEnabled() || notifier.permission() !== "granted") return;
+export async function remindersEnabled(): Promise<boolean> {
+  return (await webReminderStore.read()).adhkarOn;
+}
 
-  const timings = await ensureTodaysTimings();
-  if (!timings) return;
+export async function setRemindersEnabled(on: boolean): Promise<void> {
+  await webReminderStore.writeAdhkarOn(on);
+  window.dispatchEvent(new CustomEvent(REMINDERS_KEY, { detail: on }));
+}
 
-  const next = nextAdhkarReminder(timings, new Date());
-  if (!next) return;
+export async function readCoords(): Promise<Coordinates | null> {
+  return (await webPrayerSettingsStore.read()).coords;
+}
 
-  await notifier.schedule({
-    id: `adhkar:${next.occasion}`,
-    title: `Time for ${ADHKAR_LABEL[next.occasion]} adhkar ${ADHKAR_EMOJI[next.occasion]}`,
-    body: "Tap to open your remembrances on Ummah Library.",
-    at: next.at.toISOString(),
-    tag: `adhkar:${next.occasion}`,
+/** Today's prayer timings for the stored location, or `null` if none/failed. */
+export function ensureTodaysTimings() {
+  return webPrayerTimingsProvider.getTodaysTimings();
+}
+
+/** (Re)schedule the next adhkar notification through the shared orchestration. */
+export function syncAdhkarReminder(notifier: Notifier): Promise<void> {
+  return coreSyncAdhkarReminder({
+    notifier,
+    reminders: webReminderStore,
+    timings: webPrayerTimingsProvider,
+    now: () => new Date(),
   });
 }

--- a/apps/web/src/lib/plan-reminders.test.ts
+++ b/apps/web/src/lib/plan-reminders.test.ts
@@ -44,25 +44,25 @@ beforeEach(() => localStorage.clear());
 afterEach(() => localStorage.clear());
 
 describe("plan reminder preference", () => {
-  it("defaults to off at the default time", () => {
-    expect(readPlanReminderPref()).toEqual({ on: false, time: DEFAULT_PLAN_REMINDER_TIME });
+  it("defaults to off at the default time", async () => {
+    expect(await readPlanReminderPref()).toEqual({ on: false, time: DEFAULT_PLAN_REMINDER_TIME });
   });
 
-  it("round-trips a saved preference", () => {
-    setPlanReminderPref({ on: true, time: "07:30" });
-    expect(readPlanReminderPref()).toEqual({ on: true, time: "07:30" });
+  it("round-trips a saved preference", async () => {
+    await setPlanReminderPref({ on: true, time: "07:30" });
+    expect(await readPlanReminderPref()).toEqual({ on: true, time: "07:30" });
   });
 
-  it("falls back safely on a malformed stored value", () => {
+  it("falls back safely on a malformed stored value", async () => {
     localStorage.setItem(PLAN_REMINDER_KEY, "{not json");
-    expect(readPlanReminderPref().on).toBe(false);
+    expect((await readPlanReminderPref()).on).toBe(false);
   });
 });
 
 describe("syncPlanReminder", () => {
   it("schedules a daily nudge when on, granted, and a plan is active", async () => {
     await seedPlan();
-    setPlanReminderPref({ on: true, time: "20:00" });
+    await setPlanReminderPref({ on: true, time: "20:00" });
     const n = new FakeNotifier("granted");
     await syncPlanReminder(n);
 
@@ -75,7 +75,7 @@ describe("syncPlanReminder", () => {
 
   it("is a no-op when the reminder is off", async () => {
     await seedPlan();
-    setPlanReminderPref({ on: false, time: "20:00" });
+    await setPlanReminderPref({ on: false, time: "20:00" });
     const n = new FakeNotifier("granted");
     await syncPlanReminder(n);
     expect(n.scheduled.size).toBe(0);
@@ -83,14 +83,14 @@ describe("syncPlanReminder", () => {
 
   it("is a no-op without notification permission", async () => {
     await seedPlan();
-    setPlanReminderPref({ on: true, time: "20:00" });
+    await setPlanReminderPref({ on: true, time: "20:00" });
     const n = new FakeNotifier("denied");
     await syncPlanReminder(n);
     expect(n.scheduled.size).toBe(0);
   });
 
   it("is a no-op when no plan is active", async () => {
-    setPlanReminderPref({ on: true, time: "20:00" });
+    await setPlanReminderPref({ on: true, time: "20:00" });
     const n = new FakeNotifier("granted");
     await syncPlanReminder(n);
     expect(n.scheduled.size).toBe(0);

--- a/apps/web/src/lib/plan-reminders.ts
+++ b/apps/web/src/lib/plan-reminders.ts
@@ -1,75 +1,42 @@
 /**
- * Reading-plan daily reminder (#71). Opt-in, a single daily nudge at a chosen
- * time. All local: the on/off + time preference lives in `localStorage`, the
- * message copy is the pure core helper (`planReminderContent`), and delivery
- * goes through the {@link Notifier} port — the web adapter fires while a tab is
- * open (ADR 0019). No server push; the honest limit of a no-backend app. The
- * same core helpers will back a future Expo notifier behind the same port.
+ * Reading-plan daily reminder — web wiring (#71). The on/off + time preference
+ * goes through the {@link webReminderStore} (`ReminderStore` port, ADR 0024) and
+ * the scheduling decision is the shared `syncPlanReminder` in
+ * `@ummahlibrary/core`; this module only injects the web adapters and re-emits a
+ * `CustomEvent` so the scheduler/toggle re-sync. Delivery is the {@link Notifier}
+ * port (the web adapter fires while a tab is open, ADR 0019) — no server push.
  */
-import { type Notifier, nextDailyReminder, planReminderContent } from "@ummahlibrary/core";
-import { readActivePlan, todayStr } from "./reading-plan";
+import type { Notifier, PlanReminderPref } from "@ummahlibrary/core";
+import {
+  DEFAULT_PLAN_REMINDER_TIME,
+  PLAN_REMINDER_ID,
+  syncPlanReminder as coreSyncPlanReminder,
+} from "@ummahlibrary/core";
+import { webPlanStore } from "./plan-store";
+import { webReminderStore } from "./reminder-store";
 
+export { DEFAULT_PLAN_REMINDER_TIME, PLAN_REMINDER_ID };
+export type { PlanReminderPref };
+
+/** Event dispatched on a preference change so the scheduler re-syncs. */
 export const PLAN_REMINDER_KEY = "ul.planReminder";
-export const PLAN_REMINDER_ID = "plan:daily";
-export const DEFAULT_PLAN_REMINDER_TIME = "20:00";
 
-export interface PlanReminderPref {
-  on: boolean;
-  /** Local wall-clock time, `HH:MM`. */
-  time: string;
-}
-
-const FALLBACK: PlanReminderPref = { on: false, time: DEFAULT_PLAN_REMINDER_TIME };
-
-export function readPlanReminderPref(): PlanReminderPref {
-  try {
-    const raw = localStorage.getItem(PLAN_REMINDER_KEY);
-    if (raw) {
-      const p = JSON.parse(raw) as Partial<PlanReminderPref>;
-      return {
-        on: p.on === true,
-        time: typeof p.time === "string" ? p.time : DEFAULT_PLAN_REMINDER_TIME,
-      };
-    }
-  } catch {
-    /* storage unavailable */
-  }
-  return { ...FALLBACK };
+export async function readPlanReminderPref(): Promise<PlanReminderPref> {
+  return (await webReminderStore.read()).plan;
 }
 
 /** Persist the preference and notify the scheduler (and any open toggles). */
-export function setPlanReminderPref(pref: PlanReminderPref): void {
-  try {
-    localStorage.setItem(PLAN_REMINDER_KEY, JSON.stringify(pref));
-  } catch {
-    /* storage unavailable */
-  }
+export async function setPlanReminderPref(pref: PlanReminderPref): Promise<void> {
+  await webReminderStore.writePlan(pref);
   window.dispatchEvent(new CustomEvent(PLAN_REMINDER_KEY, { detail: pref }));
 }
 
-/**
- * (Re)schedule the active plan's daily reminder through the notifier. Idempotent:
- * cancels the pending one first, then schedules the next occurrence of the chosen
- * time with copy reflecting today's progress. A no-op when the reminder is off,
- * permission isn't granted, there's no active plan, or the time is malformed.
- */
-export async function syncPlanReminder(notifier: Notifier): Promise<void> {
-  await notifier.cancel(PLAN_REMINDER_ID);
-  const pref = readPlanReminderPref();
-  if (!pref.on || notifier.permission() !== "granted") return;
-
-  const plan = await readActivePlan();
-  if (!plan || plan.pausedOn) return; // a paused plan doesn't nudge (#68)
-
-  const at = nextDailyReminder(pref.time, new Date());
-  if (!at) return;
-
-  const { title, body } = planReminderContent(plan, todayStr());
-  await notifier.schedule({
-    id: PLAN_REMINDER_ID,
-    title,
-    body,
-    at: at.toISOString(),
-    tag: PLAN_REMINDER_ID,
+/** (Re)schedule the active plan's daily reminder through the shared orchestration. */
+export function syncPlanReminder(notifier: Notifier): Promise<void> {
+  return coreSyncPlanReminder({
+    notifier,
+    reminders: webReminderStore,
+    plans: webPlanStore,
+    now: () => new Date(),
   });
 }

--- a/apps/web/src/lib/prayer-reminders.ts
+++ b/apps/web/src/lib/prayer-reminders.ts
@@ -1,69 +1,43 @@
 /**
- * Per-prayer reminders, wired off the prayer-times module (ADR 0019). All local:
- * the per-prayer on/off map lives in `localStorage`; the decision of *what* and
- * *when* is the pure core helper `prayerReminders`; *delivery* goes through the
- * {@link Notifier} port (the web adapter fires while a tab is open). No server
- * push — the honest limit of a no-backend, local-first app.
+ * Per-prayer reminders — web wiring (ADR 0019). The per-prayer on/off map goes
+ * through the {@link webReminderStore} (`ReminderStore` port, ADR 0024); the
+ * decision of *what* and *when* is the shared `syncPrayerReminders` in
+ * `@ummahlibrary/core`; *delivery* is the {@link Notifier} port (the web adapter
+ * fires while a tab is open). No server push — the honest limit of a no-backend,
+ * local-first app.
  */
+import type { Notifier, PrayerName } from "@ummahlibrary/core";
+import { OBLIGATORY_PRAYERS, syncPrayerReminders as coreSyncPrayerReminders } from "@ummahlibrary/core";
+import { webPrayerTimingsProvider } from "./prayer-timings-provider";
+import { webReminderStore } from "./reminder-store";
 
-import {
-  type Notifier,
-  OBLIGATORY_PRAYERS,
-  PRAYER_LABELS,
-  type PrayerName,
-  prayerReminders,
-} from "@ummahlibrary/core";
-import { ensureTodaysTimings } from "./adhkar-reminders";
-
+/** Event dispatched on a preference change so the scheduler re-syncs. */
 export const PRAYER_REMINDERS_KEY = "ul.prayerReminders";
 
 export type PrayerReminderPrefs = Partial<Record<PrayerName, boolean>>;
 
-export function readPrayerReminderPrefs(): PrayerReminderPrefs {
-  try {
-    const raw = localStorage.getItem(PRAYER_REMINDERS_KEY);
-    return raw ? (JSON.parse(raw) as PrayerReminderPrefs) : {};
-  } catch {
-    return {};
-  }
+export async function readPrayerReminderPrefs(): Promise<PrayerReminderPrefs> {
+  return (await webReminderStore.read()).prayers;
 }
 
 /** Flip one prayer's reminder, persist it, and notify listeners (the scheduler). */
-export function setPrayerReminder(prayer: PrayerName, on: boolean): PrayerReminderPrefs {
-  const prefs = { ...readPrayerReminderPrefs(), [prayer]: on };
-  try {
-    localStorage.setItem(PRAYER_REMINDERS_KEY, JSON.stringify(prefs));
-  } catch {
-    /* storage unavailable */
-  }
+export async function setPrayerReminder(prayer: PrayerName, on: boolean): Promise<PrayerReminderPrefs> {
+  const prefs = { ...(await readPrayerReminderPrefs()), [prayer]: on };
+  await webReminderStore.writePrayers(prefs);
   window.dispatchEvent(new CustomEvent(PRAYER_REMINDERS_KEY, { detail: prefs }));
   return prefs;
 }
 
-export function anyPrayerReminderOn(prefs: PrayerReminderPrefs = readPrayerReminderPrefs()): boolean {
+export function anyPrayerReminderOn(prefs: PrayerReminderPrefs): boolean {
   return OBLIGATORY_PRAYERS.some((p) => prefs[p]);
 }
 
-/**
- * (Re)schedule today's enabled prayer notifications through the given notifier.
- * Idempotent: cancels everything first, then schedules each still-upcoming
- * enabled prayer. A no-op without permission, a location, or any reminder on.
- */
-export async function syncPrayerReminders(notifier: Notifier): Promise<void> {
-  await notifier.cancelAll();
-  const prefs = readPrayerReminderPrefs();
-  if (!anyPrayerReminderOn(prefs) || notifier.permission() !== "granted") return;
-
-  const timings = await ensureTodaysTimings();
-  if (!timings) return;
-
-  for (const reminder of prayerReminders(timings, prefs, new Date())) {
-    await notifier.schedule({
-      id: `prayer:${reminder.prayer}`,
-      title: `${PRAYER_LABELS[reminder.prayer]} — time to pray`,
-      body: "It’s time for prayer. Tap to open Ummah Library.",
-      at: reminder.at,
-      tag: `prayer:${reminder.prayer}`,
-    });
-  }
+/** (Re)schedule today's enabled prayer notifications through the shared orchestration. */
+export function syncPrayerReminders(notifier: Notifier): Promise<void> {
+  return coreSyncPrayerReminders({
+    notifier,
+    reminders: webReminderStore,
+    timings: webPrayerTimingsProvider,
+    now: () => new Date(),
+  });
 }

--- a/apps/web/src/lib/prayer-settings-store.ts
+++ b/apps/web/src/lib/prayer-settings-store.ts
@@ -1,0 +1,60 @@
+/**
+ * Web `PrayerSettingsStore` adapter (ADR 0024): the reader's prayer-times
+ * location and calculation config in `localStorage` under the existing
+ * `ul.prayerCoords` / `ul.prayerMethod` / `ul.prayerMadhab` keys (shared by
+ * prayer times, qibla, Ramadan, and reminders). Persistence only — `read()`
+ * applies the defaults; a synced adapter (#25) can replace it. Mirrors mobile.
+ */
+import type { Coordinates, Madhab, PrayerSettingsStore } from "@ummahlibrary/core";
+import { DEFAULT_CALCULATION_METHOD } from "@ummahlibrary/core";
+
+const COORDS_KEY = "ul.prayerCoords";
+const METHOD_KEY = "ul.prayerMethod";
+const MADHAB_KEY = "ul.prayerMadhab";
+
+export const webPrayerSettingsStore: PrayerSettingsStore = {
+  read: async () => {
+    let coords: Coordinates | null = null;
+    let method = DEFAULT_CALCULATION_METHOD;
+    let madhab: Madhab = "shafi";
+    try {
+      const raw = localStorage.getItem(COORDS_KEY);
+      coords = raw ? (JSON.parse(raw) as Coordinates) : null;
+    } catch {
+      /* storage unavailable */
+    }
+    try {
+      method = localStorage.getItem(METHOD_KEY) ?? DEFAULT_CALCULATION_METHOD;
+    } catch {
+      /* keep default */
+    }
+    try {
+      madhab = (localStorage.getItem(MADHAB_KEY) as Madhab) || "shafi";
+    } catch {
+      /* keep default */
+    }
+    return { coords, method, madhab };
+  },
+  writeCoords: async (coords) => {
+    try {
+      if (coords) localStorage.setItem(COORDS_KEY, JSON.stringify(coords));
+      else localStorage.removeItem(COORDS_KEY);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  writeMethod: async (method) => {
+    try {
+      localStorage.setItem(METHOD_KEY, method);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  writeMadhab: async (madhab) => {
+    try {
+      localStorage.setItem(MADHAB_KEY, madhab);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};

--- a/apps/web/src/lib/prayer-timings-provider.ts
+++ b/apps/web/src/lib/prayer-timings-provider.ts
@@ -1,0 +1,55 @@
+/**
+ * Web `PrayerTimingsProvider` adapter: today's prayer timings for the stored
+ * location. Fetches the existing `/api/v1/prayer-times` function once per day and
+ * caches the result under `ul.adhkarTimings`; location and calculation config
+ * come from the {@link webPrayerSettingsStore}. Returns `null` when no location
+ * is stored (the reader hasn't used prayer times/qibla yet) or the lookup fails.
+ * This keeps the reminder orchestration in `core` free of I/O.
+ */
+import type { PrayerTimings, PrayerTimingsProvider } from "@ummahlibrary/core";
+import { webPrayerSettingsStore } from "./prayer-settings-store";
+
+const TIMINGS_KEY = "ul.adhkarTimings";
+
+function localDate(d = new Date()): string {
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+export const webPrayerTimingsProvider: PrayerTimingsProvider = {
+  getTodaysTimings: async () => {
+    const { coords, method, madhab } = await webPrayerSettingsStore.read();
+    if (!coords) return null;
+
+    try {
+      const raw = localStorage.getItem(TIMINGS_KEY);
+      if (raw) {
+        const cached = JSON.parse(raw) as { date: string; timings: PrayerTimings };
+        if (cached.date === localDate()) return cached.timings;
+      }
+    } catch {
+      /* fall through to refetch */
+    }
+
+    const params = new URLSearchParams({
+      lat: String(coords.latitude),
+      lng: String(coords.longitude),
+      date: localDate(),
+      method,
+      madhab,
+    });
+    try {
+      const res = await fetch(`/api/v1/prayer-times?${params}`);
+      if (!res.ok) return null;
+      const data = (await res.json()) as { timings: PrayerTimings };
+      try {
+        localStorage.setItem(TIMINGS_KEY, JSON.stringify({ date: localDate(), timings: data.timings }));
+      } catch {
+        /* ignore cache write failure */
+      }
+      return data.timings;
+    } catch {
+      return null;
+    }
+  },
+};

--- a/apps/web/src/lib/reminder-store.ts
+++ b/apps/web/src/lib/reminder-store.ts
@@ -1,0 +1,101 @@
+/**
+ * Web `ReminderStore` adapter (ADR 0024): the reader's reminder preferences in
+ * `localStorage` under the existing `ul.planReminder` / `ul.prayerReminders` /
+ * `ul.adhkarReminders` keys (so existing prefs carry over). Persistence only —
+ * the reminder orchestration lives in `@ummahlibrary/core`; a synced adapter
+ * (#25) can replace this. `read()` applies the defaults.
+ *
+ * Also hosts the adhkar banner's "dismissed today" state — web-only UI chrome,
+ * not a cross-platform pref, so it stays out of the core port but still behind a
+ * `*-store` adapter (the one sanctioned home for raw `localStorage`).
+ */
+import type { AdhkarOccasion, PlanReminderPref, PrayerName, ReminderStore } from "@ummahlibrary/core";
+import { DEFAULT_PLAN_REMINDER_TIME } from "@ummahlibrary/core";
+
+const PLAN_KEY = "ul.planReminder";
+const PRAYERS_KEY = "ul.prayerReminders";
+const ADHKAR_KEY = "ul.adhkarReminders";
+const SEEN_KEY = "ul.adhkarReminderSeen";
+
+export const webReminderStore: ReminderStore = {
+  read: async () => {
+    let plan: PlanReminderPref = { on: false, time: DEFAULT_PLAN_REMINDER_TIME };
+    try {
+      const raw = localStorage.getItem(PLAN_KEY);
+      if (raw) {
+        const p = JSON.parse(raw) as Partial<PlanReminderPref>;
+        plan = {
+          on: p.on === true,
+          time: typeof p.time === "string" ? p.time : DEFAULT_PLAN_REMINDER_TIME,
+        };
+      }
+    } catch {
+      /* keep default */
+    }
+
+    let prayers: Partial<Record<PrayerName, boolean>> = {};
+    try {
+      const raw = localStorage.getItem(PRAYERS_KEY);
+      prayers = raw ? (JSON.parse(raw) as Partial<Record<PrayerName, boolean>>) : {};
+    } catch {
+      /* keep default */
+    }
+
+    let adhkarOn = false;
+    try {
+      adhkarOn = localStorage.getItem(ADHKAR_KEY) === "on";
+    } catch {
+      /* keep default */
+    }
+
+    return { plan, prayers, adhkarOn };
+  },
+  writePlan: async (pref) => {
+    try {
+      localStorage.setItem(PLAN_KEY, JSON.stringify(pref));
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  writePrayers: async (prefs) => {
+    try {
+      localStorage.setItem(PRAYERS_KEY, JSON.stringify(prefs));
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  writeAdhkarOn: async (on) => {
+    try {
+      localStorage.setItem(ADHKAR_KEY, on ? "on" : "off");
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};
+
+function localDate(d = new Date()): string {
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+/** Adhkar occasions the reader has dismissed in the banner today (web UI state). */
+export function readAdhkarSeen(now = new Date()): AdhkarOccasion[] {
+  try {
+    const raw = localStorage.getItem(SEEN_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as { date: string; dismissed: AdhkarOccasion[] };
+    return parsed.date === localDate(now) ? parsed.dismissed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Mark an adhkar occasion dismissed for today. */
+export function dismissAdhkar(occasion: AdhkarOccasion, now = new Date()): void {
+  const dismissed = Array.from(new Set([...readAdhkarSeen(now), occasion]));
+  try {
+    localStorage.setItem(SEEN_KEY, JSON.stringify({ date: localDate(now), dismissed }));
+  } catch {
+    /* storage unavailable */
+  }
+}


### PR DESCRIPTION
## What

Migrates the web reminder feature off raw `localStorage` onto the ADR-0024 store-port pattern, and delegates scheduling to the shared core orchestration from #122.

**New web adapters**
- `webReminderStore` — reminder prefs (`ReminderStore` port), same `ul.*` keys so existing prefs carry over
- `webPrayerSettingsStore` — coords / method / madhab (`PrayerSettingsStore` port)
- `webPrayerTimingsProvider` — today's timings; absorbs the `/api/v1/prayer-times` fetch + per-day cache that was inline in `adhkar-reminders`

**Reminder libs → thin web layers**
- `plan-reminders` / `adhkar-reminders` / `prayer-reminders` now read prefs via the store and schedule via core `syncX` with the web adapters injected. Public API is preserved (event keys for the schedulers, pref helpers, sync fns); the pref reads/writes are now **async**.
- Consumers updated for the async reads: `PlanReminderToggle`, `AdhkarReminderToggle`, `PrayerTimesView`, `AdhkarReminderBanner`.

**Notes**
- The adhkar banner's *dismissed-today* state moves into `reminder-store` — web-only UI chrome, kept out of the core port but behind a `*-store` adapter (a sanctioned `localStorage` home).
- The schedulers are unchanged: their per-feature `WebNotifier` instances still work, and core now cancels by id-space so families never clear each other.
- Minor: gitignore the personal `.claude/settings.local.json`.

## Result

Zero raw `localStorage` remains in the 6 reminder files. This is the first feature fully on the store-port pattern after the enforcement groundwork.

## Checks
`pnpm lint` + `pnpm typecheck` green; **471 tests pass** (build runs in CI).