### PR TITLE
test(web): restore reminder lib coverage gate

### DIFF
--- a/apps/web/src/lib/adhkar-reminders.test.ts
+++ b/apps/web/src/lib/adhkar-reminders.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AppNotification, Notifier, NotifyPermission } from "@ummahlibrary/core";
+import {
+  ADHKAR_EMOJI,
+  ADHKAR_LABEL,
+  ensureTodaysTimings,
+  readCoords,
+  remindersEnabled,
+  setRemindersEnabled,
+  syncAdhkarReminder,
+} from "./adhkar-reminders";
+
+class FakeNotifier implements Notifier {
+  scheduled = new Map<string, AppNotification>();
+  constructor(private readonly perm: NotifyPermission = "granted") {}
+  isSupported() {
+    return true;
+  }
+  permission() {
+    return this.perm;
+  }
+  async requestPermission() {
+    return this.perm;
+  }
+  async schedule(n: AppNotification) {
+    this.scheduled.set(n.id, n);
+  }
+  async cancel(id: string) {
+    this.scheduled.delete(id);
+  }
+  async cancelAll() {
+    this.scheduled.clear();
+  }
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("adhkar reminder web wiring", () => {
+  it("round-trips the enabled preference through the store", async () => {
+    expect(await remindersEnabled()).toBe(false);
+    await setRemindersEnabled(true);
+    expect(await remindersEnabled()).toBe(true);
+  });
+
+  it("reads coords from the shared prayer settings", async () => {
+    expect(await readCoords()).toBeNull();
+    localStorage.setItem("ul.prayerCoords", JSON.stringify({ latitude: 1, longitude: 2 }));
+    expect(await readCoords()).toEqual({ latitude: 1, longitude: 2 });
+  });
+
+  it("returns null timings without a stored location", async () => {
+    expect(await ensureTodaysTimings()).toBeNull();
+  });
+
+  it("schedules nothing when enabled but no location is set", async () => {
+    await setRemindersEnabled(true);
+    const n = new FakeNotifier("granted");
+    await syncAdhkarReminder(n);
+    expect(n.scheduled.size).toBe(0);
+  });
+
+  it("exposes display labels for each occasion", () => {
+    expect(ADHKAR_LABEL.morning).toBe("morning");
+    expect(ADHKAR_EMOJI.evening.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/lib/prayer-reminders.test.ts
+++ b/apps/web/src/lib/prayer-reminders.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AppNotification, Notifier, NotifyPermission } from "@ummahlibrary/core";
+import {
+  anyPrayerReminderOn,
+  readPrayerReminderPrefs,
+  setPrayerReminder,
+  syncPrayerReminders,
+} from "./prayer-reminders";
+
+class FakeNotifier implements Notifier {
+  scheduled = new Map<string, AppNotification>();
+  constructor(private readonly perm: NotifyPermission = "granted") {}
+  isSupported() {
+    return true;
+  }
+  permission() {
+    return this.perm;
+  }
+  async requestPermission() {
+    return this.perm;
+  }
+  async schedule(n: AppNotification) {
+    this.scheduled.set(n.id, n);
+  }
+  async cancel(id: string) {
+    this.scheduled.delete(id);
+  }
+  async cancelAll() {
+    this.scheduled.clear();
+  }
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("prayer reminder web wiring", () => {
+  it("round-trips per-prayer preferences through the store", async () => {
+    expect(await readPrayerReminderPrefs()).toEqual({});
+    const next = await setPrayerReminder("fajr", true);
+    expect(next.fajr).toBe(true);
+    expect(await readPrayerReminderPrefs()).toEqual({ fajr: true });
+  });
+
+  it("anyPrayerReminderOn reflects whether any obligatory prayer is enabled", () => {
+    expect(anyPrayerReminderOn({})).toBe(false);
+    expect(anyPrayerReminderOn({ sunrise: true })).toBe(false); // sunrise isn't obligatory
+    expect(anyPrayerReminderOn({ dhuhr: true })).toBe(true);
+  });
+
+  it("schedules nothing without permission", async () => {
+    await setPrayerReminder("dhuhr", true);
+    const n = new FakeNotifier("denied");
+    await syncPrayerReminders(n);
+    expect(n.scheduled.size).toBe(0);
+  });
+});

--- a/apps/web/src/lib/prayer-settings-store.test.ts
+++ b/apps/web/src/lib/prayer-settings-store.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { webPrayerSettingsStore as store } from "./prayer-settings-store";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("webPrayerSettingsStore", () => {
+  it("reads the defaults when nothing is stored", async () => {
+    expect(await store.read()).toEqual({
+      coords: null,
+      method: "MuslimWorldLeague",
+      madhab: "shafi",
+    });
+  });
+
+  it("round-trips coords, method, and madhab under the existing keys", async () => {
+    await store.writeCoords({ latitude: 21.42, longitude: 39.83 });
+    await store.writeMethod("Egyptian");
+    await store.writeMadhab("hanafi");
+
+    expect(await store.read()).toEqual({
+      coords: { latitude: 21.42, longitude: 39.83 },
+      method: "Egyptian",
+      madhab: "hanafi",
+    });
+    expect(localStorage.getItem("ul.prayerCoords")).toBe('{"latitude":21.42,"longitude":39.83}');
+    expect(localStorage.getItem("ul.prayerMethod")).toBe("Egyptian");
+  });
+
+  it("clears the stored location when coords are written null", async () => {
+    await store.writeCoords({ latitude: 1, longitude: 2 });
+    await store.writeCoords(null);
+    expect((await store.read()).coords).toBeNull();
+    expect(localStorage.getItem("ul.prayerCoords")).toBeNull();
+  });
+
+  it("falls back to defaults on a malformed coords value", async () => {
+    localStorage.setItem("ul.prayerCoords", "{not json");
+    expect((await store.read()).coords).toBeNull();
+  });
+});

--- a/apps/web/src/lib/prayer-timings-provider.test.ts
+++ b/apps/web/src/lib/prayer-timings-provider.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrayerTimings } from "@ummahlibrary/core";
+import { webPrayerTimingsProvider as provider } from "./prayer-timings-provider";
+
+const TIMINGS: PrayerTimings = {
+  fajr: "2026-06-21T03:00:00.000Z",
+  sunrise: "2026-06-21T04:30:00.000Z",
+  dhuhr: "2026-06-21T12:00:00.000Z",
+  asr: "2026-06-21T15:30:00.000Z",
+  maghrib: "2026-06-21T19:00:00.000Z",
+  isha: "2026-06-21T20:30:00.000Z",
+};
+
+const setCoords = () =>
+  localStorage.setItem("ul.prayerCoords", JSON.stringify({ latitude: 21.42, longitude: 39.83 }));
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("webPrayerTimingsProvider", () => {
+  it("returns null when no location is stored", async () => {
+    expect(await provider.getTodaysTimings()).toBeNull();
+  });
+
+  it("fetches today's timings once and serves the rest from cache", async () => {
+    setCoords();
+    const fetchMock = vi.fn(
+      async () => ({ ok: true, json: async () => ({ timings: TIMINGS }) }) as unknown as Response,
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await provider.getTodaysTimings()).toEqual(TIMINGS);
+    expect(await provider.getTodaysTimings()).toEqual(TIMINGS); // cache hit
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null on a non-ok response", async () => {
+    setCoords();
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false }) as Response));
+    expect(await provider.getTodaysTimings()).toBeNull();
+  });
+
+  it("returns null when the request throws", async () => {
+    setCoords();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    expect(await provider.getTodaysTimings()).toBeNull();
+  });
+});

--- a/apps/web/src/lib/reminder-store.test.ts
+++ b/apps/web/src/lib/reminder-store.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { dismissAdhkar, readAdhkarSeen, webReminderStore as store } from "./reminder-store";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("webReminderStore", () => {
+  it("reads the defaults when nothing is stored", async () => {
+    expect(await store.read()).toEqual({
+      plan: { on: false, time: "20:00" },
+      prayers: {},
+      adhkarOn: false,
+    });
+  });
+
+  it("round-trips plan, prayer, and adhkar preferences under the existing keys", async () => {
+    await store.writePlan({ on: true, time: "07:30" });
+    await store.writePrayers({ fajr: true, isha: false });
+    await store.writeAdhkarOn(true);
+
+    const r = await store.read();
+    expect(r.plan).toEqual({ on: true, time: "07:30" });
+    expect(r.prayers).toEqual({ fajr: true, isha: false });
+    expect(r.adhkarOn).toBe(true);
+    // adhkar stays the historical "on"/"off" string
+    expect(localStorage.getItem("ul.adhkarReminders")).toBe("on");
+  });
+
+  it("falls back safely on malformed stored values", async () => {
+    localStorage.setItem("ul.planReminder", "{nope");
+    localStorage.setItem("ul.prayerReminders", "{nope");
+    const r = await store.read();
+    expect(r.plan).toEqual({ on: false, time: "20:00" });
+    expect(r.prayers).toEqual({});
+  });
+});
+
+describe("adhkar banner dismissed-today state", () => {
+  it("records and reads dismissals for today", () => {
+    expect(readAdhkarSeen()).toEqual([]);
+    dismissAdhkar("morning");
+    expect(readAdhkarSeen()).toContain("morning");
+    // dismissing again is idempotent
+    dismissAdhkar("morning");
+    expect(readAdhkarSeen()).toEqual(["morning"]);
+  });
+
+  it("ignores dismissals recorded on a previous day", () => {
+    dismissAdhkar("evening", new Date("2026-06-20T10:00:00Z"));
+    expect(readAdhkarSeen(new Date("2026-06-21T10:00:00Z"))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Fix-forward for the coverage gate. #123 added the reminder adapters + rewired the libs but shipped without tests, dropping `apps/web/src/lib/**` **function coverage to 90.97%** (gate: 95%). That check failed on #123's CI and was admin-merged in error — this restores it.

Adds focused tests for:
- `webReminderStore` (round-trips, malformed fallback, banner dismissed-today state)
- `webPrayerSettingsStore` (defaults, round-trip, null-coords clear, malformed)
- `webPrayerTimingsProvider` (no-location null, fetch + cache hit, non-ok, throw — fetch mocked)
- `adhkar-reminders` / `prayer-reminders` web wrappers

## Result

`vitest run --coverage` exits 0; `apps/web/src/lib` function coverage **96.22%**; 492 tests pass; lint + typecheck green.