### PR TITLE
refactor(web): prayer-settings consumers through the store port

### DIFF
--- a/apps/web/src/components/HomeHeroCards.tsx
+++ b/apps/web/src/components/HomeHeroCards.tsx
@@ -3,8 +3,6 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
-  type Coordinates,
-  DEFAULT_CALCULATION_METHOD,
   PRAYER_LABELS,
   type PrayerTimings,
   computeStreak,
@@ -12,25 +10,8 @@ import {
 } from "@ummahlibrary/core";
 import { Khatam, N } from "@ummahlibrary/ui";
 import { HomePrayerCard } from "./HomePrayerCard";
+import { webPrayerTimingsProvider } from "../lib/prayer-timings-provider";
 import { readReadingState, today } from "../lib/reading-goals";
-
-const COORDS_KEY = "ul.prayerCoords";
-const METHOD_KEY = "ul.prayerMethod";
-const MADHAB_KEY = "ul.prayerMadhab";
-
-function read<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function localDate(d: Date): string {
-  const p = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
-}
 
 function fmtTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
@@ -58,24 +39,9 @@ export function HomeHeroCards() {
     void readReadingState().then((s) =>
       setReading({ pages: s.pagesToday, goal: s.goal, streak: computeStreak(s.activeDates, today()) }),
     );
-    const saved = read<Coordinates | null>(COORDS_KEY, null);
-    if (saved) {
-      const method = localStorage.getItem(METHOD_KEY) ?? DEFAULT_CALCULATION_METHOD;
-      const madhab = localStorage.getItem(MADHAB_KEY) ?? "shafi";
-      const params = new URLSearchParams({
-        lat: String(saved.latitude),
-        lng: String(saved.longitude),
-        date: localDate(new Date()),
-        method,
-        madhab,
-      });
-      fetch(`/api/v1/prayer-times?${params}`)
-        .then((res) => (res.ok ? res.json() : null))
-        .then((data: { timings: PrayerTimings } | null) => {
-          if (data) setTimings(data.timings);
-        })
-        .catch(() => {});
-    }
+    void webPrayerTimingsProvider.getTodaysTimings().then((t) => {
+      if (t) setTimings(t);
+    });
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/components/PrayerTimesView.tsx
+++ b/apps/web/src/components/PrayerTimesView.tsx
@@ -22,22 +22,10 @@ import {
   readPrayerReminderPrefs,
   setPrayerReminder,
 } from "../lib/prayer-reminders";
+import { webPrayerSettingsStore } from "../lib/prayer-settings-store";
 import { WebNotifier } from "../lib/web-notifier";
 
-const METHOD_KEY = "ul.prayerMethod";
-const MADHAB_KEY = "ul.prayerMadhab";
-const COORDS_KEY = "ul.prayerCoords";
-
 type Status = "idle" | "locating" | "loading" | "ready" | "error" | "denied";
-
-function read<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
 
 /** Local calendar date as YYYY-MM-DD (not UTC — prayer times are a local concept). */
 function localDate(d: Date): string {
@@ -136,17 +124,16 @@ export function PrayerTimesView() {
 
   // Restore preferences + last location, and load times if we have a location.
   useEffect(() => {
-    const m = localStorage.getItem(METHOD_KEY) ?? DEFAULT_CALCULATION_METHOD;
-    const mad = (localStorage.getItem(MADHAB_KEY) as Madhab) || "shafi";
-    const saved = read<Coordinates | null>(COORDS_KEY, null);
-    setMethod(m);
-    setMadhab(mad);
+    void webPrayerSettingsStore.read().then(({ coords: saved, method: m, madhab: mad }) => {
+      setMethod(m);
+      setMadhab(mad);
+      if (saved) {
+        setCoords(saved);
+        void fetchTimings(saved, m, mad);
+      }
+    });
     void readPrayerReminderPrefs().then(setReminders);
     setPermission(getNotifier().permission());
-    if (saved) {
-      setCoords(saved);
-      void fetchTimings(saved, m, mad);
-    }
   }, [fetchTimings]);
 
   // Tick the clock for the live countdown.
@@ -165,11 +152,7 @@ export function PrayerTimesView() {
       (pos) => {
         const c = { latitude: pos.coords.latitude, longitude: pos.coords.longitude };
         setCoords(c);
-        try {
-          localStorage.setItem(COORDS_KEY, JSON.stringify(c));
-        } catch {
-          /* storage unavailable */
-        }
+        void webPrayerSettingsStore.writeCoords(c);
         void fetchTimings(c, method, madhab);
       },
       () => setStatus("denied"),
@@ -179,12 +162,12 @@ export function PrayerTimesView() {
 
   function changeMethod(m: string) {
     setMethod(m);
-    localStorage.setItem(METHOD_KEY, m);
+    void webPrayerSettingsStore.writeMethod(m);
     if (coords) void fetchTimings(coords, m, madhab);
   }
   function changeMadhab(m: Madhab) {
     setMadhab(m);
-    localStorage.setItem(MADHAB_KEY, m);
+    void webPrayerSettingsStore.writeMadhab(m);
     if (coords) void fetchTimings(coords, method, m);
   }
 

--- a/apps/web/src/components/QiblaCompass.test.tsx
+++ b/apps/web/src/components/QiblaCompass.test.tsx
@@ -19,11 +19,12 @@ describe("QiblaCompass", () => {
     expect(screen.queryByText("Qibla direction")).not.toBeInTheDocument();
   });
 
-  it("renders the qibla bearing from a saved location", () => {
+  it("renders the qibla bearing from a saved location", async () => {
     localStorage.setItem(COORDS_KEY, JSON.stringify(london));
     render(<QiblaCompass />);
 
-    expect(screen.getByText("Qibla direction")).toBeInTheDocument();
+    // Location is restored asynchronously through the prayer-settings store.
+    expect(await screen.findByText("Qibla direction")).toBeInTheDocument();
     // Bearing renders as "<degrees>° <cardinal>", e.g. "119° ESE".
     expect(screen.getByText(/^\d+° [NESW]+$/)).toBeInTheDocument();
     // The Kaaba marker sits on the needle.

--- a/apps/web/src/components/QiblaCompass.tsx
+++ b/apps/web/src/components/QiblaCompass.tsx
@@ -4,20 +4,9 @@ import type { CSSProperties } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { type Coordinates, compassPoint, qiblaDirection } from "@ummahlibrary/core";
 import { N } from "@ummahlibrary/ui";
-
-// Shared with the prayer-times page — one stored location for both.
-const COORDS_KEY = "ul.prayerCoords";
+import { webPrayerSettingsStore } from "../lib/prayer-settings-store";
 
 type Status = "idle" | "locating" | "ready" | "denied" | "error";
-
-function read<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
 
 /** iOS 13+ gates DeviceOrientation behind an explicit permission prompt. */
 interface OrientationEventStatic {
@@ -56,11 +45,12 @@ export function QiblaCompass() {
 
   // Restore the shared location on mount.
   useEffect(() => {
-    const saved = read<Coordinates | null>(COORDS_KEY, null);
-    if (saved) {
-      setCoords(saved);
-      setStatus("ready");
-    }
+    void webPrayerSettingsStore.read().then(({ coords: saved }) => {
+      if (saved) {
+        setCoords(saved);
+        setStatus("ready");
+      }
+    });
   }, []);
 
   const listenToOrientation = useCallback(() => {
@@ -109,11 +99,7 @@ export function QiblaCompass() {
         const c = { latitude: pos.coords.latitude, longitude: pos.coords.longitude };
         setCoords(c);
         setStatus("ready");
-        try {
-          localStorage.setItem(COORDS_KEY, JSON.stringify(c));
-        } catch {
-          /* storage unavailable */
-        }
+        void webPrayerSettingsStore.writeCoords(c);
       },
       () => setStatus("denied"),
       { enableHighAccuracy: false, timeout: 10000, maximumAge: 3600000 },

--- a/apps/web/src/components/ToolsPrayerCard.tsx
+++ b/apps/web/src/components/ToolsPrayerCard.tsx
@@ -3,32 +3,13 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
-  type Coordinates,
-  DEFAULT_CALCULATION_METHOD,
   OBLIGATORY_PRAYERS,
   PRAYER_LABELS,
   type PrayerTimings,
   nextPrayer,
 } from "@ummahlibrary/core";
 import { Icon, Khatam, N } from "@ummahlibrary/ui";
-
-const COORDS_KEY = "ul.prayerCoords";
-const METHOD_KEY = "ul.prayerMethod";
-const MADHAB_KEY = "ul.prayerMadhab";
-
-function read<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function localDate(d: Date): string {
-  const p = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
-}
+import { webPrayerTimingsProvider } from "../lib/prayer-timings-provider";
 
 function fmtTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
@@ -62,24 +43,9 @@ export function ToolsPrayerCard() {
 
   useEffect(() => {
     setReady(true);
-    const saved = read<Coordinates | null>(COORDS_KEY, null);
-    if (saved) {
-      const method = localStorage.getItem(METHOD_KEY) ?? DEFAULT_CALCULATION_METHOD;
-      const madhab = localStorage.getItem(MADHAB_KEY) ?? "shafi";
-      const params = new URLSearchParams({
-        lat: String(saved.latitude),
-        lng: String(saved.longitude),
-        date: localDate(new Date()),
-        method,
-        madhab,
-      });
-      fetch(`/api/v1/prayer-times?${params}`)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((d: { timings: PrayerTimings } | null) => {
-          if (d) setTimings(d.timings);
-        })
-        .catch(() => {});
-    }
+    void webPrayerTimingsProvider.getTodaysTimings().then((t) => {
+      if (t) setTimings(t);
+    });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What

Migrates the prayer-times / qibla / home / tools cards off raw `localStorage` (`ul.prayerCoords` / `ul.prayerMethod` / `ul.prayerMadhab`) onto the existing `webPrayerSettingsStore` adapter introduced in #122 — no new port.

- `HomeHeroCards` + `ToolsPrayerCard`: today's timings now come from `webPrayerTimingsProvider` (drops their inline coords-read + `/api/v1/prayer-times` fetch + cache — the provider already does it).
- `QiblaCompass` + `PrayerTimesView`: coords/method/madhab read + write via the store; each component's local `read<T>`/key constants removed.
- Reads are now async (settings restored just after mount); the QiblaCompass test awaits the restore via `findByText`.

`RamadanView` (coords + Ramadan-specific state) lands with the Ramadan PR so it's touched once.

## Checks
lint + typecheck green; `vitest run --coverage` exits 0; 492 tests pass.