### PR TITLE
refactor(web): theme persistence behind theme-store

### DIFF
--- a/apps/web/src/lib/theme-store.ts
+++ b/apps/web/src/lib/theme-store.ts
@@ -1,0 +1,30 @@
+/**
+ * Web theme persistence (ADR 0024) — the one `localStorage` home for the active
+ * theme and the last theme used in each mode. Kept **synchronous**: the theme is
+ * read before paint (the inline script in `app/layout.tsx`) to avoid a flash, so
+ * an async port can't serve it. The pure theme logic (resolving/normalising)
+ * stays in `./themes`.
+ */
+import type { ThemeMode } from "./themes";
+
+const THEME_KEY = "ul.theme";
+const lastKey = (mode: ThemeMode): string => (mode === "dark" ? "ul.lastDark" : "ul.lastLight");
+
+/** The last theme stored for a mode (raw string), or `null`. */
+export function readLastTheme(mode: ThemeMode): string | null {
+  try {
+    return localStorage.getItem(lastKey(mode));
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the active theme and remember it as the last one used in its mode. */
+export function writeActiveTheme(key: string, mode: ThemeMode): void {
+  try {
+    localStorage.setItem(THEME_KEY, key);
+    localStorage.setItem(lastKey(mode), key);
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/apps/web/src/lib/themes.ts
+++ b/apps/web/src/lib/themes.ts
@@ -1,8 +1,10 @@
 /**
- * The eight Noor theme palettes and the small amount of logic for selecting,
- * resolving and persisting them. The palettes themselves live in globals.css as
- * `[data-theme="…"]` blocks; here we only track which one is active.
+ * The eight Noor theme palettes and the small amount of logic for selecting and
+ * resolving them. The palettes themselves live in globals.css as `[data-theme="…"]`
+ * blocks; here we only track which one is active. Persistence is delegated to the
+ * `./theme-store` adapter (ADR 0024).
  */
+import { readLastTheme, writeActiveTheme } from "./theme-store";
 
 export type ThemeMode = "dark" | "light";
 
@@ -38,9 +40,6 @@ export const THEMES: ThemeMeta[] = [
 export const DEFAULT_DARK: ThemeKey = "obsidian";
 export const DEFAULT_LIGHT: ThemeKey = "ivory";
 
-/** localStorage key holding the active theme. */
-export const THEME_STORAGE_KEY = "ul.theme";
-
 const BY_KEY = new Map<string, ThemeMeta>(THEMES.map((t) => [t.key, t]));
 const LEGACY: Record<string, ThemeKey> = { dark: DEFAULT_DARK, light: DEFAULT_LIGHT };
 
@@ -58,8 +57,7 @@ export function themeMode(key: ThemeKey): ThemeMode {
 /** The theme last used in a given mode, or that mode's default. */
 export function lastThemeForMode(mode: ThemeMode): ThemeKey {
   const fallback = mode === "dark" ? DEFAULT_DARK : DEFAULT_LIGHT;
-  if (typeof localStorage === "undefined") return fallback;
-  const stored = localStorage.getItem(mode === "dark" ? "ul.lastDark" : "ul.lastLight");
+  const stored = readLastTheme(mode);
   const key = stored ? normalizeTheme(stored) : null;
   return key && themeMode(key) === mode ? key : fallback;
 }
@@ -70,10 +68,5 @@ export function applyTheme(key: ThemeKey): void {
   const root = document.documentElement;
   root.dataset.theme = key;
   root.dataset.mode = mode;
-  try {
-    localStorage.setItem(THEME_STORAGE_KEY, key);
-    localStorage.setItem(mode === "dark" ? "ul.lastDark" : "ul.lastLight", key);
-  } catch {
-    /* ignore */
-  }
+  writeActiveTheme(key, mode);
 }


### PR DESCRIPTION
## What
Moves the active-theme + last-per-mode `localStorage` out of `themes.ts` into a dedicated `theme-store.ts` adapter (ADR 0024). `themes.ts` keeps only the pure resolve/normalise logic.

Kept **synchronous** on purpose — the theme is read before paint (the inline FOUC script in `app/layout.tsx`) so an async port can't serve it; the `*-store` file is the sanctioned `localStorage` home. Public API (`applyTheme`, `lastThemeForMode`) is unchanged, so ThemeToggle/ThemePicker are untouched.

## Checks
lint + typecheck green; `vitest run --coverage` exits 0 (theme-store 100% fn cov); 492 tests pass.