### PR TITLE
refactor(web): reader UI prefs behind reader-prefs-store

### DIFF
--- a/apps/web/src/components/ReaderControls.tsx
+++ b/apps/web/src/components/ReaderControls.tsx
@@ -5,18 +5,10 @@ import { useEffect, useState } from "react";
 import { EditionManager } from "./EditionManager";
 import { readBookmarks, toggleBookmark as toggleBm } from "../lib/bookmarks";
 import { readScale, writeScale } from "../lib/reader-prefs";
+import { writeLastRead } from "../lib/reader-prefs-store";
 
-const LAST_READ_KEY = "ul.lastRead";
 const SCALE_MIN = 0.8;
 const SCALE_MAX = 1.8;
-
-function write(key: string, value: unknown): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    /* storage unavailable — ignore */
-  }
-}
 
 export function ReaderControls({
   surahNumber,
@@ -33,7 +25,7 @@ export function ReaderControls({
   // Hydrate from localStorage and record this surah as last-read.
   useEffect(() => {
     void readBookmarks().then((list) => setBookmarked(list.includes(surahNumber)));
-    write(LAST_READ_KEY, { surah: surahNumber });
+    writeLastRead(surahNumber);
 
     void readScale().then((s) => {
       setScale(s);

--- a/apps/web/src/components/ReaderShortcuts.tsx
+++ b/apps/web/src/components/ReaderShortcuts.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { readScroll, writeScroll } from "../lib/reader-prefs-store";
 
 /**
  * Reader keyboard shortcuts, a top reading-progress bar, and scroll-position
@@ -73,23 +74,13 @@ export function ReaderShortcuts({ storageKey }: { storageKey: string }) {
         setProgress(max > 0 ? Math.min(100, Math.max(0, (doc.scrollTop / max) * 100)) : 0);
       });
       if (saveTimer) clearTimeout(saveTimer);
-      saveTimer = setTimeout(() => {
-        try {
-          sessionStorage.setItem(scrollKey, String(window.scrollY));
-        } catch {
-          /* storage unavailable */
-        }
-      }, 250);
+      saveTimer = setTimeout(() => writeScroll(scrollKey, window.scrollY), 250);
     }
 
     // Restore scroll position unless the URL deep-links to a specific āyah.
     if (!window.location.hash) {
-      try {
-        const saved = Number(sessionStorage.getItem(scrollKey));
-        if (saved > 0) window.scrollTo(0, saved);
-      } catch {
-        /* storage unavailable */
-      }
+      const saved = readScroll(scrollKey);
+      if (saved > 0) window.scrollTo(0, saved);
     }
     onScroll();
 

--- a/apps/web/src/components/ReaderToolbar.tsx
+++ b/apps/web/src/components/ReaderToolbar.tsx
@@ -8,22 +8,14 @@ import { type EditionChoice, DEFAULT_EDITIONS, readEditions } from "../lib/editi
 import { fetchCatalogue } from "../lib/catalogue";
 import { readBookmarks, toggleBookmark as toggleBm } from "../lib/bookmarks";
 import { readReciter, readScale, writeReciter, writeScale } from "../lib/reader-prefs";
+import { readWordByWord, writeLastRead, writeWordByWord } from "../lib/reader-prefs-store";
 import { TranslationSettings } from "./TranslationSettings";
 import { TafsirPicker } from "./TafsirPicker";
 import { WBW_KEY } from "./WordByWord";
 
 const SCALE_MIN = 0.8;
 const SCALE_MAX = 1.8;
-const LAST_READ_KEY = "ul.lastRead";
 const RECITER_KEY = "ul.reciter";
-
-function write(key: string, value: unknown): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    /* storage unavailable */
-  }
-}
 
 interface SegOption {
   value: string;
@@ -67,11 +59,11 @@ export function ReaderToolbar({
       document.documentElement.style.setProperty("--reading-scale", String(s));
     });
     void readBookmarks().then((list) => setBookmarked(list.includes(surahNumber)));
-    write(LAST_READ_KEY, { surah: surahNumber });
+    writeLastRead(surahNumber);
     void readReciter().then((r) => {
       if (r && reciters.some((x) => x.id === r)) setReciterId(r);
     });
-    const wbwOn = localStorage.getItem(WBW_KEY) === "1";
+    const wbwOn = readWordByWord();
     setWbw(wbwOn);
     document.body.classList.toggle("wbw-on", wbwOn);
     void readEditions().then((ids) => setSelected(new Set(ids)));
@@ -82,12 +74,8 @@ export function ReaderToolbar({
     const next = !wbw;
     setWbw(next);
     document.body.classList.toggle("wbw-on", next);
-    try {
-      localStorage.setItem(WBW_KEY, next ? "1" : "0");
-      window.dispatchEvent(new CustomEvent(WBW_KEY, { detail: next }));
-    } catch {
-      /* ignore */
-    }
+    writeWordByWord(next);
+    window.dispatchEvent(new CustomEvent(WBW_KEY, { detail: next }));
   }
 
   function changeScale(delta: number) {

--- a/apps/web/src/components/ReadingAudio.tsx
+++ b/apps/web/src/components/ReadingAudio.tsx
@@ -4,9 +4,9 @@ import { useEffect, useRef, useState } from "react";
 import { type ReciterPlugin, quranComAudioUrl, reciterAudioUrl } from "@ummahlibrary/core";
 import { N, Icon } from "@ummahlibrary/ui";
 import { readReciter, writeReciter } from "../lib/reader-prefs";
+import { readLoop, writeLoop } from "../lib/reader-prefs-store";
 
 const RECITER_KEY = "ul.reciter";
-const LOOP_KEY = "ul.loop";
 
 interface Verse {
   sura: number;
@@ -87,7 +87,7 @@ export function ReadingAudio({
     void readReciter().then((saved) => {
       if (saved && reciters.some((r) => r.id === saved)) setReciterId(saved);
     });
-    const savedLoop = localStorage.getItem(LOOP_KEY) === "1";
+    const savedLoop = readLoop();
     setLoop(savedLoop);
     loopRef.current = savedLoop;
 
@@ -107,7 +107,7 @@ export function ReadingAudio({
     const next = !loopRef.current;
     loopRef.current = next;
     setLoop(next);
-    localStorage.setItem(LOOP_KEY, next ? "1" : "0");
+    writeLoop(next);
   }
 
   function clearWord() {

--- a/apps/web/src/components/ReadingShelf.tsx
+++ b/apps/web/src/components/ReadingShelf.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { readBookmarks } from "../lib/bookmarks";
+import { readLastRead } from "../lib/reader-prefs-store";
 
 interface SurahRef {
   number: number;
@@ -10,23 +11,14 @@ interface SurahRef {
   englishName: string;
 }
 
-function read<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-/** Client-only "continue reading" + bookmarks, backed by localStorage. */
+/** Client-only "continue reading" + bookmarks, backed by the reader-prefs store. */
 export function ReadingShelf({ surahs }: { surahs: SurahRef[] }) {
   const [lastRead, setLastRead] = useState<number | null>(null);
   const [bookmarks, setBookmarks] = useState<number[]>([]);
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    setLastRead(read<{ surah: number } | null>("ul.lastRead", null)?.surah ?? null);
+    setLastRead(readLastRead());
     void readBookmarks().then(setBookmarks);
     setReady(true);
   }, []);

--- a/apps/web/src/lib/reader-prefs-store.test.ts
+++ b/apps/web/src/lib/reader-prefs-store.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  readLastRead,
+  readLoop,
+  readScroll,
+  readWordByWord,
+  writeLastRead,
+  writeLoop,
+  writeScroll,
+  writeWordByWord,
+} from "./reader-prefs-store";
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
+afterEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+describe("reader-prefs-store", () => {
+  it("round-trips the last-read surah", () => {
+    expect(readLastRead()).toBeNull();
+    writeLastRead(36);
+    expect(readLastRead()).toBe(36);
+  });
+
+  it("returns null last-read on a malformed value", () => {
+    localStorage.setItem("ul.lastRead", "{nope");
+    expect(readLastRead()).toBeNull();
+  });
+
+  it("round-trips the word-by-word toggle", () => {
+    expect(readWordByWord()).toBe(false);
+    writeWordByWord(true);
+    expect(readWordByWord()).toBe(true);
+    expect(localStorage.getItem("ul.wbw")).toBe("1");
+    writeWordByWord(false);
+    expect(readWordByWord()).toBe(false);
+  });
+
+  it("round-trips the audio loop toggle", () => {
+    expect(readLoop()).toBe(false);
+    writeLoop(true);
+    expect(readLoop()).toBe(true);
+  });
+
+  it("round-trips a per-page scroll offset in sessionStorage", () => {
+    expect(readScroll("ul.scroll.2")).toBe(0);
+    writeScroll("ul.scroll.2", 540);
+    expect(readScroll("ul.scroll.2")).toBe(540);
+  });
+});

--- a/apps/web/src/lib/reader-prefs-store.ts
+++ b/apps/web/src/lib/reader-prefs-store.ts
@@ -1,0 +1,80 @@
+/**
+ * Web reader-UI preferences (ADR 0024) — the raw-storage home for small
+ * per-reader display state: the last-read surah, the word-by-word toggle, the
+ * audio loop, and per-page scroll position. Kept **synchronous** (these are read
+ * during render / scroll restore, before paint), so components import these
+ * helpers instead of touching `localStorage` / `sessionStorage` directly. This
+ * `*-store` file is the sanctioned raw-storage home.
+ */
+
+const LAST_READ_KEY = "ul.lastRead";
+const LOOP_KEY = "ul.loop";
+// Mirrors the event key exported by components/WordByWord.
+const WBW_KEY = "ul.wbw";
+
+/** The surah number the reader last opened, or `null`. */
+export function readLastRead(): number | null {
+  try {
+    const raw = localStorage.getItem(LAST_READ_KEY);
+    return raw ? ((JSON.parse(raw) as { surah?: number }).surah ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeLastRead(surah: number): void {
+  try {
+    localStorage.setItem(LAST_READ_KEY, JSON.stringify({ surah }));
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+export function readWordByWord(): boolean {
+  try {
+    return localStorage.getItem(WBW_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeWordByWord(on: boolean): void {
+  try {
+    localStorage.setItem(WBW_KEY, on ? "1" : "0");
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+export function readLoop(): boolean {
+  try {
+    return localStorage.getItem(LOOP_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeLoop(on: boolean): void {
+  try {
+    localStorage.setItem(LOOP_KEY, on ? "1" : "0");
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+/** Per-page scroll offset (session-scoped — restores within a tab session). */
+export function readScroll(key: string): number {
+  try {
+    return Number(sessionStorage.getItem(key)) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function writeScroll(key: string, y: number): void {
+  try {
+    sessionStorage.setItem(key, String(y));
+  } catch {
+    /* storage unavailable */
+  }
+}


### PR DESCRIPTION
## What
Moves the reader components' small per-reader display state off raw `localStorage`/`sessionStorage` into a dedicated `reader-prefs-store.ts` adapter (ADR 0024): last-read surah, word-by-word toggle, audio loop, and per-page scroll position.

Kept **synchronous** (read during render / scroll restore); the `*-store` file is the sanctioned raw-storage home. Components (`ReaderToolbar`, `ReaderControls`, `ReadingAudio`, `ReaderShortcuts`, `ReadingShelf`) keep their `CustomEvent` dispatches — only storage moves.

## Checks
lint + typecheck green; `vitest run --coverage` exits 0; 497 tests pass (new reader-prefs-store tests included).