### PR TITLE
refactor(web): Ramadan + Hijri persistence behind stores

### DIFF
--- a/apps/web/src/components/RamadanView.tsx
+++ b/apps/web/src/components/RamadanView.tsx
@@ -2,15 +2,11 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import {
-  type Coordinates,
-  DEFAULT_CALCULATION_METHOD,
-  type PrayerTimings,
-  gregorianToHijri,
-  hijriMonth,
-} from "@ummahlibrary/core";
+import { type PrayerTimings, gregorianToHijri, hijriMonth } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
 import type { IconName } from "@ummahlibrary/ui";
+import { webPrayerSettingsStore } from "../lib/prayer-settings-store";
+import { webPrayerTimingsProvider } from "../lib/prayer-timings-provider";
 import { RAMADAN_EVENT, readFasts, readWorship, toggleFast, toggleWorship } from "../lib/ramadan";
 import { readReadingState } from "../lib/reading-goals";
 
@@ -35,15 +31,6 @@ function countdown(target: Date, now: Date): string {
   const m = Math.floor(s / 60);
   s -= m * 60;
   return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-}
-
-function read<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
 }
 
 const statCard = {
@@ -83,23 +70,10 @@ export function RamadanView() {
     sync();
     window.addEventListener(RAMADAN_EVENT, sync);
 
-    const coords = read<Coordinates | null>("ul.prayerCoords", null);
-    if (coords) {
-      setHasCoords(true);
-      const method = localStorage.getItem("ul.prayerMethod") ?? DEFAULT_CALCULATION_METHOD;
-      const madhab = localStorage.getItem("ul.prayerMadhab") ?? "shafi";
-      const params = new URLSearchParams({
-        lat: String(coords.latitude),
-        lng: String(coords.longitude),
-        date: today,
-        method,
-        madhab,
-      });
-      fetch(`/api/v1/prayer-times?${params}`)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((d: { timings: PrayerTimings } | null) => d && setTimings(d.timings))
-        .catch(() => {});
-    }
+    void webPrayerSettingsStore.read().then(({ coords }) => setHasCoords(coords !== null));
+    void webPrayerTimingsProvider.getTodaysTimings().then((t) => {
+      if (t) setTimings(t);
+    });
     return () => window.removeEventListener(RAMADAN_EVENT, sync);
   }, [today]);
 

--- a/apps/web/src/lib/hijri-store.ts
+++ b/apps/web/src/lib/hijri-store.ts
@@ -1,0 +1,22 @@
+/**
+ * Web persistence for the Hijri-date adjustment (ADR 0024), under
+ * `ul.hijriAdjust`. Sync; the `*-store` file is the sanctioned `localStorage`
+ * home. Clamping and the change event live in `./hijri`.
+ */
+const KEY = "ul.hijriAdjust";
+
+export function readAdjustRaw(): string | null {
+  try {
+    return localStorage.getItem(KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeAdjustRaw(value: number): void {
+  try {
+    localStorage.setItem(KEY, String(value));
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/apps/web/src/lib/hijri.ts
+++ b/apps/web/src/lib/hijri.ts
@@ -5,6 +5,8 @@
  * on-page Hijri date re-renders together.
  */
 
+import { readAdjustRaw, writeAdjustRaw } from "./hijri-store";
+
 export const HIJRI_ADJUST_KEY = "ul.hijriAdjust";
 
 /** Clamp to a sane range — a sighting is never more than a couple of days out. */
@@ -13,21 +15,13 @@ function clamp(n: number): number {
 }
 
 export function readHijriAdjust(): number {
-  try {
-    const raw = localStorage.getItem(HIJRI_ADJUST_KEY);
-    const n = raw === null ? 0 : Number.parseInt(raw, 10);
-    return Number.isFinite(n) ? clamp(n) : 0;
-  } catch {
-    return 0;
-  }
+  const raw = readAdjustRaw();
+  const n = raw === null ? 0 : Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? clamp(n) : 0;
 }
 
 export function writeHijriAdjust(days: number): void {
   const value = clamp(days);
-  try {
-    localStorage.setItem(HIJRI_ADJUST_KEY, String(value));
-  } catch {
-    /* storage unavailable — ignore */
-  }
+  writeAdjustRaw(value);
   window.dispatchEvent(new CustomEvent(HIJRI_ADJUST_KEY, { detail: value }));
 }

--- a/apps/web/src/lib/ramadan-store.test.ts
+++ b/apps/web/src/lib/ramadan-store.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readFastsRaw, readWorshipRaw, writeFastsRaw, writeWorshipRaw } from "./ramadan-store";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("ramadan-store", () => {
+  it("round-trips kept fasts", () => {
+    expect(readFastsRaw()).toEqual({});
+    writeFastsRaw({ 1: true, 3: true });
+    expect(readFastsRaw()).toEqual({ 1: true, 3: true });
+  });
+
+  it("round-trips the per-date worship checklist", () => {
+    expect(readWorshipRaw()).toEqual({});
+    writeWorshipRaw({ "2026-03-01": { taraweeh: true } });
+    expect(readWorshipRaw()["2026-03-01"]).toEqual({ taraweeh: true });
+  });
+
+  it("falls back to empty on a malformed value", () => {
+    localStorage.setItem("ul.ramadanFasts", "{nope");
+    expect(readFastsRaw()).toEqual({});
+  });
+});

--- a/apps/web/src/lib/ramadan-store.ts
+++ b/apps/web/src/lib/ramadan-store.ts
@@ -1,0 +1,41 @@
+/**
+ * Web persistence for Ramaḍān tracking (ADR 0024): kept fasts (`ul.ramadanFasts`)
+ * and the per-date worship checklist (`ul.ramadanWorship`). Sync; the `*-store`
+ * file is the sanctioned `localStorage` home. The toggle logic and the change
+ * event live in `./ramadan`.
+ */
+const FASTS_KEY = "ul.ramadanFasts";
+const WORSHIP_KEY = "ul.ramadanWorship";
+
+function get<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function set(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+export function readFastsRaw(): Record<number, true> {
+  return get<Record<number, true>>(FASTS_KEY, {});
+}
+
+export function writeFastsRaw(value: Record<number, true>): void {
+  set(FASTS_KEY, value);
+}
+
+export function readWorshipRaw(): Record<string, Record<string, true>> {
+  return get<Record<string, Record<string, true>>>(WORSHIP_KEY, {});
+}
+
+export function writeWorshipRaw(value: Record<string, Record<string, true>>): void {
+  set(WORSHIP_KEY, value);
+}

--- a/apps/web/src/lib/ramadan.ts
+++ b/apps/web/src/lib/ramadan.ts
@@ -1,28 +1,19 @@
 /**
- * Local-first Ramaḍān tracking (ADR 0006): which of the 30 fasts you've kept
- * (`ul.ramadanFasts`) and today's worship checklist (`ul.ramadanWorship`, keyed
- * by date). All in `localStorage`; a window event lets the page re-render.
- * Mirrors the mobile Ramadan screen's storage.
+ * Local-first Ramaḍān tracking (ADR 0006): which of the 30 fasts you've kept and
+ * the per-date worship checklist. Persistence goes through the `./ramadan-store`
+ * adapter (ADR 0024); a window event lets the page re-render. Mirrors the mobile
+ * Ramadan screen's storage.
  */
+import {
+  readFastsRaw,
+  readWorshipRaw,
+  writeFastsRaw,
+  writeWorshipRaw,
+} from "./ramadan-store";
 
 export const RAMADAN_EVENT = "ul.ramadan";
-const FASTS_KEY = "ul.ramadanFasts";
-const WORSHIP_KEY = "ul.ramadanWorship";
 
-function get<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-function set(key: string, value: unknown): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    /* storage unavailable */
-  }
+function emit(): void {
   try {
     window.dispatchEvent(new CustomEvent(RAMADAN_EVENT));
   } catch {
@@ -31,26 +22,28 @@ function set(key: string, value: unknown): void {
 }
 
 export function readFasts(): Record<number, true> {
-  return get<Record<number, true>>(FASTS_KEY, {});
+  return readFastsRaw();
 }
 
 export function toggleFast(day: number): Record<number, true> {
-  const next = { ...readFasts() };
+  const next = { ...readFastsRaw() };
   if (next[day]) delete next[day];
   else next[day] = true;
-  set(FASTS_KEY, next);
+  writeFastsRaw(next);
+  emit();
   return next;
 }
 
 export function readWorship(date: string): Record<string, true> {
-  return get<Record<string, Record<string, true>>>(WORSHIP_KEY, {})[date] ?? {};
+  return readWorshipRaw()[date] ?? {};
 }
 
 export function toggleWorship(date: string, key: string): Record<string, true> {
-  const all = get<Record<string, Record<string, true>>>(WORSHIP_KEY, {});
+  const all = readWorshipRaw();
   const day = { ...(all[date] ?? {}) };
   if (day[key]) delete day[key];
   else day[key] = true;
-  set(WORSHIP_KEY, { ...all, [date]: day });
+  writeWorshipRaw({ ...all, [date]: day });
+  emit();
   return day;
 }


### PR DESCRIPTION
## What
- **hijri-store** (`ul.hijriAdjust`) — `hijri.ts` keeps clamping + the change event, delegates storage.
- **ramadan-store** (`ul.ramadanFasts` / `ul.ramadanWorship`) — `ramadan.ts` keeps the toggle logic + `RAMADAN_EVENT`, delegates storage (+ tests).
- **RamadanView** — location via `webPrayerSettingsStore`, today's timings via `webPrayerTimingsProvider` (drops its inline coords-read + `/api/v1/prayer-times` fetch).

## Checks
lint + typecheck green; `vitest run --coverage` exits 0; 503 tests pass.