### PR TITLE
refactor(web): search/zakat/adhkar persistence behind stores

### DIFF
--- a/apps/web/src/components/SearchView.tsx
+++ b/apps/web/src/components/SearchView.tsx
@@ -5,10 +5,14 @@ import Link from "next/link";
 import { searchText } from "@ummahlibrary/core";
 import { N, Icon, Khatam } from "@ummahlibrary/ui";
 import type { IconName } from "@ummahlibrary/ui";
+import {
+  clearHistory as clearStoredHistory,
+  readHistory,
+  writeHistory,
+} from "../lib/search-history-store";
 
 const ENGLISH_EDITION = "eng-mustafakhattaba";
 const ENGLISH_URL = `https://cdn.jsdelivr.net/gh/fawazahmed0/quran-api@1/editions/${ENGLISH_EDITION}.min.json`;
-const HISTORY_KEY = "ul.searchHistory";
 const MAX_HISTORY = 6;
 
 const TOPICS = ["mercy", "patience", "Mulk", "forgiveness", "knowledge", "Raḥmān", "guidance", "light"];
@@ -167,15 +171,6 @@ async function buildIndex(surahs: SurahRef[]): Promise<SearchItem[]> {
   return items;
 }
 
-function readHistory(): string[] {
-  try {
-    const raw = localStorage.getItem(HISTORY_KEY);
-    return raw ? (JSON.parse(raw) as string[]) : [];
-  } catch {
-    return [];
-  }
-}
-
 function highlight(text: string, q: string): React.ReactNode {
   const at = text.toLowerCase().indexOf(q.toLowerCase());
   if (!q || at < 0) return text;
@@ -238,20 +233,12 @@ export function SearchView({ surahs }: { surahs: SurahRef[] }) {
     if (trimmed.length < 2) return;
     const next = [trimmed, ...history.filter((h) => h !== trimmed)].slice(0, MAX_HISTORY);
     setHistory(next);
-    try {
-      localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
-    } catch {
-      /* storage unavailable */
-    }
+    writeHistory(next);
   }
 
   function clearHistory() {
     setHistory([]);
-    try {
-      localStorage.removeItem(HISTORY_KEY);
-    } catch {
-      /* ignore */
-    }
+    clearStoredHistory();
   }
 
   // Count by filter key (surahs fold into "ayah"/Quran).

--- a/apps/web/src/components/ZakatCalculator.tsx
+++ b/apps/web/src/components/ZakatCalculator.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { type NisabBasis, ZAKAT_ASSET_CATEGORIES, calculateZakat } from "@ummahlibrary/core";
 import { N, Khatam } from "@ummahlibrary/ui";
+import { readZakat, writeZakat } from "../lib/zakat-store";
 
-const STORAGE_KEY = "ul.zakat";
 const lcard = { background: N.card, border: `1px solid ${N.border}`, borderRadius: 16 } as const;
 
 interface State {
@@ -120,29 +120,20 @@ export function ZakatCalculator() {
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        const saved = JSON.parse(raw) as Partial<State>;
-        setState({
-          ...DEFAULT_STATE,
-          ...saved,
-          assets: { ...EMPTY_ASSETS, ...(saved.assets ?? {}) },
-        });
-      }
-    } catch {
-      /* ignore corrupt storage */
+    const saved = readZakat() as Partial<State> | null;
+    if (saved) {
+      setState({
+        ...DEFAULT_STATE,
+        ...saved,
+        assets: { ...EMPTY_ASSETS, ...(saved.assets ?? {}) },
+      });
     }
     setLoaded(true);
   }, []);
 
   useEffect(() => {
     if (!loaded) return;
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-    } catch {
-      /* storage unavailable */
-    }
+    writeZakat(state);
   }, [state, loaded]);
 
   const result = useMemo(

--- a/apps/web/src/lib/adhkar-counts-store.ts
+++ b/apps/web/src/lib/adhkar-counts-store.ts
@@ -1,0 +1,28 @@
+/**
+ * Web persistence for adhkar tap-tallies (ADR 0024), under `ul.adhkar`. Sync;
+ * the `*-store` file is the sanctioned `localStorage` home. The per-day reset
+ * logic lives in `./adhkar`.
+ */
+const KEY = "ul.adhkar";
+
+export interface StoredAdhkar {
+  date: string;
+  counts: Record<string, number>;
+}
+
+export function readStored(): StoredAdhkar | null {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as StoredAdhkar) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStored(value: StoredAdhkar): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(value));
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/apps/web/src/lib/adhkar.ts
+++ b/apps/web/src/lib/adhkar.ts
@@ -1,15 +1,10 @@
 /**
  * Local-first adhkar progress (ADR 0006 + 0016). Tap tallies are kept per day
  * and reset automatically at the next calendar day — your morning/evening
- * remembrances start fresh each day, on the device, with no account.
+ * remembrances start fresh each day, on the device, with no account. Persistence
+ * goes through the `./adhkar-counts-store` adapter (ADR 0024).
  */
-
-const STORAGE_KEY = "ul.adhkar";
-
-interface Stored {
-  date: string;
-  counts: Record<string, number>;
-}
+import { readStored, writeStored } from "./adhkar-counts-store";
 
 /** Local calendar date as YYYY-MM-DD (adhkar are a local, daily concept). */
 export function adhkarToday(d = new Date()): string {
@@ -19,20 +14,11 @@ export function adhkarToday(d = new Date()): string {
 
 /** Today's tallies (empty if nothing saved today — yesterday's reset away). */
 export function readAdhkarCounts(): Record<string, number> {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as Stored;
-    return parsed.date === adhkarToday() ? (parsed.counts ?? {}) : {};
-  } catch {
-    return {};
-  }
+  const parsed = readStored();
+  if (!parsed) return {};
+  return parsed.date === adhkarToday() ? (parsed.counts ?? {}) : {};
 }
 
 export function writeAdhkarCounts(counts: Record<string, number>): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ date: adhkarToday(), counts } satisfies Stored));
-  } catch {
-    /* storage unavailable — ignore */
-  }
+  writeStored({ date: adhkarToday(), counts });
 }

--- a/apps/web/src/lib/search-history-store.test.ts
+++ b/apps/web/src/lib/search-history-store.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearHistory, readHistory, writeHistory } from "./search-history-store";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("search-history-store", () => {
+  it("reads an empty history by default", () => {
+    expect(readHistory()).toEqual([]);
+  });
+
+  it("round-trips and clears the history", () => {
+    writeHistory(["fatiha", "ayatul kursi"]);
+    expect(readHistory()).toEqual(["fatiha", "ayatul kursi"]);
+    clearHistory();
+    expect(readHistory()).toEqual([]);
+  });
+
+  it("falls back to empty on a malformed value", () => {
+    localStorage.setItem("ul.searchHistory", "{nope");
+    expect(readHistory()).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/search-history-store.ts
+++ b/apps/web/src/lib/search-history-store.ts
@@ -1,0 +1,30 @@
+/**
+ * Web persistence for recent search queries (ADR 0024), under `ul.searchHistory`.
+ * Sync; the `*-store` file is the sanctioned `localStorage` home.
+ */
+const KEY = "ul.searchHistory";
+
+export function readHistory(): string[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeHistory(history: string[]): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(history));
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+export function clearHistory(): void {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/apps/web/src/lib/zakat-store.test.ts
+++ b/apps/web/src/lib/zakat-store.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readZakat, writeZakat } from "./zakat-store";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("zakat-store", () => {
+  it("reads null when nothing is saved", () => {
+    expect(readZakat()).toBeNull();
+  });
+
+  it("round-trips the saved state", () => {
+    writeZakat({ assets: { cash: 1000 }, currency: "USD" });
+    expect(readZakat()).toEqual({ assets: { cash: 1000 }, currency: "USD" });
+  });
+
+  it("falls back to null on a malformed value", () => {
+    localStorage.setItem("ul.zakat", "{nope");
+    expect(readZakat()).toBeNull();
+  });
+});

--- a/apps/web/src/lib/zakat-store.ts
+++ b/apps/web/src/lib/zakat-store.ts
@@ -1,0 +1,23 @@
+/**
+ * Web persistence for the zakat calculator's saved inputs (ADR 0024), under
+ * `ul.zakat`. Sync; the `*-store` file is the sanctioned `localStorage` home.
+ * The caller owns the state shape (this layer is shape-agnostic).
+ */
+const KEY = "ul.zakat";
+
+export function readZakat(): unknown {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeZakat(state: unknown): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(state));
+  } catch {
+    /* storage unavailable */
+  }
+}


### PR DESCRIPTION
## What
- **adhkar-counts-store** (`ul.adhkar`) — `adhkar.ts` keeps the per-day reset logic, delegates storage.
- **search-history-store** (`ul.searchHistory`) — `SearchView` delegates (+ tests).
- **zakat-store** (`ul.zakat`, shape-agnostic) — `ZakatCalculator` delegates (+ tests).

## Checks
lint + typecheck green; `vitest run --coverage` exits 0; 509 tests pass.