### PR TITLE
feat(lint): enforce persistence-behind-a-port app-wide + backup-store

### DIFF
--- a/apps/extension/src/lib/theme-store.ts
+++ b/apps/extension/src/lib/theme-store.ts
@@ -1,0 +1,23 @@
+/**
+ * Synchronous theme mirror for the extension popup (ADR 0024) — a `localStorage`
+ * copy of the chosen theme, read before paint to avoid a flash (the authoritative
+ * value lives in `chrome.storage.sync` via `./storage`, which is async). This
+ * `*-store` file is the sanctioned synchronous-`localStorage` home.
+ */
+const MIRROR_KEY = "ul.ext.themeMirror";
+
+export function readThemeMirror(): string | null {
+  try {
+    return localStorage.getItem(MIRROR_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeThemeMirror(key: string): void {
+  try {
+    localStorage.setItem(MIRROR_KEY, key);
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
+}

--- a/apps/extension/src/lib/theme.ts
+++ b/apps/extension/src/lib/theme.ts
@@ -1,16 +1,12 @@
 import { noorThemes } from "@ummahlibrary/ui";
 import type { ThemeKey } from "@ummahlibrary/ui";
 import { getPref, setPref } from "./storage";
+import { readThemeMirror, writeThemeMirror } from "./theme-store";
 
 /** All Noor themes, in palette order — the single source (ADR 0023/0027). */
 export const THEME_KEYS = Object.keys(noorThemes) as ThemeKey[];
 
 const DEFAULT_THEME: ThemeKey = "obsidian";
-
-/** Synchronous mirror of the chosen theme, read before paint to avoid a flash.
- *  (chrome.storage.sync is async; localStorage is synchronous.) Distinct from the
- *  `getPref`/`setPref` namespace so the two writes never alias. */
-const MIRROR_KEY = "ul.ext.themeMirror";
 
 function isThemeKey(value: unknown): value is ThemeKey {
   return typeof value === "string" && (THEME_KEYS as string[]).includes(value);
@@ -24,12 +20,8 @@ export function applyTheme(key: ThemeKey): void {
 
 /** Best-effort synchronous read for pre-paint. Falls back to the default. */
 export function readThemeSync(): ThemeKey {
-  try {
-    const v = localStorage.getItem(MIRROR_KEY);
-    return isThemeKey(v) ? v : DEFAULT_THEME;
-  } catch {
-    return DEFAULT_THEME;
-  }
+  const v = readThemeMirror();
+  return isThemeKey(v) ? v : DEFAULT_THEME;
 }
 
 /** Authoritative read from synced storage (follows the user across devices),
@@ -42,10 +34,6 @@ export async function getStoredTheme(): Promise<ThemeKey> {
 /** Persist + apply: synced pref (cross-device) + the synchronous mirror. */
 export async function setStoredTheme(key: ThemeKey): Promise<void> {
   applyTheme(key);
-  try {
-    localStorage.setItem(MIRROR_KEY, key);
-  } catch {
-    /* storage unavailable — non-fatal */
-  }
+  writeThemeMirror(key);
   await setPref("theme", key);
 }

--- a/apps/web/src/lib/backup-store.ts
+++ b/apps/web/src/lib/backup-store.ts
@@ -1,0 +1,41 @@
+/**
+ * Web backup storage adapter (ADR 0024) — the **one** place that enumerates the
+ * whole `ul.*` key-space in `localStorage`, so the backup feature can snapshot,
+ * restore, and clear it. The envelope/validate/merge logic is pure in
+ * `@ummahlibrary/core`; this file is the sanctioned raw-`localStorage` home.
+ */
+import { isBackupKey } from "@ummahlibrary/core";
+
+/** Every local-first (`ul.*`) key in localStorage, with its raw string value. */
+export function snapshot(): Record<string, string> {
+  const out: Record<string, string> = {};
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && isBackupKey(key)) {
+        const value = localStorage.getItem(key);
+        if (value !== null) out[key] = value;
+      }
+    }
+  } catch {
+    /* storage unavailable */
+  }
+  return out;
+}
+
+/** Write the given entries; when `replace`, clear existing `ul.*` keys first. */
+export function restore(entries: Record<string, string>, replace: boolean): void {
+  if (replace) for (const key of Object.keys(snapshot())) localStorage.removeItem(key);
+  for (const [key, value] of Object.entries(entries)) localStorage.setItem(key, value);
+}
+
+/** Remove every local-first (`ul.*`) key. Returns how many were removed. */
+export function clearAll(): number {
+  const keys = Object.keys(snapshot());
+  try {
+    for (const key of keys) localStorage.removeItem(key);
+  } catch {
+    /* storage unavailable */
+  }
+  return keys.length;
+}

--- a/apps/web/src/lib/backup.ts
+++ b/apps/web/src/lib/backup.ts
@@ -4,29 +4,12 @@
  * merge logic is pure in `@ummahlibrary/core`.
  */
 
-import {
-  type MergeStrategy,
-  buildBackup,
-  isBackupKey,
-  mergeBackups,
-  validateBackup,
-} from "@ummahlibrary/core";
+import { type MergeStrategy, buildBackup, mergeBackups, validateBackup } from "@ummahlibrary/core";
+import { clearAll, restore, snapshot } from "./backup-store";
 
 /** Every local-first (`ul.*`) key in localStorage, with its raw string value. */
 export function collectLocalData(): Record<string, string> {
-  const out: Record<string, string> = {};
-  try {
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i);
-      if (key && isBackupKey(key)) {
-        const value = localStorage.getItem(key);
-        if (value !== null) out[key] = value;
-      }
-    }
-  } catch {
-    /* storage unavailable */
-  }
-  return out;
+  return snapshot();
 }
 
 export function exportBackup(): void {
@@ -60,13 +43,9 @@ export function importBackup(text: string, strategy: MergeStrategy): ImportResul
   if (errors.length) return { ok: false, message: errors.join(" ") };
 
   const incoming = (parsed as { data: Record<string, string> }).data;
-  const merged = mergeBackups(collectLocalData(), incoming, strategy);
+  const merged = mergeBackups(snapshot(), incoming, strategy);
   try {
-    if (strategy === "replace") {
-      // Clear existing ul.* keys so a replace is a true restore.
-      for (const key of Object.keys(collectLocalData())) localStorage.removeItem(key);
-    }
-    for (const [key, value] of Object.entries(merged)) localStorage.setItem(key, value);
+    restore(merged, strategy === "replace");
   } catch {
     return { ok: false, message: "Couldn’t write to local storage." };
   }
@@ -78,11 +57,5 @@ export function importBackup(text: string, strategy: MergeStrategy): ImportResul
 }
 
 export function clearAllData(): number {
-  const keys = Object.keys(collectLocalData());
-  try {
-    for (const key of keys) localStorage.removeItem(key);
-  } catch {
-    /* ignore */
-  }
-  return keys.length;
+  return clearAll();
 }

--- a/docs/adr/0028-persistence-enforcement.md
+++ b/docs/adr/0028-persistence-enforcement.md
@@ -1,0 +1,57 @@
+# ADR 0028 — Persistence behind store adapters is lint-enforced
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+- **Amends:** [ADR 0024](0024-local-storage-ports.md), [ADR 0001](0001-modular-monolith.md)
+
+## Context
+
+ADR 0024 established the pattern: on-device state lives behind a Store **port**,
+with a per-platform adapter (`localStorage` on web, `AsyncStorage` on mobile,
+`chrome.storage` in the extension), so a future synced adapter (#25) can replace
+the storage without touching feature logic. ADR 0001 makes `core` pure and
+points dependencies inward.
+
+Both were **convention only**. In practice the pattern was about half-adopted on
+web: ~30 feature files (and the reminder feature, which blocked sharing its
+scheduling logic with mobile — see the reminder-orchestration work) read and
+wrote `localStorage`/`sessionStorage` **directly**. `eslint-plugin-boundaries`
+caught cross-package *imports* but could not see global usage, nondeterminism, or
+raw storage, so nothing stopped a new direct-storage write from landing.
+
+## Decision
+
+**Encode the invariants as ESLint rules so they fail the build, and migrate every
+existing violation so the rules can ship with no allowlist.**
+
+Two checks in `eslint.config.mjs` (the same engine as the boundaries rule):
+
+- **Check A — `core` purity** (`packages/core/src/**`): `no-restricted-globals`
+  (no `window`/`document`/`localStorage`/`fetch`/`process`/…), `no-restricted-syntax`
+  (no `Date.now()`/`Math.random()` — inject the clock, see `hifz.ts`), and
+  `no-restricted-imports` (no Node built-ins). A bare `new Date()` **default
+  parameter** stays allowed (the injected-clock idiom). Codifies ADR 0001 #1/#3.
+- **Check B — persistence behind a port** (`apps/**`): `no-restricted-globals`
+  for `localStorage`/`sessionStorage`/`indexedDB` and `no-restricted-imports` for
+  `@react-native-async-storage/async-storage`. The **only** sanctioned raw-storage
+  homes are the adapter files: `*-store.ts`, `*-provider.ts`, the web
+  `web-notifier.ts`, and each app's `storage.ts`. **No legacy allowlist** — every
+  feature was migrated first.
+
+To make Check B shippable, all web feature storage was moved behind adapters
+(reminders, prayer settings, theme, reader prefs, asma, hifz-streak, ramadan,
+hijri, search history, zakat, adhkar) plus a `backup-store` (the one place that
+enumerates the whole `ul.*` key-space) and the extension's theme mirror. Reader
+state that is read before paint (theme, reader prefs, scroll) uses **synchronous**
+adapters — an async port can't serve a pre-paint read; the FOUC inline script in
+`app/layout.tsx` reads `localStorage` as a string and is not feature code.
+
+## Consequences
+
+- A new direct `localStorage`/`AsyncStorage` use in feature code now **fails CI**;
+  the fix is to add (or route through) a Store adapter, never to relax the rule.
+- The reminder orchestration is now platform-neutral in `core`, unblocking the
+  native `ExpoNotifier` (#71).
+- The synced-storage adapter (#25), when it lands, swaps the adapter files only.
+- Adding a genuinely new storage adapter means a `*-store.ts` / `*-provider.ts` /
+  `storage.ts` file (already carved out) — not a feature-code exception.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ through Phases 1–3; later decisions get their own record at the time they're m
 | [0025](0025-reading-plans.md)                 | Reading plans: pure schedule engine, catalogue bundled in core   | Accepted |
 | [0026](0026-browser-extension.md)             | Browser extension: thin client over the public REST API          | Accepted |
 | [0027](0027-generated-theme-css.md)           | Theme CSS generated from one token source (amends 0023)          | Accepted |
+| [0028](0028-persistence-enforcement.md)       | Persistence behind store adapters is lint-enforced (amends 0024) | Accepted |
 
 ## Writing a new ADR
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -187,4 +187,43 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // Check B — persistence behind a port (ADR 0024). App feature code must not
+    // touch raw web storage; it goes through a Store adapter so a synced adapter
+    // (#25) can replace it. The ONLY sanctioned raw-storage homes are the adapter
+    // files carved out below (`*-store` / `*-provider` / the notifier / each app's
+    // `storage.ts`). No legacy allowlist — every feature is migrated.
+    files: ["apps/**/*.{ts,tsx}"],
+    ignores: [
+      "apps/**/*.test.{ts,tsx}",
+      "apps/web/src/test-setup.ts",
+      "apps/*/scripts/**",
+      "apps/**/*-store.ts",
+      "apps/**/*-provider.ts",
+      "apps/web/src/lib/web-notifier.ts",
+      "apps/*/src/**/storage.ts",
+    ],
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        ...["localStorage", "sessionStorage", "indexedDB"].map((name) => ({
+          name,
+          message:
+            "Persisted state must go through a Store adapter (ADR 0024): keep raw web storage in a *-store / *-provider / storage.ts file, not in feature code.",
+        })),
+      ],
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@react-native-async-storage/async-storage",
+              message:
+                "Persisted state must go through a Store adapter (ADR 0024): keep AsyncStorage in a *-store / storage.ts file.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 );


### PR DESCRIPTION
## What — the capstone of the persistence migration

- **backup-store** — the single place that enumerates the whole `ul.*` key-space; `backup.ts` delegates `snapshot`/`restore`/`clearAll`.
- **extension theme-store** — the synchronous FOUC theme mirror moves out of `theme.ts`.
- **ESLint Check B** (`apps/**`): bans raw `localStorage`/`sessionStorage`/`indexedDB` and `AsyncStorage` imports outside the sanctioned adapter files (`*-store` / `*-provider` / `web-notifier` / `storage.ts`). **No legacy allowlist** — every feature was migrated first, so lint is clean with it on.
- **ADR 0028** documents Check A + Check B (amends 0024/0001).

## Result

Raw web-storage access in feature code now **fails CI**. Combined with Check A (core purity, #121), the clean-architecture invariants from ADR 0001/0024 are now machine-enforced rather than convention.

## Checks
`pnpm lint` (with Check B) + `pnpm typecheck` green; `vitest run --coverage` exits 0; 509 tests pass.