### PR TITLE
feat(mobile): ExpoNotifier + reading-plan daily reminder (#71)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { AppState } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import { useFonts } from "expo-font";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -16,6 +17,8 @@ import { RootTabs } from "./src/navigation/RootTabs";
 import { OnboardingScreen } from "./src/screens/OnboardingScreen";
 import { fontMap } from "./src/fonts";
 import { KEYS, getString, setString } from "./src/storage";
+import { initNotifier } from "./src/notifier";
+import { syncPlanReminder } from "./src/plan-reminders";
 import type { RootTabParamList } from "./src/navigation/types";
 
 /** URL routes for the web build and OS deep links (ummahlibrary://). */
@@ -106,6 +109,17 @@ function AppGate() {
 
 export default function App() {
   const [fontsLoaded] = useFonts(fontMap);
+
+  // Prime the notifier, then keep the plan reminder scheduled — re-syncing on
+  // foreground so the schedule rolls to the next day after one fires (#71).
+  useEffect(() => {
+    void initNotifier().then(() => syncPlanReminder());
+    const sub = AppState.addEventListener("change", (s) => {
+      if (s === "active") void syncPlanReminder();
+    });
+    return () => sub.remove();
+  }, []);
+
   if (!fontsLoaded) return null;
   return (
     <SafeAreaProvider>

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -51,7 +51,8 @@
           "locationWhenInUsePermission": "Allow Ummah Library to use your location to calculate prayer times and find the qibla direction."
         }
       ],
-      "expo-font"
+      "expo-font",
+      "expo-notifications"
     ],
     "extra": {
       "eas": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -32,6 +32,7 @@
     "expo-clipboard": "~8.0.8",
     "expo-font": "~14.0.12",
     "expo-location": "^19.0.8",
+    "expo-notifications": "~0.32.17",
     "expo-sensors": "^15.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.0",

--- a/apps/mobile/src/components/PlanReminderToggle.tsx
+++ b/apps/mobile/src/components/PlanReminderToggle.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useState } from "react";
+import { StyleSheet, Switch, Text, View } from "../Type";
+import { Icon, type Palette } from "@ummahlibrary/ui";
+import { DEFAULT_PLAN_REMINDER_TIME } from "@ummahlibrary/core";
+import { useTheme } from "../theme";
+import { FONT } from "../fonts";
+import { expoNotifier } from "../notifier";
+import { readPlanReminderPref, setPlanReminderPref } from "../plan-reminders";
+
+/** `"20:00"` → `"8:00 PM"`. */
+function label(time: string): string {
+  const [h, m] = time.split(":").map(Number);
+  const am = (h ?? 0) < 12;
+  const h12 = (h ?? 0) % 12 === 0 ? 12 : (h ?? 0) % 12;
+  return `${h12}:${String(m ?? 0).padStart(2, "0")} ${am ? "AM" : "PM"}`;
+}
+
+/**
+ * Opt-in daily reminder for the active plan (#71). Delivery is the OS scheduler
+ * (expo-notifications) so it fires even when the app is closed. Time is the
+ * default for now; a picker is a follow-up.
+ */
+export function PlanReminderToggle() {
+  const { colors } = useTheme();
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const [on, setOn] = useState(false);
+  const [time, setTime] = useState(DEFAULT_PLAN_REMINDER_TIME);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    void readPlanReminderPref().then((p) => {
+      setOn(p.on);
+      setTime(p.time);
+      setReady(true);
+    });
+  }, []);
+
+  async function toggle(next: boolean) {
+    if (next && expoNotifier.permission() !== "granted") await expoNotifier.requestPermission();
+    setOn(next);
+    await setPlanReminderPref({ on: next, time });
+  }
+
+  if (!ready) return null;
+
+  return (
+    <View style={styles.card}>
+      <Icon name="bell" size={17} color={on ? colors.accent : colors.muted} sw={1.8} />
+      <View style={styles.text}>
+        <Text style={styles.title}>Daily reminder</Text>
+        <Text style={styles.note}>
+          {on ? `A nudge at ${label(time)} for today's portion.` : "A gentle daily nudge for today's portion."}
+        </Text>
+      </View>
+      <Switch
+        value={on}
+        onValueChange={(v) => void toggle(v)}
+        trackColor={{ true: colors.accentSoft, false: colors.border }}
+        thumbColor={on ? colors.accent : colors.faint}
+      />
+    </View>
+  );
+}
+
+function makeStyles(c: Palette) {
+  return StyleSheet.create({
+    card: {
+      marginTop: 14,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 14,
+      padding: 14,
+      backgroundColor: c.bgElev,
+    },
+    text: { flex: 1 },
+    title: { color: c.fg, fontFamily: FONT.semibold, fontSize: 14 },
+    note: { color: c.muted, fontFamily: FONT.regular, fontSize: 12.5, marginTop: 2 },
+  });
+}

--- a/apps/mobile/src/notifier.ts
+++ b/apps/mobile/src/notifier.ts
@@ -1,0 +1,87 @@
+/**
+ * Mobile adapter for the core {@link Notifier} port, backed by expo-notifications.
+ *
+ * Unlike the web adapter (in-page timers that fire only while a tab is open), the
+ * OS scheduler delivers these even when the app is closed — the point of #71. The
+ * decision of what-and-when stays in `core` (`reminders.ts`): each notification is
+ * a one-shot at its `at`, and the app re-syncs on foreground (AppState) to roll
+ * the schedule to the next day. Cancellation is by id, matching the core
+ * orchestration, so one notifier serves every reminder family.
+ */
+import { Platform } from "react-native";
+import * as Notifications from "expo-notifications";
+import type { AppNotification, Notifier, NotifyPermission } from "@ummahlibrary/core";
+
+const CHANNEL_ID = "reminders";
+
+// permission() is synchronous in the port, but expo's lookup is async — cache the
+// last-known status, refreshed by initNotifier()/requestPermission().
+let cachedPermission: NotifyPermission = "default";
+
+function mapStatus(status: string): NotifyPermission {
+  if (status === "granted") return "granted";
+  if (status === "denied") return "denied";
+  return "default";
+}
+
+// Show reminders as a banner even while the app is in the foreground.
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+});
+
+/** Prime the Android channel and the cached permission. Call once on app start. */
+export async function initNotifier(): Promise<void> {
+  if (Platform.OS === "android") {
+    await Notifications.setNotificationChannelAsync(CHANNEL_ID, {
+      name: "Reminders",
+      importance: Notifications.AndroidImportance.DEFAULT,
+    });
+  }
+  try {
+    cachedPermission = mapStatus((await Notifications.getPermissionsAsync()).status);
+  } catch {
+    /* leave the default */
+  }
+}
+
+export const expoNotifier: Notifier = {
+  isSupported: () => true,
+  permission: () => cachedPermission,
+  requestPermission: async () => {
+    try {
+      cachedPermission = mapStatus((await Notifications.requestPermissionsAsync()).status);
+    } catch {
+      /* keep the cached value */
+    }
+    return cachedPermission;
+  },
+  schedule: async (n: AppNotification) => {
+    await Notifications.cancelScheduledNotificationAsync(n.id).catch(() => {});
+    if (cachedPermission !== "granted") return;
+    const at = n.at ? new Date(n.at) : null;
+    const trigger =
+      at && at.getTime() > Date.now()
+        ? {
+            type: Notifications.SchedulableTriggerInputTypes.DATE,
+            date: at,
+            channelId: CHANNEL_ID,
+          }
+        : null;
+    await Notifications.scheduleNotificationAsync({
+      identifier: n.id,
+      content: { title: n.title, body: n.body },
+      trigger,
+    });
+  },
+  cancel: async (id) => {
+    await Notifications.cancelScheduledNotificationAsync(id).catch(() => {});
+  },
+  cancelAll: async () => {
+    await Notifications.cancelAllScheduledNotificationsAsync();
+  },
+};

--- a/apps/mobile/src/plan-reminders.ts
+++ b/apps/mobile/src/plan-reminders.ts
@@ -1,0 +1,31 @@
+/**
+ * Reading-plan daily reminder — mobile wiring (#71). The on/off + time preference
+ * goes through the {@link mobileReminderStore} (`ReminderStore` port) and the
+ * scheduling decision is the shared `syncPlanReminder` in `@ummahlibrary/core`;
+ * this module injects the mobile adapters. Delivery is the {@link expoNotifier}
+ * (OS-scheduled — fires even when the app is closed), unlike the web's tab-bound
+ * notifier.
+ */
+import { type PlanReminderPref, syncPlanReminder as coreSyncPlanReminder } from "@ummahlibrary/core";
+import { expoNotifier } from "./notifier";
+import { mobilePlanStore } from "./plan-store";
+import { mobileReminderStore } from "./reminder-store";
+
+export async function readPlanReminderPref(): Promise<PlanReminderPref> {
+  return (await mobileReminderStore.read()).plan;
+}
+
+export async function setPlanReminderPref(pref: PlanReminderPref): Promise<void> {
+  await mobileReminderStore.writePlan(pref);
+  await syncPlanReminder();
+}
+
+/** (Re)schedule the active plan's daily reminder through the shared orchestration. */
+export function syncPlanReminder(): Promise<void> {
+  return coreSyncPlanReminder({
+    notifier: expoNotifier,
+    reminders: mobileReminderStore,
+    plans: mobilePlanStore,
+    now: () => new Date(),
+  });
+}

--- a/apps/mobile/src/reminder-store.ts
+++ b/apps/mobile/src/reminder-store.ts
@@ -1,0 +1,35 @@
+/**
+ * Mobile `ReminderStore` adapter (ADR 0024): the reader's reminder preferences
+ * in AsyncStorage under the same `ul.*` keys the web uses, so both clients
+ * describe the same local-first state. Persistence only — the reminder
+ * orchestration lives in `@ummahlibrary/core`. Mirrors the web adapter.
+ */
+import {
+  DEFAULT_PLAN_REMINDER_TIME,
+  type PlanReminderPref,
+  type PrayerName,
+  type ReminderPrefs,
+  type ReminderStore,
+} from "@ummahlibrary/core";
+import { KEYS, getJSON, getString, setJSON, setString } from "./storage";
+
+export const mobileReminderStore: ReminderStore = {
+  read: async (): Promise<ReminderPrefs> => {
+    const [plan, prayers, adhkar] = await Promise.all([
+      getJSON<PlanReminderPref>(KEYS.planReminder, { on: false, time: DEFAULT_PLAN_REMINDER_TIME }),
+      getJSON<Partial<Record<PrayerName, boolean>>>(KEYS.prayerReminders, {}),
+      getString(KEYS.adhkarReminders),
+    ]);
+    return {
+      plan: {
+        on: plan.on === true,
+        time: typeof plan.time === "string" ? plan.time : DEFAULT_PLAN_REMINDER_TIME,
+      },
+      prayers,
+      adhkarOn: adhkar === "on",
+    };
+  },
+  writePlan: (pref) => setJSON(KEYS.planReminder, pref),
+  writePrayers: (prefs) => setJSON(KEYS.prayerReminders, prefs),
+  writeAdhkarOn: (on) => setString(KEYS.adhkarReminders, on ? "on" : "off"),
+};

--- a/apps/mobile/src/screens/PlanDetailScreen.tsx
+++ b/apps/mobile/src/screens/PlanDetailScreen.tsx
@@ -29,6 +29,7 @@ import {
   todayStr,
 } from "../plans";
 import { PlanCompletionCard } from "../components/PlanCompletionCard";
+import { PlanReminderToggle } from "../components/PlanReminderToggle";
 import type { ReadStackParamList } from "../navigation/types";
 
 type Props = NativeStackScreenProps<ReadStackParamList, "PlanDetail">;
@@ -145,6 +146,8 @@ export function PlanDetailScreen({ navigation }: Props) {
           </Pressable>
         </View>
       )}
+
+      {!complete && <PlanReminderToggle />}
 
       {!paused && behind < 0 && (
         <Text style={styles.behindNote}>

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -38,6 +38,9 @@ export const KEYS = {
   onboarded: "ul.onboarded",
   ramadanFasts: "ul.ramadanFasts",
   ramadanWorship: "ul.ramadanWorship",
+  planReminder: "ul.planReminder",
+  prayerReminders: "ul.prayerReminders",
+  adhkarReminders: "ul.adhkarReminders",
 } as const;
 
 export async function getJSON<T>(key: string, fallback: T): Promise<T> {

--- a/docs/adr/0029-mobile-notifier.md
+++ b/docs/adr/0029-mobile-notifier.md
@@ -1,0 +1,56 @@
+# ADR 0029 — Mobile notifications: ExpoNotifier behind the Notifier port
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+- **Relates to:** [ADR 0019](0019-reminders.md), [ADR 0024](0024-local-storage-ports.md), #71
+
+## Context
+
+Reminders (prayer, adhkar, reading-plan) shipped web-only: the `Notifier` port
+had just one adapter, `WebNotifier`, which uses in-page `setTimeout` and so fires
+only while a tab is open. Mobile had no notifier at all. The reminder
+*orchestration* was also trapped in the web app until it was moved into
+`core/reminders.ts` (platform-neutral, every dependency injected) — which
+unblocked a second adapter.
+
+Two wrinkles shaped the mobile adapter:
+
+1. **Sync vs async permission.** The `Notifier.permission()` contract is
+   synchronous (the web reads `Notification.permission`), but
+   `expo-notifications` exposes permission only via an async call.
+2. **Recurrence.** `AppNotification` is a one-shot (`at`). The web re-schedules
+   on every tab focus; a mobile app that's closed never re-runs that loop.
+
+## Decision
+
+**Add `ExpoNotifier` (`apps/mobile/src/notifier.ts`) implementing the existing
+`Notifier` port — no port change.**
+
+- **Cached permission.** The adapter caches the last-known status; `initNotifier()`
+  (called on app start) and `requestPermission()` refresh it, so the synchronous
+  `permission()` the orchestration calls stays accurate.
+- **One-shot triggers, foreground re-sync.** Each `schedule()` maps `at` to a
+  one-shot `expo-notifications` date trigger — **OS-scheduled, so it fires even
+  when the app is closed** (the actual win over web). The app re-syncs on
+  `AppState` "active" (the mobile analogue of the web's tab-focus re-sync) to roll
+  the schedule to the next day. We deliberately did **not** add a native repeating
+  trigger: it would force a port change and bake stale copy into a notification
+  that can't reflect "today's" progress. Honest limit: a never-opened app gets
+  today's reminder but not tomorrow's — same shape as the web's tab-bound limit,
+  documented in ADR 0019.
+- **Cancel by id.** Matches the core orchestration's id-space cancellation, so one
+  notifier serves every reminder family.
+
+This first cut wires the **reading-plan** daily reminder (the #71 primary bullet)
+end-to-end on mobile (toggle on `PlanDetailScreen`, default time, opt-in,
+permission requested on enable). The adhkar/prayer families — which also need a
+mobile `PrayerSettingsStore` + `PrayerTimingsProvider` — follow next; the shared
+`core` orchestration already supports them.
+
+## Consequences
+
+- #71 is delivered on mobile for reading plans; closed-app delivery works via the
+  OS scheduler.
+- Reusing the `core` orchestration means web and mobile share one reminder brain.
+- Follow-ups: a time picker (currently the default time), and the mobile prayer
+  adapters to light up adhkar/prayer reminders.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,6 +37,7 @@ through Phases 1–3; later decisions get their own record at the time they're m
 | [0026](0026-browser-extension.md)             | Browser extension: thin client over the public REST API          | Accepted |
 | [0027](0027-generated-theme-css.md)           | Theme CSS generated from one token source (amends 0023)          | Accepted |
 | [0028](0028-persistence-enforcement.md)       | Persistence behind store adapters is lint-enforced (amends 0024) | Accepted |
+| [0029](0029-mobile-notifier.md)               | Mobile notifications: ExpoNotifier behind the Notifier port       | Accepted |
 
 ## Writing a new ADR
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       expo-location:
         specifier: ^19.0.8
         version: 19.0.8(expo@54.0.35)
+      expo-notifications:
+        specifier: ~0.32.17
+        version: 0.32.17(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-sensors:
         specifier: ^15.0.8
         version: 15.0.8(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))
@@ -211,7 +214,7 @@ importers:
         version: link:../../packages/ui
       next:
         specifier: ^15.1.3
-        version: 15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 15.5.19(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -1471,6 +1474,9 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@ide/backoff@1.0.0':
+    resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -2469,6 +2475,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2478,6 +2487,10 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -2542,6 +2555,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2626,6 +2642,14 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -2853,9 +2877,17 @@ packages:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -3115,6 +3147,11 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  expo-application@7.0.8:
+    resolution: {integrity: sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==}
+    peerDependencies:
+      expo: '*'
+
   expo-asset@12.0.13:
     resolution: {integrity: sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==}
     peerDependencies:
@@ -3174,6 +3211,13 @@ packages:
   expo-modules-core@3.0.30:
     resolution: {integrity: sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-notifications@0.32.17:
+    resolution: {integrity: sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A==}
+    peerDependencies:
+      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -3277,6 +3321,10 @@ packages:
   fontfaceobserver@2.3.0:
     resolution: {integrity: sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -3308,6 +3356,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3388,6 +3440,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -3500,11 +3555,19 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -3527,9 +3590,17 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -3541,6 +3612,14 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -4128,6 +4207,18 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -4267,6 +4358,10 @@ packages:
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -4535,6 +4630,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -4572,6 +4671,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -4953,6 +5056,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -5085,6 +5191,10 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -6471,6 +6581,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@ide/backoff@1.0.0': {}
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -7483,11 +7595,23 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.9
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   async-limiter@1.0.1: {}
 
   asynckit@0.4.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   babel-jest@29.7.0(@babel/core@7.29.7):
     dependencies:
@@ -7616,6 +7740,8 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
+  badgin@1.2.3: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -7700,6 +7826,18 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -7922,7 +8060,19 @@ snapshots:
 
   defer-to-connect@2.0.1: {}
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   define-lazy-prop@2.0.0: {}
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
 
@@ -8212,6 +8362,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  expo-application@7.0.8(expo@54.0.35):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+
   expo-asset@12.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@5.9.3)
@@ -8279,6 +8433,22 @@ snapshots:
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0)
+
+  expo-notifications@0.32.17(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+    dependencies:
+      '@expo/image-utils': 0.8.14(typescript@5.9.3)
+      '@ide/backoff': 1.0.0
+      abort-controller: 3.0.0
+      assert: 2.1.0
+      badgin: 1.2.3
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-application: 7.0.8(expo@54.0.35)
+      expo-constants: 18.0.13(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   expo-sensors@15.0.8(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0)):
     dependencies:
@@ -8403,6 +8573,10 @@ snapshots:
 
   fontfaceobserver@2.3.0: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8429,6 +8603,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -8526,6 +8702,10 @@ snapshots:
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -8636,11 +8816,18 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-arrayish@0.3.4: {}
 
   is-bun-module@2.0.0:
     dependencies:
       semver: 7.8.1
+
+  is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -8656,15 +8843,39 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
 
   is-number@7.0.0: {}
 
   is-plain-obj@2.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.22
 
   is-wsl@2.2.0:
     dependencies:
@@ -9401,7 +9612,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@15.5.19(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
@@ -9409,7 +9620,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.19
       '@next/swc-darwin-x64': 15.5.19
@@ -9464,6 +9675,22 @@ snapshots:
       flow-enums-runtime: 0.0.6
 
   object-assign@4.1.1: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
 
   on-finished@2.3.0:
     dependencies:
@@ -9593,6 +9820,8 @@ snapshots:
       xmlbuilder: 15.1.1
 
   pngjs@3.4.0: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
 
@@ -9970,6 +10199,12 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
@@ -10014,6 +10249,15 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   setimmediate@1.0.5: {}
 
@@ -10155,12 +10399,10 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
+  styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
-    optionalDependencies:
-      '@babel/core': 7.29.7
 
   styleq@0.1.3: {}
 
@@ -10389,6 +10631,14 @@ snapshots:
     dependencies:
       react: 19.1.0
 
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.22
+
   utils-merge@1.0.1: {}
 
   uuid@3.4.0: {}
@@ -10509,6 +10759,16 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-typed-array@1.1.22:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## What
Lands the native notifier that the persistence migration unblocked.

- **ExpoNotifier** implements the core `Notifier` port via `expo-notifications`: OS-scheduled (fires when the app is closed), cached synchronous permission, cancel-by-id.
- **mobileReminderStore** (AsyncStorage) + **plan-reminders** glue wire the shared `core` orchestration on mobile; `App` primes the notifier and re-syncs on `AppState` foreground.
- **PlanReminderToggle** (opt-in, default time) on `PlanDetailScreen` — #71's primary bullet, end-to-end on mobile. Adhkar/prayer families + a time picker are follow-ups.
- **ADR 0029** — one-shot triggers + foreground re-sync, no port change.

## Verification
CI: typecheck + lint green; `vitest --coverage` exits 0; 509 tests pass. Native delivery verified on the `ul_pixel` Android emulator (see PR thread).