### PR TITLE
feat(mobile): reminder time picker + adhkar & prayer families (#71)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -19,6 +19,8 @@ import { fontMap } from "./src/fonts";
 import { KEYS, getString, setString } from "./src/storage";
 import { initNotifier } from "./src/notifier";
 import { syncPlanReminder } from "./src/plan-reminders";
+import { syncAdhkarReminder } from "./src/adhkar-reminders";
+import { syncPrayerReminders } from "./src/prayer-reminders";
 import type { RootTabParamList } from "./src/navigation/types";
 
 /** URL routes for the web build and OS deep links (ummahlibrary://). */
@@ -110,12 +112,17 @@ function AppGate() {
 export default function App() {
   const [fontsLoaded] = useFonts(fontMap);
 
-  // Prime the notifier, then keep the plan reminder scheduled — re-syncing on
+  // Prime the notifier, then keep every reminder family scheduled — re-syncing on
   // foreground so the schedule rolls to the next day after one fires (#71).
   useEffect(() => {
-    void initNotifier().then(() => syncPlanReminder());
+    const syncAll = () => {
+      void syncPlanReminder();
+      void syncAdhkarReminder();
+      void syncPrayerReminders();
+    };
+    void initNotifier().then(syncAll);
     const sub = AppState.addEventListener("change", (s) => {
-      if (s === "active") void syncPlanReminder();
+      if (s === "active") syncAll();
     });
     return () => sub.remove();
   }, []);

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -34,7 +34,9 @@
       "bundleIdentifier": "org.ummahlibrary.app",
       "supportsTablet": true,
       "infoPlist": {
-        "UIBackgroundModes": ["audio"],
+        "UIBackgroundModes": [
+          "audio"
+        ],
         "ITSAppUsesNonExemptEncryption": false
       }
     },
@@ -52,7 +54,8 @@
         }
       ],
       "expo-font",
-      "expo-notifications"
+      "expo-notifications",
+      "@react-native-community/datetimepicker"
     ],
     "extra": {
       "eas": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,6 +21,7 @@
     "@expo-google-fonts/ibm-plex-sans-arabic": "^0.4.2",
     "@expo/metro-runtime": "~6.1.2",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "^7.16.2",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",

--- a/apps/mobile/src/adhkar-reminders.ts
+++ b/apps/mobile/src/adhkar-reminders.ts
@@ -1,0 +1,28 @@
+/**
+ * Adhkar reminders — mobile wiring (ADR 0017/0019). The on/off pref goes through
+ * the {@link mobileReminderStore}; the scheduling decision is the shared
+ * `syncAdhkarReminder` in `@ummahlibrary/core`; delivery is the {@link expoNotifier}
+ * (OS-scheduled). Reuses the same orchestration as the web.
+ */
+import { syncAdhkarReminder as coreSyncAdhkarReminder } from "@ummahlibrary/core";
+import { expoNotifier } from "./notifier";
+import { mobilePrayerTimingsProvider } from "./prayer-timings-provider";
+import { mobileReminderStore } from "./reminder-store";
+
+export async function readAdhkarReminderOn(): Promise<boolean> {
+  return (await mobileReminderStore.read()).adhkarOn;
+}
+
+export async function setAdhkarReminderOn(on: boolean): Promise<void> {
+  await mobileReminderStore.writeAdhkarOn(on);
+  await syncAdhkarReminder();
+}
+
+export function syncAdhkarReminder(): Promise<void> {
+  return coreSyncAdhkarReminder({
+    notifier: expoNotifier,
+    reminders: mobileReminderStore,
+    timings: mobilePrayerTimingsProvider,
+    now: () => new Date(),
+  });
+}

--- a/apps/mobile/src/components/AdhkarReminderToggle.tsx
+++ b/apps/mobile/src/components/AdhkarReminderToggle.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useMemo, useState } from "react";
+import { StyleSheet, Switch, Text, View } from "../Type";
+import { Icon, type Palette } from "@ummahlibrary/ui";
+import { useTheme } from "../theme";
+import { FONT } from "../fonts";
+import { expoNotifier } from "../notifier";
+import { mobilePrayerSettingsStore } from "../prayer-settings-store";
+import { readAdhkarReminderOn, setAdhkarReminderOn } from "../adhkar-reminders";
+
+/**
+ * Opt-in reminder for morning/evening adhkar (#71), timed off the reader's prayer
+ * times and delivered by the OS scheduler. A no-op without a saved location.
+ */
+export function AdhkarReminderToggle() {
+  const { colors } = useTheme();
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const [on, setOn] = useState(false);
+  const [hasCoords, setHasCoords] = useState(true);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    void Promise.all([readAdhkarReminderOn(), mobilePrayerSettingsStore.read()]).then(([o, s]) => {
+      setOn(o);
+      setHasCoords(s.coords !== null);
+      setReady(true);
+    });
+  }, []);
+
+  async function toggle(next: boolean) {
+    if (next && expoNotifier.permission() !== "granted") await expoNotifier.requestPermission();
+    setOn(next);
+    await setAdhkarReminderOn(next);
+  }
+
+  if (!ready) return null;
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.row}>
+        <Icon name="bell" size={17} color={on ? colors.accent : colors.muted} sw={1.8} />
+        <View style={styles.text}>
+          <Text style={styles.title}>Reminders</Text>
+          <Text style={styles.note}>Morning &amp; evening adhkar, timed off your prayer times.</Text>
+        </View>
+        <Switch
+          value={on}
+          onValueChange={(v) => void toggle(v)}
+          trackColor={{ true: colors.accentSoft, false: colors.border }}
+          thumbColor={on ? colors.accent : colors.faint}
+        />
+      </View>
+      {on && !hasCoords && (
+        <Text style={styles.hint}>Set your location on Prayer times so reminders know when Fajr and ʿAṣr are.</Text>
+      )}
+    </View>
+  );
+}
+
+function makeStyles(c: Palette) {
+  return StyleSheet.create({
+    card: {
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 14,
+      padding: 14,
+      backgroundColor: c.bgElev,
+    },
+    row: { flexDirection: "row", alignItems: "center", gap: 12 },
+    text: { flex: 1 },
+    title: { color: c.fg, fontFamily: FONT.semibold, fontSize: 14 },
+    note: { color: c.muted, fontFamily: FONT.regular, fontSize: 12.5, marginTop: 2 },
+    hint: { color: c.faint, fontFamily: FONT.regular, fontSize: 12, marginTop: 10 },
+  });
+}

--- a/apps/mobile/src/components/PlanReminderToggle.tsx
+++ b/apps/mobile/src/components/PlanReminderToggle.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { StyleSheet, Switch, Text, View } from "../Type";
+import { Pressable, StyleSheet, Switch, Text, View } from "../Type";
+import DateTimePicker, { type DateTimePickerEvent } from "@react-native-community/datetimepicker";
 import { Icon, type Palette } from "@ummahlibrary/ui";
 import { DEFAULT_PLAN_REMINDER_TIME } from "@ummahlibrary/core";
 import { useTheme } from "../theme";
@@ -15,16 +16,28 @@ function label(time: string): string {
   return `${h12}:${String(m ?? 0).padStart(2, "0")} ${am ? "AM" : "PM"}`;
 }
 
+function timeToDate(time: string): Date {
+  const [h, m] = time.split(":").map(Number);
+  const d = new Date();
+  d.setHours(h ?? 20, m ?? 0, 0, 0);
+  return d;
+}
+
+function dateToTime(d: Date): string {
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
 /**
  * Opt-in daily reminder for the active plan (#71). Delivery is the OS scheduler
- * (expo-notifications) so it fires even when the app is closed. Time is the
- * default for now; a picker is a follow-up.
+ * (expo-notifications) so it fires even when the app is closed. Tap the time to
+ * pick when.
  */
 export function PlanReminderToggle() {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
   const [on, setOn] = useState(false);
   const [time, setTime] = useState(DEFAULT_PLAN_REMINDER_TIME);
+  const [showPicker, setShowPicker] = useState(false);
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
@@ -41,23 +54,46 @@ export function PlanReminderToggle() {
     await setPlanReminderPref({ on: next, time });
   }
 
+  function onPickTime(event: DateTimePickerEvent, date?: Date) {
+    setShowPicker(false);
+    if (event.type === "set" && date) {
+      const next = dateToTime(date);
+      setTime(next);
+      void setPlanReminderPref({ on, time: next });
+    }
+  }
+
   if (!ready) return null;
 
   return (
     <View style={styles.card}>
-      <Icon name="bell" size={17} color={on ? colors.accent : colors.muted} sw={1.8} />
-      <View style={styles.text}>
-        <Text style={styles.title}>Daily reminder</Text>
-        <Text style={styles.note}>
-          {on ? `A nudge at ${label(time)} for today's portion.` : "A gentle daily nudge for today's portion."}
-        </Text>
+      <View style={styles.row}>
+        <Icon name="bell" size={17} color={on ? colors.accent : colors.muted} sw={1.8} />
+        <View style={styles.text}>
+          <Text style={styles.title}>Daily reminder</Text>
+          <Text style={styles.note}>A gentle daily nudge for today's portion.</Text>
+        </View>
+        <Switch
+          value={on}
+          onValueChange={(v) => void toggle(v)}
+          trackColor={{ true: colors.accentSoft, false: colors.border }}
+          thumbColor={on ? colors.accent : colors.faint}
+        />
       </View>
-      <Switch
-        value={on}
-        onValueChange={(v) => void toggle(v)}
-        trackColor={{ true: colors.accentSoft, false: colors.border }}
-        thumbColor={on ? colors.accent : colors.faint}
-      />
+
+      {on && (
+        <Pressable style={styles.timeRow} onPress={() => setShowPicker(true)} accessibilityRole="button">
+          <Text style={styles.timeLabel}>Remind me at</Text>
+          <View style={styles.timePill}>
+            <Icon name="clock" size={13} color={colors.accent} sw={1.8} />
+            <Text style={styles.timeValue}>{label(time)}</Text>
+          </View>
+        </Pressable>
+      )}
+
+      {showPicker && (
+        <DateTimePicker value={timeToDate(time)} mode="time" is24Hour={false} onChange={onPickTime} />
+      )}
     </View>
   );
 }
@@ -66,17 +102,37 @@ function makeStyles(c: Palette) {
   return StyleSheet.create({
     card: {
       marginTop: 14,
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 12,
       borderWidth: 1,
       borderColor: c.border,
       borderRadius: 14,
       padding: 14,
       backgroundColor: c.bgElev,
     },
+    row: { flexDirection: "row", alignItems: "center", gap: 12 },
     text: { flex: 1 },
     title: { color: c.fg, fontFamily: FONT.semibold, fontSize: 14 },
     note: { color: c.muted, fontFamily: FONT.regular, fontSize: 12.5, marginTop: 2 },
+    timeRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginTop: 14,
+      paddingTop: 12,
+      borderTopWidth: 1,
+      borderTopColor: c.border,
+    },
+    timeLabel: { color: c.muted, fontFamily: FONT.regular, fontSize: 13 },
+    timePill: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 999,
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      backgroundColor: c.cardHi,
+    },
+    timeValue: { color: c.fg, fontFamily: FONT.semibold, fontSize: 13 },
   });
 }

--- a/apps/mobile/src/prayer-reminders.ts
+++ b/apps/mobile/src/prayer-reminders.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-prayer reminders — mobile wiring (ADR 0019). The per-prayer on/off map goes
+ * through the {@link mobileReminderStore}; the scheduling decision is the shared
+ * `syncPrayerReminders` in `@ummahlibrary/core`; delivery is the {@link expoNotifier}
+ * (OS-scheduled). Reuses the same orchestration as the web.
+ */
+import type { PrayerName } from "@ummahlibrary/core";
+import { syncPrayerReminders as coreSyncPrayerReminders } from "@ummahlibrary/core";
+import { expoNotifier } from "./notifier";
+import { mobilePrayerTimingsProvider } from "./prayer-timings-provider";
+import { mobileReminderStore } from "./reminder-store";
+
+export type PrayerReminderPrefs = Partial<Record<PrayerName, boolean>>;
+
+export async function readPrayerReminderPrefs(): Promise<PrayerReminderPrefs> {
+  return (await mobileReminderStore.read()).prayers;
+}
+
+export async function setPrayerReminder(prayer: PrayerName, on: boolean): Promise<PrayerReminderPrefs> {
+  const prefs = { ...(await readPrayerReminderPrefs()), [prayer]: on };
+  await mobileReminderStore.writePrayers(prefs);
+  await syncPrayerReminders();
+  return prefs;
+}
+
+export function syncPrayerReminders(): Promise<void> {
+  return coreSyncPrayerReminders({
+    notifier: expoNotifier,
+    reminders: mobileReminderStore,
+    timings: mobilePrayerTimingsProvider,
+    now: () => new Date(),
+  });
+}

--- a/apps/mobile/src/prayer-settings-store.ts
+++ b/apps/mobile/src/prayer-settings-store.ts
@@ -1,0 +1,32 @@
+/**
+ * Mobile `PrayerSettingsStore` adapter (ADR 0024): the reader's prayer-times
+ * location and calculation config in AsyncStorage under the same `ul.*` keys the
+ * web uses. Persistence only; `read()` applies the defaults. Mirrors the web
+ * adapter.
+ */
+import {
+  type Coordinates,
+  DEFAULT_CALCULATION_METHOD,
+  type Madhab,
+  type PrayerSettingsStore,
+} from "@ummahlibrary/core";
+import { KEYS, getJSON, getString, setJSON, setString } from "./storage";
+
+export const mobilePrayerSettingsStore: PrayerSettingsStore = {
+  read: async () => {
+    const [coords, method, madhab] = await Promise.all([
+      getJSON<Coordinates | null>(KEYS.prayerCoords, null),
+      getString(KEYS.prayerMethod),
+      getString(KEYS.prayerMadhab),
+    ]);
+    return {
+      coords,
+      method: method ?? DEFAULT_CALCULATION_METHOD,
+      madhab: (madhab as Madhab) || "shafi",
+    };
+  },
+  // `null` is stored as JSON null, which read-back resolves to the fallback.
+  writeCoords: (coords) => setJSON(KEYS.prayerCoords, coords),
+  writeMethod: (method) => setString(KEYS.prayerMethod, method),
+  writeMadhab: (madhab) => setString(KEYS.prayerMadhab, madhab),
+};

--- a/apps/mobile/src/prayer-timings-provider.ts
+++ b/apps/mobile/src/prayer-timings-provider.ts
@@ -1,0 +1,40 @@
+/**
+ * Mobile `PrayerTimingsProvider` adapter: today's prayer timings for the stored
+ * location, fetched once per day from the REST API (`api.getPrayerTimes`) and
+ * cached in AsyncStorage. Returns `null` when no location is stored or the
+ * lookup fails. Keeps the reminder orchestration in `core` free of I/O. Mirrors
+ * the web adapter (which fetches the same function).
+ */
+import type { PrayerTimings, PrayerTimingsProvider } from "@ummahlibrary/core";
+import { api } from "./api";
+import { KEYS, getJSON, setJSON } from "./storage";
+import { mobilePrayerSettingsStore } from "./prayer-settings-store";
+import { localISODate } from "./utils";
+
+export const mobilePrayerTimingsProvider: PrayerTimingsProvider = {
+  getTodaysTimings: async () => {
+    const { coords, method, madhab } = await mobilePrayerSettingsStore.read();
+    if (!coords) return null;
+
+    const date = localISODate(new Date());
+    const cached = await getJSON<{ date: string; timings: PrayerTimings } | null>(
+      KEYS.adhkarTimings,
+      null,
+    );
+    if (cached && cached.date === date) return cached.timings;
+
+    try {
+      const timings = (await api.getPrayerTimes({
+        lat: coords.latitude,
+        lng: coords.longitude,
+        date,
+        method,
+        madhab,
+      })) as PrayerTimings;
+      await setJSON(KEYS.adhkarTimings, { date, timings });
+      return timings;
+    } catch {
+      return null;
+    }
+  },
+};

--- a/apps/mobile/src/screens/AdhkarScreen.tsx
+++ b/apps/mobile/src/screens/AdhkarScreen.tsx
@@ -14,6 +14,7 @@ import { KEYS, getJSON, setJSON } from "../storage";
 import { useTheme, type Palette } from "../theme";
 import { FONT } from "../fonts";
 import { adhkarToday } from "../utils";
+import { AdhkarReminderToggle } from "../components/AdhkarReminderToggle";
 
 interface Stored {
   date: string;
@@ -90,6 +91,7 @@ export function AdhkarScreen() {
 
   return (
     <ScrollView contentContainerStyle={styles.screen}>
+      <AdhkarReminderToggle />
       <View style={styles.tabs} accessibilityRole="tablist">
         {ADHKAR_OCCASIONS.map((o) => (
           <Pressable

--- a/apps/mobile/src/screens/PrayerTimesScreen.tsx
+++ b/apps/mobile/src/screens/PrayerTimesScreen.tsx
@@ -20,6 +20,8 @@ import { KEYS, getJSON, getString, setJSON, setString } from "../storage";
 import { useTheme, type Palette } from "../theme";
 import { FONT } from "../fonts";
 import { fmtCountdown, fmtTime, localISODate } from "../utils";
+import { expoNotifier } from "../notifier";
+import { type PrayerReminderPrefs, readPrayerReminderPrefs, setPrayerReminder } from "../prayer-reminders";
 
 type Status = "idle" | "locating" | "loading" | "ready" | "error" | "denied";
 
@@ -50,6 +52,7 @@ export function PrayerTimesScreen() {
   const [timings, setTimings] = useState<PrayerTimings | null>(null);
   const [status, setStatus] = useState<Status>("idle");
   const [now, setNow] = useState(() => new Date());
+  const [reminders, setReminders] = useState<PrayerReminderPrefs>({});
   const reqId = useRef(0);
 
   const fetchTimings = useCallback(async (c: Coordinates, m: string, mad: Madhab) => {
@@ -86,6 +89,7 @@ export function PrayerTimesScreen() {
         void fetchTimings(savedCoords, m, mad);
       }
     });
+    void readPrayerReminderPrefs().then(setReminders);
   }, [fetchTimings]);
 
   useEffect(() => {
@@ -118,6 +122,12 @@ export function PrayerTimesScreen() {
     setMadhab(m);
     void setString(KEYS.prayerMadhab, m);
     if (coords) void fetchTimings(coords, method, m);
+  }
+
+  async function toggleReminder(name: PrayerName) {
+    const turningOn = !reminders[name];
+    if (turningOn && expoNotifier.permission() !== "granted") await expoNotifier.requestPermission();
+    setReminders(await setPrayerReminder(name, turningOn));
   }
 
   const upcoming = timings ? nextPrayer(timings, now) : null;
@@ -203,6 +213,16 @@ export function PrayerTimesScreen() {
                   <Text style={[styles.prayerTime, isNext && styles.prayerTimeNext]}>
                     {fmtTime(timings[name])}
                   </Text>
+                  {OBLIGATORY_PRAYERS.includes(name) && (
+                    <Pressable
+                      onPress={() => void toggleReminder(name)}
+                      hitSlop={10}
+                      accessibilityRole="switch"
+                      accessibilityState={{ checked: !!reminders[name] }}
+                    >
+                      <Icon name="bell" size={17} color={reminders[name] ? colors.accent : colors.faint} sw={1.8} />
+                    </Pressable>
+                  )}
                 </View>
               );
             })}

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -41,6 +41,7 @@ export const KEYS = {
   planReminder: "ul.planReminder",
   prayerReminders: "ul.prayerReminders",
   adhkarReminders: "ul.adhkarReminders",
+  adhkarTimings: "ul.adhkarTimings",
 } as const;
 
 export async function getJSON<T>(key: string, fallback: T): Promise<T> {

--- a/docs/adr/0029-mobile-notifier.md
+++ b/docs/adr/0029-mobile-notifier.md
@@ -52,5 +52,8 @@ mobile `PrayerSettingsStore` + `PrayerTimingsProvider` — follow next; the shar
 - #71 is delivered on mobile for reading plans; closed-app delivery works via the
   OS scheduler.
 - Reusing the `core` orchestration means web and mobile share one reminder brain.
-- Follow-ups: a time picker (currently the default time), and the mobile prayer
-  adapters to light up adhkar/prayer reminders.
+- Follow-ups (now landed): a time picker for the plan reminder
+  (`@react-native-community/datetimepicker`), and the mobile `PrayerSettingsStore`
+  + `PrayerTimingsProvider` adapters that light up the adhkar (AdhkarScreen toggle)
+  and per-prayer (PrayerTimesScreen) reminder families — all reusing the same
+  `core` orchestration. App's foreground re-sync covers all three families.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
         version: 2.2.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))
+      '@react-native-community/datetimepicker':
+        specifier: 8.4.4
+        version: 8.4.4(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0)
       '@react-navigation/bottom-tabs':
         specifier: ^7.16.2
         version: 7.16.2(@react-navigation/native@7.2.5(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0)
@@ -1747,6 +1750,19 @@ packages:
     resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
     peerDependencies:
       react-native: ^0.0.0-0 || >=0.65 <1.0
+
+  '@react-native-community/datetimepicker@8.4.4':
+    resolution: {integrity: sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==}
+    peerDependencies:
+      expo: '>=52.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      react-native-windows:
+        optional: true
 
   '@react-native/assets-registry@0.81.5':
     resolution: {integrity: sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w==}
@@ -6825,6 +6841,14 @@ snapshots:
     dependencies:
       merge-options: 3.0.4
       react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0)
+
+  '@react-native-community/datetimepicker@8.4.4(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0)
+    optionalDependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/metro-runtime@6.1.2)(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.3)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   '@react-native/assets-registry@0.81.5': {}
 


### PR DESCRIPTION
## What — completes mobile reminders on the shared core orchestration
- **Plan reminder time picker** — `@react-native-community/datetimepicker`; tap the time to choose when (was a fixed default).
- **mobilePrayerSettingsStore** + **mobilePrayerTimingsProvider** (REST `api` + per-day AsyncStorage cache) so the adhkar & prayer orchestration runs on mobile.
- **Adhkar reminder toggle** on AdhkarScreen + **per-prayer reminder bells** on PrayerTimesScreen — each requests notification permission on first enable.
- `App` primes the notifier and re-syncs all three families on foreground.

## Verification
CI: typecheck + lint green; `vitest --coverage` exits 0; 509 tests pass. Native delivery verified on the `ul_pixel` emulator (see thread).