### PR TITLE
feat(tracker): qaḍāʾ (missed-prayer) make-up tracker, web + mobile (#137)

### DIFF
--- a/apps/mobile/src/qada-store.ts
+++ b/apps/mobile/src/qada-store.ts
@@ -1,0 +1,13 @@
+/**
+ * Mobile `QadaStore` adapter (ADR 0024, 0030): the missed-prayer backlog in
+ * AsyncStorage under `ul.qada` (mirrors the web key so the two clients describe
+ * the same local-first state). Persistence only — the maths lives in
+ * `@ummahlibrary/core`.
+ */
+import type { QadaLog, QadaStore } from "@ummahlibrary/core";
+import { KEYS, getJSON, setJSON } from "./storage";
+
+export const mobileQadaStore: QadaStore = {
+  read: () => getJSON<QadaLog>(KEYS.qada, {}),
+  write: (log) => setJSON(KEYS.qada, log),
+};

--- a/apps/mobile/src/screens/PrayerTrackerScreen.tsx
+++ b/apps/mobile/src/screens/PrayerTrackerScreen.tsx
@@ -5,17 +5,22 @@ import {
   PRAYER_LABELS,
   type PrayerStatus,
   type PrayerTrackerLog,
+  type QadaLog,
+  adjustQada,
   longestStreak,
   nextPrayerStatus,
   onTimeRate,
+  owedFor,
   prayedCount,
   prayerStreak,
   recentDays,
   setPrayerStatus,
   statusFor,
+  totalOwed,
 } from "@ummahlibrary/core";
 import { useTheme, type Palette } from "../theme";
 import { mobilePrayerTrackerStore as prayerStore } from "../prayer-tracker-store";
+import { mobileQadaStore as qadaStore } from "../qada-store";
 import { localISODate } from "../utils";
 
 const STATUS_LABEL: Record<PrayerStatus, string> = {
@@ -32,11 +37,21 @@ export function PrayerTrackerScreen() {
     s === "ontime" ? colors.accent : s === "late" ? LATE : colors.border;
 
   const [log, setLog] = useState<PrayerTrackerLog>({});
+  const [qada, setQadaLog] = useState<QadaLog>({});
   const today = localISODate(new Date());
 
   useEffect(() => {
     void prayerStore.read().then(setLog);
+    void qadaStore.read().then(setQadaLog);
   }, []);
+
+  function adjustQadaFor(prayer: (typeof OBLIGATORY_PRAYERS)[number], delta: number) {
+    setQadaLog((prev) => {
+      const next = adjustQada(prev, prayer, delta);
+      void qadaStore.write(next);
+      return next;
+    });
+  }
 
   function cycle(prayer: (typeof OBLIGATORY_PRAYERS)[number]) {
     setLog((prev) => {
@@ -127,6 +142,38 @@ export function PrayerTrackerScreen() {
           </View>
         ))}
       </View>
+
+      <Text style={styles.sectionLabel}>Make-up prayers · qaḍāʾ ({totalOwed(qada)} owed)</Text>
+      <View style={styles.qadaList}>
+        {OBLIGATORY_PRAYERS.map((p) => {
+          const owed = owedFor(qada, p);
+          return (
+            <View key={p} style={styles.qadaRow}>
+              <Text style={styles.qadaName}>{PRAYER_LABELS[p]}</Text>
+              <View style={styles.qadaCtrls}>
+                <Pressable
+                  style={[styles.step, owed === 0 && styles.stepDisabled]}
+                  disabled={owed === 0}
+                  onPress={() => adjustQadaFor(p, -1)}
+                  accessibilityLabel={`Make up one ${PRAYER_LABELS[p]}`}
+                >
+                  <Text style={styles.stepMark}>−</Text>
+                </Pressable>
+                <Text style={[styles.qadaCount, { color: owed ? colors.accent : colors.faint }]}>
+                  {owed}
+                </Text>
+                <Pressable
+                  style={styles.step}
+                  onPress={() => adjustQadaFor(p, 1)}
+                  accessibilityLabel={`Record a missed ${PRAYER_LABELS[p]}`}
+                >
+                  <Text style={styles.stepMark}>+</Text>
+                </Pressable>
+              </View>
+            </View>
+          );
+        })}
+      </View>
     </ScrollView>
   );
 }
@@ -211,5 +258,22 @@ function makeStyles(c: Palette) {
     gridRow: { flexDirection: "row", alignItems: "center", gap: 7 },
     gridLabel: { color: c.muted, fontSize: 12.5, fontWeight: "600", width: 56 },
     cell: { flex: 1, aspectRatio: 1, maxWidth: 34, borderRadius: 7 },
+    qadaList: { gap: 8 },
+    qadaRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+    qadaName: { color: c.fg, fontSize: 14, fontWeight: "700" },
+    qadaCtrls: { flexDirection: "row", alignItems: "center", gap: 12 },
+    step: {
+      width: 34,
+      height: 34,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.accentSoft,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    stepDisabled: { backgroundColor: "transparent", opacity: 0.5 },
+    stepMark: { color: c.accent, fontSize: 20, fontWeight: "700", lineHeight: 22 },
+    qadaCount: { minWidth: 26, textAlign: "center", fontSize: 16, fontWeight: "800" },
   });
 }

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -33,6 +33,7 @@ export const KEYS = {
   prayerMadhab: "ul.prayerMadhab",
   prayerCoords: "ul.prayerCoords",
   prayerLog: "ul.prayerLog",
+  qada: "ul.qada",
   hijriAdjust: "ul.hijriAdjust",
   zakat: "ul.zakat",
   onboarded: "ul.onboarded",

--- a/apps/web/src/app/tracker/page.tsx
+++ b/apps/web/src/app/tracker/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { NoorPageFrame } from "../../components/NoorPageFrame";
 import { PrayerTracker } from "../../components/PrayerTracker";
+import { QadaTracker } from "../../components/QadaTracker";
 
 export const metadata: Metadata = {
   title: "Prayer Tracker",
@@ -19,6 +20,7 @@ export default function PrayerTrackerPage() {
       maxW={820}
     >
       <PrayerTracker />
+      <QadaTracker />
     </NoorPageFrame>
   );
 }

--- a/apps/web/src/components/QadaTracker.test.tsx
+++ b/apps/web/src/components/QadaTracker.test.tsx
@@ -1,0 +1,28 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QadaTracker } from "./QadaTracker";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("QadaTracker", () => {
+  it("records a missed prayer then makes it up, persisting to ul.qada", async () => {
+    render(<QadaTracker />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Record a missed Fajr" }));
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem("ul.qada") ?? "{}").fajr).toBe(1),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Make up one Fajr" }));
+    await waitFor(() => expect(localStorage.getItem("ul.qada")).toBe("{}"));
+  });
+
+  it("reflects an existing backlog and its total", async () => {
+    localStorage.setItem("ul.qada", JSON.stringify({ fajr: 2, isha: 1 }));
+    render(<QadaTracker />);
+    // Total owed (2 + 1) is shown once.
+    expect(await screen.findByText("3")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/QadaTracker.tsx
+++ b/apps/web/src/components/QadaTracker.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
+import { OBLIGATORY_PRAYERS, PRAYER_LABELS, type QadaLog, owedFor, totalOwed } from "@ummahlibrary/core";
+import { N } from "@ummahlibrary/ui";
+import { QADA_EVENT, adjustQadaCount, readQada } from "../lib/qada";
+
+const card: CSSProperties = {
+  background: N.card,
+  border: `1px solid ${N.border}`,
+  borderRadius: 16,
+};
+const sectionLabel: CSSProperties = {
+  fontSize: 12,
+  letterSpacing: 1,
+  textTransform: "uppercase",
+  color: N.faint,
+  fontWeight: 700,
+};
+
+export function QadaTracker() {
+  const [ready, setReady] = useState(false);
+  const [log, setLog] = useState<QadaLog>({});
+
+  useEffect(() => {
+    void readQada().then(setLog);
+    setReady(true);
+    const onChange = () => void readQada().then(setLog);
+    window.addEventListener(QADA_EVENT, onChange);
+    return () => window.removeEventListener(QADA_EVENT, onChange);
+  }, []);
+
+  if (!ready) return null;
+
+  const total = totalOwed(log);
+
+  return (
+    <div style={{ ...card, padding: 24, marginTop: 18 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          gap: 12,
+          flexWrap: "wrap",
+          marginBottom: 16,
+        }}
+      >
+        <div style={sectionLabel}>Make-up prayers · qaḍāʾ</div>
+        <div style={{ fontSize: 13, color: N.faint }}>
+          <span style={{ color: N.gold, fontWeight: 800, fontSize: 18 }}>{total}</span> owed
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: 10 }}>
+        {OBLIGATORY_PRAYERS.map((p) => {
+          const owed = owedFor(log, p);
+          return (
+            <div
+              key={p}
+              style={{ display: "grid", gridTemplateColumns: "1fr auto", alignItems: "center", gap: 12 }}
+            >
+              <span style={{ fontSize: 14, fontWeight: 700, color: N.fg }}>{PRAYER_LABELS[p]}</span>
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <Step
+                  label={`Make up one ${PRAYER_LABELS[p]}`}
+                  symbol="−"
+                  disabled={owed === 0}
+                  onClick={() => void adjustQadaCount(p, -1).then(setLog)}
+                />
+                <span
+                  aria-live="polite"
+                  style={{
+                    minWidth: 28,
+                    textAlign: "center",
+                    fontSize: 16,
+                    fontWeight: 800,
+                    color: owed ? N.gold : N.faint,
+                    fontVariantNumeric: "tabular-nums",
+                  }}
+                >
+                  {owed}
+                </span>
+                <Step
+                  label={`Record a missed ${PRAYER_LABELS[p]}`}
+                  symbol="+"
+                  onClick={() => void adjustQadaCount(p, 1).then(setLog)}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <p style={{ fontSize: 12, color: N.faint, marginTop: 14, marginBottom: 0 }}>
+        Tap + when you miss a prayer, − as you make it up. Stored on your device.
+      </p>
+    </div>
+  );
+}
+
+function Step({
+  label,
+  symbol,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  symbol: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        width: 34,
+        height: 34,
+        borderRadius: 10,
+        border: `1px solid ${N.border}`,
+        background: disabled ? "transparent" : N.goldSoft,
+        color: disabled ? N.faint : N.gold,
+        cursor: disabled ? "default" : "pointer",
+        fontSize: 20,
+        fontWeight: 700,
+        lineHeight: 1,
+        fontFamily: N.ui,
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      {symbol}
+    </button>
+  );
+}

--- a/apps/web/src/lib/qada-store.ts
+++ b/apps/web/src/lib/qada-store.ts
@@ -1,0 +1,27 @@
+/**
+ * Web `QadaStore` adapter (ADR 0024, 0030): the missed-prayer backlog in
+ * `localStorage` under `ul.qada`. Persistence only — the maths lives in
+ * `@ummahlibrary/core` — so a synced adapter (#25) can replace it without
+ * touching the feature. Mirrors mobile.
+ */
+import type { QadaLog, QadaStore } from "@ummahlibrary/core";
+
+const KEY = "ul.qada";
+
+export const webQadaStore: QadaStore = {
+  read: async () => {
+    try {
+      const raw = localStorage.getItem(KEY);
+      return raw ? (JSON.parse(raw) as QadaLog) : {};
+    } catch {
+      return {};
+    }
+  },
+  write: async (log) => {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(log));
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};

--- a/apps/web/src/lib/qada.test.ts
+++ b/apps/web/src/lib/qada.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QADA_EVENT, adjustQadaCount, readQada, setQadaCount } from "./qada";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("qada store (web)", () => {
+  it("starts with an empty backlog", async () => {
+    expect(await readQada()).toEqual({});
+  });
+
+  it("adjusts a backlog up and down, clamped at zero, and persists", async () => {
+    expect((await adjustQadaCount("fajr", 1)).fajr).toBe(1);
+    expect((await adjustQadaCount("fajr", 1)).fajr).toBe(2);
+    // Cannot go negative — the entry drops at zero.
+    expect((await adjustQadaCount("fajr", -5)).fajr).toBeUndefined();
+    expect(await readQada()).toEqual({});
+  });
+
+  it("sets an explicit count and survives a fresh read", async () => {
+    await setQadaCount("isha", 4);
+    expect((await readQada()).isha).toBe(4);
+    await setQadaCount("isha", 0);
+    expect(await readQada()).toEqual({});
+  });
+
+  it("emits a change event so subscribers can re-render", async () => {
+    const handler = vi.fn();
+    window.addEventListener(QADA_EVENT, handler);
+    await adjustQadaCount("asr", 1);
+    window.removeEventListener(QADA_EVENT, handler);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to an empty backlog when stored JSON is corrupt", async () => {
+    localStorage.setItem("ul.qada", "{not json");
+    expect(await readQada()).toEqual({});
+  });
+});

--- a/apps/web/src/lib/qada.ts
+++ b/apps/web/src/lib/qada.ts
@@ -1,0 +1,39 @@
+/**
+ * Local-first qaḍāʾ (missed-prayer) backlog (ADR 0006, 0030): how many of each
+ * obligatory prayer you owe and are making up. Persistence goes through the
+ * `QadaStore` port (web adapter `webQadaStore`, ADR 0024); the maths lives in
+ * `@ummahlibrary/core`. A window event lets the tracker page re-render on change
+ * — the established pattern from the prayer tracker.
+ */
+import { type PrayerName, type QadaLog, adjustQada, setQada } from "@ummahlibrary/core";
+import { webQadaStore as store } from "./qada-store";
+
+export const QADA_EVENT = "ul.qada";
+
+function emit(): void {
+  try {
+    window.dispatchEvent(new CustomEvent(QADA_EVENT));
+  } catch {
+    /* non-browser */
+  }
+}
+
+export function readQada(): Promise<QadaLog> {
+  return store.read();
+}
+
+/** Adjust a prayer's backlog by `delta` (clamped at zero) and persist. */
+export async function adjustQadaCount(prayer: PrayerName, delta: number): Promise<QadaLog> {
+  const next = adjustQada(await store.read(), prayer, delta);
+  await store.write(next);
+  emit();
+  return next;
+}
+
+/** Set a prayer's backlog to an explicit count and persist. */
+export async function setQadaCount(prayer: PrayerName, count: number): Promise<QadaLog> {
+  const next = setQada(await store.read(), prayer, count);
+  await store.write(next);
+  emit();
+  return next;
+}

--- a/docs/adr/0030-qada-tracker.md
+++ b/docs/adr/0030-qada-tracker.md
@@ -1,0 +1,53 @@
+# ADR 0030 — Qaḍāʾ (missed-prayer) tracker behind a store port
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+
+## Context
+
+The prayer tracker ([0020](0020-prayer-tracker.md)) logs whether you prayed each
+of the five daily prayers **today** (on time or late) and computes streaks over
+that dated log. It does not model the other half of the habit: the **backlog of
+missed prayers you owe and make up over time** (qaḍāʾ). Tracking and burning down
+that backlog is a common feature in competitor apps (Pillars, Al-Azan, Namaz
+Vakti) and the first item picked from the Phase 8 competitive set (#137).
+
+This is purely the user's own habit data — like the prayer log and reading goals
+([0006](0006-local-first-persistence.md)) — with no external system involved.
+
+## Decision
+
+**1. The maths is pure `core`.** `core/qada.ts` holds the backlog shape
+(`QadaLog` = prayer → non-negative count) and immutable, deterministic helpers:
+`owedFor`, `totalOwed`, `setQada`, `adjustQada`, and the `recordMissed` / `makeUp`
+shorthands. Counts are clamped to non-negative integers (corrupt or fractional
+stored values are coerced), and a zero count drops the entry so the log stays
+sparse. Everything is unit-tested. It covers the **five obligatory prayers**;
+Witr and other prayers are deferred until asked for.
+
+**2. A separate domain from the daily log.** Qaḍāʾ is a running *balance*, not
+dated entries, so it lives in its own module and **does not touch the streak
+math** in `prayer-tracker.ts` — adding it cannot regress the existing tracker.
+The daily log and the backlog are intentionally not auto-linked: a prayer marked
+missed today does not silently increment the backlog (that would double-count and
+surprise users); the user adds to the backlog explicitly.
+
+**3. Persistence is behind a port from day one.** Unlike 0020 (which began
+port-less and pre-dated the pattern), the backlog sits behind a `QadaStore`
+(`read`/`write`) under the `ul.qada` key, with a `localStorage` web adapter and
+an `AsyncStorage` mobile adapter — the now-standard typed-storage-port pattern
+([0024](0024-local-storage-ports.md)), which the lint enforces app-wide
+([0028](0028-persistence-enforcement.md)). The web feature glue emits a window
+event so the tracker page re-renders on change, mirroring the prayer tracker.
+
+## Consequences
+
+- **Good:** a useful make-up tracker that stays **100% local** — no backend, no
+  accounts, no PII. The maths is shared, testable `core`; web and mobile render
+  the same numbers off the same helpers and ship together. The `ul.qada` key is
+  picked up by the key-agnostic backup ([0018](0018-local-data-backup.md)) with
+  no extra work, and the port is the seam for sync (#25) when it lands.
+- **Scope:** five obligatory prayers only; no automatic coupling to the daily
+  log; no reminders to make up qaḍāʾ (a possible later addition).
+- **Limit & trigger to revisit:** the backlog is per-device like all local-first
+  data — the export/import bridge (0018) covers it until accounts/sync (#25).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ through Phases 1–3; later decisions get their own record at the time they're m
 | [0027](0027-generated-theme-css.md)           | Theme CSS generated from one token source (amends 0023)          | Accepted |
 | [0028](0028-persistence-enforcement.md)       | Persistence behind store adapters is lint-enforced (amends 0024) | Accepted |
 | [0029](0029-mobile-notifier.md)               | Mobile notifications: ExpoNotifier behind the Notifier port       | Accepted |
+| [0030](0030-qada-tracker.md)                  | Qaḍāʾ tracker: missed-prayer backlog behind a store port          | Accepted |
 
 ## Writing a new ADR
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from "./search";
 export * from "./hadith";
 export * from "./prayer";
 export * from "./prayer-tracker";
+export * from "./qada";
 export * from "./qibla";
 export * from "./hijri";
 export * from "./zakat";

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -18,6 +18,7 @@ import type {
 } from "./entities";
 import type { Collection } from "./collections";
 import type { PrayerTrackerLog } from "./prayer-tracker";
+import type { QadaLog } from "./qada";
 import type { TasbihRecord } from "./tasbih";
 import type { HifzCard } from "./hifz";
 import type { Coordinates, Madhab, PrayerName, PrayerTimings } from "./prayer";
@@ -245,6 +246,17 @@ export interface LibraryStore {
 export interface PrayerTrackerStore {
   read(): Promise<PrayerTrackerLog>;
   write(log: PrayerTrackerLog): Promise<void>;
+}
+
+/**
+ * Persists the qaḍāʾ (missed-prayer) backlog on-device (ADR 0024, 0030): how
+ * many of each obligatory prayer are owed. Web uses `localStorage`, mobile
+ * `AsyncStorage`; a synced adapter (#25) replaces either without touching the
+ * backlog maths (`qada.ts`). `read()` returns an empty log when nothing is owed.
+ */
+export interface QadaStore {
+  read(): Promise<QadaLog>;
+  write(log: QadaLog): Promise<void>;
 }
 
 /**

--- a/packages/core/src/qada.test.ts
+++ b/packages/core/src/qada.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { adjustQada, makeUp, owedFor, recordMissed, setQada, totalOwed, type QadaLog } from "./qada";
+
+describe("qada (missed-prayer backlog)", () => {
+  it("reports zero owed for an empty log", () => {
+    expect(owedFor({}, "fajr")).toBe(0);
+    expect(totalOwed({})).toBe(0);
+  });
+
+  it("reads an existing balance and sums the total", () => {
+    const log: QadaLog = { fajr: 3, isha: 2 };
+    expect(owedFor(log, "fajr")).toBe(3);
+    expect(owedFor(log, "dhuhr")).toBe(0);
+    expect(totalOwed(log)).toBe(5);
+  });
+
+  it("clamps corrupt stored values (negative / fractional / non-finite) to a safe count", () => {
+    expect(owedFor({ fajr: -4 }, "fajr")).toBe(0);
+    expect(owedFor({ fajr: 2.9 }, "fajr")).toBe(2);
+    expect(owedFor({ fajr: Number.NaN }, "fajr")).toBe(0);
+    expect(owedFor({ fajr: Infinity }, "fajr")).toBe(0);
+  });
+
+  it("setQada stores an explicit count and is immutable", () => {
+    const log: QadaLog = {};
+    const next = setQada(log, "asr", 5);
+    expect(next.asr).toBe(5);
+    expect(log).toEqual({}); // original untouched
+  });
+
+  it("setQada drops the entry when set to zero (keeps the log sparse)", () => {
+    expect(setQada({ asr: 5 }, "asr", 0)).toEqual({});
+    expect(setQada({ asr: 5 }, "asr", -3)).toEqual({}); // clamped to 0 → dropped
+  });
+
+  it("setQada floors fractional inputs", () => {
+    expect(setQada({}, "maghrib", 3.8).maghrib).toBe(3);
+  });
+
+  it("adjustQada increments and decrements, clamped at zero", () => {
+    let log: QadaLog = {};
+    log = adjustQada(log, "fajr", 2);
+    expect(log.fajr).toBe(2);
+    log = adjustQada(log, "fajr", -1);
+    expect(log.fajr).toBe(1);
+    log = adjustQada(log, "fajr", -5); // cannot go negative; entry dropped at 0
+    expect(log.fajr).toBeUndefined();
+    expect(totalOwed(log)).toBe(0);
+  });
+
+  it("adjustQada truncates a fractional delta", () => {
+    expect(adjustQada({}, "isha", 2.9).isha).toBe(2);
+  });
+
+  it("recordMissed adds one and makeUp removes one", () => {
+    const afterMiss = recordMissed(recordMissed({}, "dhuhr"), "dhuhr");
+    expect(afterMiss.dhuhr).toBe(2);
+    expect(makeUp(afterMiss, "dhuhr").dhuhr).toBe(1);
+  });
+
+  it("makeUp is a no-op when none are owed", () => {
+    expect(makeUp({}, "asr")).toEqual({});
+  });
+});

--- a/packages/core/src/qada.ts
+++ b/packages/core/src/qada.ts
@@ -1,0 +1,61 @@
+/**
+ * Qaḍāʾ (missed-prayer) tracking domain: a per-prayer backlog of obligatory
+ * prayers owed, kept separate from the daily prayer log (`prayer-tracker.ts`).
+ * Pure and deterministic — non-negative integer balances and immutable
+ * operations over them. The backlog is persisted on-device behind the
+ * `QadaStore` port (ADR 0024, 0030); these helpers only compute over it.
+ */
+
+import { OBLIGATORY_PRAYERS, type PrayerName } from "./prayer";
+
+/**
+ * A backlog of missed obligatory prayers owed, keyed by prayer. An absent (or
+ * zero) entry means none are owed, so the log stays sparse.
+ */
+export type QadaLog = Partial<Record<PrayerName, number>>;
+
+/** Coerce any stored/input value to a safe, non-negative integer count. */
+function clampCount(n: number): number {
+  return Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 0;
+}
+
+/** How many of a given prayer are owed (0 when none recorded). */
+export function owedFor(log: QadaLog, prayer: PrayerName): number {
+  return clampCount(log[prayer] ?? 0);
+}
+
+/** Total obligatory prayers owed across all five. */
+export function totalOwed(log: QadaLog): number {
+  return OBLIGATORY_PRAYERS.reduce((sum, p) => sum + owedFor(log, p), 0);
+}
+
+/**
+ * Set a prayer's backlog to an explicit count (clamped to a non-negative
+ * integer). A zero count drops the entry so the log stays sparse. Immutable —
+ * returns a new log.
+ */
+export function setQada(log: QadaLog, prayer: PrayerName, count: number): QadaLog {
+  const next: QadaLog = { ...log };
+  const safe = clampCount(count);
+  if (safe === 0) delete next[prayer];
+  else next[prayer] = safe;
+  return next;
+}
+
+/**
+ * Adjust a prayer's backlog by `delta` — `+1` to record a missed prayer, `-1`
+ * to make one up — clamped at zero so it can never go negative. Immutable.
+ */
+export function adjustQada(log: QadaLog, prayer: PrayerName, delta: number): QadaLog {
+  return setQada(log, prayer, owedFor(log, prayer) + Math.trunc(delta));
+}
+
+/** Record one missed prayer (shorthand for `adjustQada(log, prayer, +1)`). */
+export function recordMissed(log: QadaLog, prayer: PrayerName): QadaLog {
+  return adjustQada(log, prayer, 1);
+}
+
+/** Mark one owed prayer as made up; a no-op when none are owed. */
+export function makeUp(log: QadaLog, prayer: PrayerName): QadaLog {
+  return adjustQada(log, prayer, -1);
+}


### PR DESCRIPTION
## Qaḍāʾ (missed-prayer) make-up tracker — web + mobile

Closes #137. First item picked from the Phase 8 competitive set (epic #152).

The prayer tracker (ADR 0020) logs whether you prayed each of the five daily
prayers **today** and computes streaks. It doesn't model the other half of the
habit: the **backlog of missed prayers you owe and make up over time** (qaḍāʾ).
This adds that — a running per-prayer balance you increment when you miss a
prayer and decrement as you make it up.

### What's in it

- **`packages/core/src/qada.ts`** — pure, deterministic domain: `QadaLog`
  (prayer → non-negative count) with `owedFor`, `totalOwed`, `setQada`,
  `adjustQada`, and `recordMissed` / `makeUp`. Counts are clamped to
  non-negative integers (corrupt/fractional stored values coerced) and a zero
  count drops the entry so the log stays sparse. Fully unit-tested (100%).
- **`packages/core/src/ports.ts`** — new `QadaStore` (`read`/`write`).
  Persistence sits behind a port **from day one** (ADR 0024/0028) under the
  `ul.qada` key, so the key-agnostic backup (ADR 0018) picks it up for free and
  it's already the seam for sync (#25) when that lands.
- **web** — `localStorage` adapter (`lib/qada-store.ts`) + a window-event lib
  wrapper (`lib/qada.ts`), and a `QadaTracker` card on `/tracker` with
  per-prayer −/+ steppers and a live "owed" total.
- **mobile** — `AsyncStorage` adapter (`qada-store.ts`) + a qaḍāʾ section on
  `PrayerTrackerScreen`, rendering the same numbers off the same core helpers.

### Design notes (ADR 0030)

- **Separate from the daily log.** Qaḍāʾ is a running *balance*, not dated
  entries — it lives in its own module and **does not touch the streak math**,
  so it can't regress the existing tracker. The daily log and the backlog are
  intentionally **not** auto-linked: marking a prayer missed today does not
  silently bump the backlog (that would double-count and surprise users); the
  user edits the backlog explicitly.
- **Local-first** (ADR 0006): no backend, no accounts, no PII — per-device,
  covered by export/import until accounts/sync.
- Scope: the **five obligatory prayers**; Witr and others deferred until asked.

### Verification

- `pnpm lint` ✓ (boundaries + persistence-behind-a-port rules)
- `pnpm typecheck` ✓ (all packages, incl. mobile)
- `pnpm test` ✓ (526 tests; new core `qada.ts` and web `QadaTracker` at 100%)
- `pnpm build` ✓ (`/tracker` prerenders)
- **Live browser check**: drove the steppers over CDP — record (+), make-up (−),
  the disabled-at-zero state, the live total, and `localStorage["ul.qada"]`
  persistence all behave; the sparse-log invariant holds (zero counts drop out).

See ADR **0030** for the full rationale.
