### PR TITLE
feat(tracker): ḥayḍ (menstruation) pause preserves prayer streak, web + mobile (#138)

### DIFF
--- a/apps/mobile/src/haid-store.ts
+++ b/apps/mobile/src/haid-store.ts
@@ -1,0 +1,13 @@
+/**
+ * Mobile `HaidStore` adapter (ADR 0024, 0031): the ḥayḍ pause ranges in
+ * AsyncStorage under `ul.haid` (mirrors the web key so the two clients describe
+ * the same local-first state). Persistence only — the pause maths lives in
+ * `@ummahlibrary/core`.
+ */
+import type { HaidLog, HaidStore } from "@ummahlibrary/core";
+import { KEYS, getJSON, setJSON } from "./storage";
+
+export const mobileHaidStore: HaidStore = {
+  read: () => getJSON<HaidLog>(KEYS.haid, []),
+  write: (log) => setJSON(KEYS.haid, log),
+};

--- a/apps/mobile/src/screens/PrayerTrackerScreen.tsx
+++ b/apps/mobile/src/screens/PrayerTrackerScreen.tsx
@@ -3,24 +3,30 @@ import { Pressable, ScrollView, StyleSheet, Text, View } from "../Type";
 import {
   OBLIGATORY_PRAYERS,
   PRAYER_LABELS,
+  type HaidLog,
   type PrayerStatus,
   type PrayerTrackerLog,
   type QadaLog,
   adjustQada,
-  longestStreak,
+  currentPeriod,
+  isDatePaused,
+  longestPrayerStreakWithPause,
   nextPrayerStatus,
   onTimeRate,
   owedFor,
+  periodLength,
   prayedCount,
-  prayerStreak,
+  prayerStreakWithPause,
   recentDays,
   setPrayerStatus,
   statusFor,
+  togglePauseToday,
   totalOwed,
 } from "@ummahlibrary/core";
 import { useTheme, type Palette } from "../theme";
 import { mobilePrayerTrackerStore as prayerStore } from "../prayer-tracker-store";
 import { mobileQadaStore as qadaStore } from "../qada-store";
+import { mobileHaidStore as haidStore } from "../haid-store";
 import { localISODate } from "../utils";
 
 const STATUS_LABEL: Record<PrayerStatus, string> = {
@@ -38,17 +44,27 @@ export function PrayerTrackerScreen() {
 
   const [log, setLog] = useState<PrayerTrackerLog>({});
   const [qada, setQadaLog] = useState<QadaLog>({});
+  const [haid, setHaid] = useState<HaidLog>([]);
   const today = localISODate(new Date());
 
   useEffect(() => {
     void prayerStore.read().then(setLog);
     void qadaStore.read().then(setQadaLog);
+    void haidStore.read().then(setHaid);
   }, []);
 
   function adjustQadaFor(prayer: (typeof OBLIGATORY_PRAYERS)[number], delta: number) {
     setQadaLog((prev) => {
       const next = adjustQada(prev, prayer, delta);
       void qadaStore.write(next);
+      return next;
+    });
+  }
+
+  function toggleHaid() {
+    setHaid((prev) => {
+      const next = togglePauseToday(prev, today);
+      void haidStore.write(next);
       return next;
     });
   }
@@ -63,11 +79,13 @@ export function PrayerTrackerScreen() {
 
   const todayLog = log[today];
   const days = recentDays(log, today, 7);
+  const haidCurrent = currentPeriod(haid);
+  const haidDays = haidCurrent ? periodLength(haidCurrent, today) : 0;
   const stats: [string, string][] = [
     [`${prayedCount(todayLog)}/5`, "Prayed today"],
-    [`${prayerStreak(log, today)} 🔥`, "Day streak"],
+    [`${prayerStreakWithPause(log, haid, today)} 🔥`, "Day streak"],
     [`${onTimeRate(log, today)}%`, "On time (30d)"],
-    [`${longestStreak(log)}`, "Best streak"],
+    [`${longestPrayerStreakWithPause(log, haid)}`, "Best streak"],
   ];
 
   return (
@@ -120,6 +138,7 @@ export function PrayerTrackerScreen() {
         <Legend color={colors.accent} label="On time" colors={colors} />
         <Legend color={LATE} label="Late" colors={colors} />
         <Legend color={colors.border} label="Missed" colors={colors} outline />
+        <Legend color={colors.muted} label="Paused" colors={colors} outline />
       </View>
       <View style={styles.grid}>
         {OBLIGATORY_PRAYERS.map((p, pi) => (
@@ -127,20 +146,48 @@ export function PrayerTrackerScreen() {
             <Text style={styles.gridLabel}>{PRAYER_LABELS[p]}</Text>
             {days.map((d) => {
               const st = d.statuses[pi] ?? "none";
+              const dayPaused = isDatePaused(haid, d.date);
               return (
                 <View
                   key={d.date}
                   style={[
                     styles.cell,
-                    st === "none"
-                      ? { borderWidth: 1, borderColor: colors.border }
-                      : { backgroundColor: statusColor(st) },
+                    dayPaused
+                      ? { borderWidth: 1, borderStyle: "dashed", borderColor: colors.muted }
+                      : st === "none"
+                        ? { borderWidth: 1, borderColor: colors.border }
+                        : { backgroundColor: statusColor(st) },
                   ]}
                 />
               );
             })}
           </View>
         ))}
+      </View>
+
+      <Text style={styles.sectionLabel}>Cycle pause · ḥayḍ</Text>
+      <View style={styles.haidCard}>
+        <View style={styles.haidInfo}>
+          <Text style={[styles.haidStatus, { color: haidCurrent ? colors.accent : colors.fg }]}>
+            {haidCurrent ? `Paused — day ${haidDays}` : "Tracking active"}
+          </Text>
+          <Text style={styles.haidHint}>
+            {haidCurrent
+              ? `Since ${haidCurrent.start}. Prayers aren’t counted as missed; your streak is held.`
+              : "On your period? Pause tracking — those days won’t break your streak."}
+          </Text>
+        </View>
+        <Pressable
+          onPress={toggleHaid}
+          style={[styles.haidBtn, haidCurrent ? styles.haidBtnOutline : null]}
+          accessibilityLabel={haidCurrent ? "End cycle pause" : "Start cycle pause"}
+        >
+          <Text
+            style={[styles.haidBtnText, { color: haidCurrent ? colors.fg : colors.accent }]}
+          >
+            {haidCurrent ? "End pause" : "Start pause"}
+          </Text>
+        </Pressable>
       </View>
 
       <Text style={styles.sectionLabel}>Make-up prayers · qaḍāʾ ({totalOwed(qada)} owed)</Text>
@@ -258,6 +305,29 @@ function makeStyles(c: Palette) {
     gridRow: { flexDirection: "row", alignItems: "center", gap: 7 },
     gridLabel: { color: c.muted, fontSize: 12.5, fontWeight: "600", width: 56 },
     cell: { flex: 1, aspectRatio: 1, maxWidth: 34, borderRadius: 7 },
+    haidCard: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+      backgroundColor: c.bgElev,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 14,
+      padding: 16,
+    },
+    haidInfo: { flex: 1 },
+    haidStatus: { fontSize: 15, fontWeight: "800" },
+    haidHint: { color: c.faint, fontSize: 12.5, marginTop: 4 },
+    haidBtn: {
+      backgroundColor: c.accentSoft,
+      borderRadius: 12,
+      paddingVertical: 10,
+      paddingHorizontal: 16,
+      borderWidth: 1,
+      borderColor: "transparent",
+    },
+    haidBtnOutline: { backgroundColor: "transparent", borderColor: c.border },
+    haidBtnText: { fontSize: 14, fontWeight: "700" },
     qadaList: { gap: 8 },
     qadaRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
     qadaName: { color: c.fg, fontSize: 14, fontWeight: "700" },

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -34,6 +34,7 @@ export const KEYS = {
   prayerCoords: "ul.prayerCoords",
   prayerLog: "ul.prayerLog",
   qada: "ul.qada",
+  haid: "ul.haid",
   hijriAdjust: "ul.hijriAdjust",
   zakat: "ul.zakat",
   onboarded: "ul.onboarded",

--- a/apps/web/src/app/tracker/page.tsx
+++ b/apps/web/src/app/tracker/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { NoorPageFrame } from "../../components/NoorPageFrame";
 import { PrayerTracker } from "../../components/PrayerTracker";
+import { CyclePause } from "../../components/CyclePause";
 import { QadaTracker } from "../../components/QadaTracker";
 
 export const metadata: Metadata = {
@@ -20,6 +21,7 @@ export default function PrayerTrackerPage() {
       maxW={820}
     >
       <PrayerTracker />
+      <CyclePause />
       <QadaTracker />
     </NoorPageFrame>
   );

--- a/apps/web/src/components/CyclePause.test.tsx
+++ b/apps/web/src/components/CyclePause.test.tsx
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CyclePause } from "./CyclePause";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("CyclePause", () => {
+  it("starts a pause, persisting an open period to ul.haid", async () => {
+    render(<CyclePause />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Start cycle pause" }));
+
+    await waitFor(() => {
+      const log = JSON.parse(localStorage.getItem("ul.haid") ?? "[]");
+      expect(log).toHaveLength(1);
+      expect(log[0].end).toBeUndefined();
+    });
+    // Button flips to the end action.
+    expect(screen.getByRole("button", { name: "End cycle pause" })).toBeInTheDocument();
+  });
+
+  it("reflects an existing ongoing pause", async () => {
+    localStorage.setItem("ul.haid", JSON.stringify([{ start: "2026-06-10" }]));
+    render(<CyclePause />);
+    expect(await screen.findByRole("button", { name: "End cycle pause" })).toBeInTheDocument();
+    expect(screen.getByText(/Paused — day/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/CyclePause.tsx
+++ b/apps/web/src/components/CyclePause.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
+import { type HaidLog, currentPeriod, periodLength } from "@ummahlibrary/core";
+import { N } from "@ummahlibrary/ui";
+import { HAID_EVENT, readHaid, togglePause } from "../lib/haid";
+import { today } from "../lib/prayer-tracker";
+
+const card: CSSProperties = {
+  background: N.card,
+  border: `1px solid ${N.border}`,
+  borderRadius: 16,
+};
+const sectionLabel: CSSProperties = {
+  fontSize: 12,
+  letterSpacing: 1,
+  textTransform: "uppercase",
+  color: N.faint,
+  fontWeight: 700,
+};
+
+const fmt = (d: string): string =>
+  new Date(`${d}T00:00:00`).toLocaleDateString([], { month: "short", day: "numeric" });
+
+export function CyclePause() {
+  const [ready, setReady] = useState(false);
+  const [log, setLog] = useState<HaidLog>([]);
+  const [todayStr, setTodayStr] = useState("");
+
+  useEffect(() => {
+    setTodayStr(today());
+    void readHaid().then(setLog);
+    setReady(true);
+    const onChange = () => void readHaid().then(setLog);
+    window.addEventListener(HAID_EVENT, onChange);
+    return () => window.removeEventListener(HAID_EVENT, onChange);
+  }, []);
+
+  if (!ready) return null;
+
+  const current = currentPeriod(log);
+  const days = current ? periodLength(current, todayStr) : 0;
+
+  return (
+    <div style={{ ...card, padding: 24, marginTop: 18 }}>
+      <div style={{ ...sectionLabel, marginBottom: 12 }}>Cycle pause · ḥayḍ</div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 16, fontWeight: 800, color: current ? N.gold : N.fg }}>
+            {current ? `Paused — day ${days}` : "Tracking active"}
+          </div>
+          <div style={{ fontSize: 13, color: N.faint, marginTop: 4, maxWidth: 460 }}>
+            {current
+              ? `Since ${fmt(current.start)}. Prayers aren’t counted as missed and your streak is held.`
+              : "On your period? Start a pause — those days won’t break your streak or count as missed."}
+          </div>
+        </div>
+        <button
+          type="button"
+          aria-label={current ? "End cycle pause" : "Start cycle pause"}
+          onClick={() => void togglePause(todayStr).then(setLog)}
+          style={{
+            padding: "10px 18px",
+            borderRadius: 12,
+            border: `1px solid ${current ? N.border : "transparent"}`,
+            background: current ? "transparent" : N.goldSoft,
+            color: current ? N.fg : N.gold,
+            cursor: "pointer",
+            fontFamily: N.ui,
+            fontSize: 14,
+            fontWeight: 700,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {current ? "End pause" : "Start pause"}
+        </button>
+      </div>
+      <p style={{ fontSize: 12, color: N.faint, marginTop: 14, marginBottom: 0 }}>
+        Any missed fasts in this time are made up later. Stored on your device.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/PrayerTracker.test.tsx
+++ b/apps/web/src/components/PrayerTracker.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { addDays, type PrayerDayLog } from "@ummahlibrary/core";
+import { PrayerTracker } from "./PrayerTracker";
+
+const COMPLETE: PrayerDayLog = {
+  fajr: "ontime",
+  dhuhr: "ontime",
+  asr: "ontime",
+  maghrib: "ontime",
+  isha: "ontime",
+};
+
+// Mirror lib/prayer-tracker's local-date helper so the seeded dates line up with
+// the "today" the component reads from the real clock.
+function todayStr(): string {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("PrayerTracker × ḥayḍ pause", () => {
+  it("keeps the streak alive across a pause instead of breaking on the gap", async () => {
+    const t = todayStr();
+    // Complete today & yesterday, a 3-day pause, then two more complete days.
+    localStorage.setItem(
+      "ul.prayerLog",
+      JSON.stringify({
+        [t]: COMPLETE,
+        [addDays(t, -1)]: COMPLETE,
+        [addDays(t, -5)]: COMPLETE,
+        [addDays(t, -6)]: COMPLETE,
+      }),
+    );
+    localStorage.setItem(
+      "ul.haid",
+      JSON.stringify([{ start: addDays(t, -4), end: addDays(t, -2) }]),
+    );
+
+    render(<PrayerTracker />);
+
+    // 4 complete days, bridged by the pause → streak 4 (would be 2 without it).
+    expect(await screen.findByText("4 🔥")).toBeInTheDocument();
+  });
+
+  it("shows a Paused legend for the history grid", async () => {
+    render(<PrayerTracker />);
+    expect(await screen.findByText("Paused")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/PrayerTracker.tsx
+++ b/apps/web/src/components/PrayerTracker.tsx
@@ -5,17 +5,20 @@ import { useEffect, useState } from "react";
 import {
   OBLIGATORY_PRAYERS,
   PRAYER_LABELS,
+  type HaidLog,
   type PrayerStatus,
   type PrayerTrackerLog,
-  longestStreak,
+  isDatePaused,
+  longestPrayerStreakWithPause,
   onTimeRate,
   prayedCount,
-  prayerStreak,
+  prayerStreakWithPause,
   recentDays,
   statusFor,
 } from "@ummahlibrary/core";
 import { Icon, N } from "@ummahlibrary/ui";
 import { PRAYER_TRACKER_EVENT, cyclePrayer, readPrayerLog, today } from "../lib/prayer-tracker";
+import { HAID_EVENT, readHaid } from "../lib/haid";
 
 // A warm bronze for "late", distinct from the gold used for "on time".
 const LATE = "#C98A57";
@@ -45,15 +48,23 @@ function weekdayInitial(date: string): string {
 export function PrayerTracker() {
   const [ready, setReady] = useState(false);
   const [log, setLog] = useState<PrayerTrackerLog>({});
+  const [haid, setHaid] = useState<HaidLog>([]);
   const [todayStr, setTodayStr] = useState("");
 
   useEffect(() => {
     setTodayStr(today());
-    void readPrayerLog().then(setLog);
+    const refresh = () => {
+      void readPrayerLog().then(setLog);
+      void readHaid().then(setHaid);
+    };
+    refresh();
     setReady(true);
-    const onChange = () => void readPrayerLog().then(setLog);
-    window.addEventListener(PRAYER_TRACKER_EVENT, onChange);
-    return () => window.removeEventListener(PRAYER_TRACKER_EVENT, onChange);
+    window.addEventListener(PRAYER_TRACKER_EVENT, refresh);
+    window.addEventListener(HAID_EVENT, refresh);
+    return () => {
+      window.removeEventListener(PRAYER_TRACKER_EVENT, refresh);
+      window.removeEventListener(HAID_EVENT, refresh);
+    };
   }, []);
 
   if (!ready) return null;
@@ -63,9 +74,9 @@ export function PrayerTracker() {
 
   const stats: [string, string][] = [
     [`${prayedCount(todayLog)}/5`, "Prayed today"],
-    [`${prayerStreak(log, todayStr)} 🔥`, "Day streak"],
+    [`${prayerStreakWithPause(log, haid, todayStr)} 🔥`, "Day streak"],
     [`${onTimeRate(log, todayStr)}%`, "On time (30d)"],
-    [`${longestStreak(log)}`, "Best streak"],
+    [`${longestPrayerStreakWithPause(log, haid)}`, "Best streak"],
   ];
 
   return (
@@ -164,6 +175,7 @@ export function PrayerTracker() {
             <Legend swatch={{ background: N.gold }}>On time</Legend>
             <Legend swatch={{ background: LATE }}>Late</Legend>
             <Legend swatch={{ border: `1px solid ${N.border}` }}>Missed</Legend>
+            <Legend swatch={{ border: `1px dashed ${N.muted}` }}>Paused</Legend>
           </div>
         </div>
         <div
@@ -190,18 +202,25 @@ export function PrayerTracker() {
               </div>
               {days.map((d) => {
                 const st = d.statuses[pi] ?? "none";
+                const dayPaused = isDatePaused(haid, d.date);
                 return (
                   <div
                     key={d.date}
-                    title={`${PRAYER_LABELS[p]} · ${weekdayInitial(d.date)}: ${statusLabel(st)}`}
+                    title={`${PRAYER_LABELS[p]} · ${weekdayInitial(d.date)}: ${
+                      dayPaused ? "Paused" : statusLabel(st)
+                    }`}
                     style={{
                       aspectRatio: "1",
                       width: "100%",
                       maxWidth: 30,
                       margin: "0 auto",
                       borderRadius: 7,
-                      background: st === "none" ? "transparent" : statusColor(st),
-                      border: st === "none" ? `1px solid ${N.border}` : "none",
+                      background: dayPaused || st === "none" ? "transparent" : statusColor(st),
+                      border: dayPaused
+                        ? `1px dashed ${N.muted}`
+                        : st === "none"
+                          ? `1px solid ${N.border}`
+                          : "none",
                     }}
                   />
                 );

--- a/apps/web/src/lib/haid-store.ts
+++ b/apps/web/src/lib/haid-store.ts
@@ -1,0 +1,27 @@
+/**
+ * Web `HaidStore` adapter (ADR 0024, 0031): the ḥayḍ pause ranges in
+ * `localStorage` under `ul.haid`. Persistence only — the pause maths lives in
+ * `@ummahlibrary/core` — so a synced adapter (#25) can replace it without
+ * touching the feature. Mirrors mobile.
+ */
+import type { HaidLog, HaidStore } from "@ummahlibrary/core";
+
+const KEY = "ul.haid";
+
+export const webHaidStore: HaidStore = {
+  read: async () => {
+    try {
+      const raw = localStorage.getItem(KEY);
+      return raw ? (JSON.parse(raw) as HaidLog) : [];
+    } catch {
+      return [];
+    }
+  },
+  write: async (log) => {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(log));
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};

--- a/apps/web/src/lib/haid.test.ts
+++ b/apps/web/src/lib/haid.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { currentPeriod } from "@ummahlibrary/core";
+import { HAID_EVENT, readHaid, togglePause } from "./haid";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("haid store (web)", () => {
+  it("starts with an empty pause log", async () => {
+    expect(await readHaid()).toEqual([]);
+  });
+
+  it("starts a pause, then ends it on the next toggle, persisting both", async () => {
+    const started = await togglePause("2026-06-10");
+    expect(currentPeriod(started)?.start).toBe("2026-06-10");
+    expect(JSON.parse(localStorage.getItem("ul.haid") ?? "[]")).toEqual([{ start: "2026-06-10" }]);
+
+    const ended = await togglePause("2026-06-16");
+    expect(currentPeriod(ended)).toBeUndefined();
+    expect((await readHaid())[0]).toEqual({ start: "2026-06-10", end: "2026-06-16" });
+  });
+
+  it("emits a change event so subscribers can re-render", async () => {
+    const handler = vi.fn();
+    window.addEventListener(HAID_EVENT, handler);
+    await togglePause("2026-06-10");
+    window.removeEventListener(HAID_EVENT, handler);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to an empty log when stored JSON is corrupt", async () => {
+    localStorage.setItem("ul.haid", "[not json");
+    expect(await readHaid()).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/haid.ts
+++ b/apps/web/src/lib/haid.ts
@@ -1,0 +1,31 @@
+/**
+ * Local-first ḥayḍ (menstruation) pause (ADR 0006, 0031): the date ranges during
+ * which prayer tracking is paused. Persistence goes through the `HaidStore` port
+ * (web adapter `webHaidStore`, ADR 0024); the pause maths lives in
+ * `@ummahlibrary/core`. A window event lets the tracker page re-render on change
+ * — the established pattern from the prayer/qaḍāʾ trackers.
+ */
+import { type HaidLog, togglePauseToday } from "@ummahlibrary/core";
+import { webHaidStore as store } from "./haid-store";
+
+export const HAID_EVENT = "ul.haid";
+
+function emit(): void {
+  try {
+    window.dispatchEvent(new CustomEvent(HAID_EVENT));
+  } catch {
+    /* non-browser */
+  }
+}
+
+export function readHaid(): Promise<HaidLog> {
+  return store.read();
+}
+
+/** Start a pause today, or end the ongoing one, and persist. */
+export async function togglePause(today: string): Promise<HaidLog> {
+  const next = togglePauseToday(await store.read(), today);
+  await store.write(next);
+  emit();
+  return next;
+}

--- a/docs/adr/0031-haid-pause.md
+++ b/docs/adr/0031-haid-pause.md
@@ -1,0 +1,60 @@
+# ADR 0031 — Ḥayḍ (menstruation) pause for prayer tracking
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+The prayer tracker ([0020](0020-prayer-tracker.md)) rewards a streak of complete
+days and shows a "missed" history. For roughly half the user base this is
+incorrect during menstruation (ḥayḍ): a woman does not pray during her period,
+and — per fiqh — those prayers are **not** made up. Without a pause, the tracker
+punishes a religiously-correct gap as a broken streak and a wall of "missed"
+days. Pillars and Athan both ship a menstrual pause that preserves the streak;
+it is the first parity item from the Phase 8 set (#138) and a sibling of the
+qaḍāʾ tracker ([0030](0030-qada-tracker.md)).
+
+This is purely the user's own habit data, like the prayer log and the backlog
+([0006](0006-local-first-persistence.md)) — no external system involved.
+
+## Decision
+
+**1. The maths is pure `core`.** `core/haid.ts` holds the pause shape
+(`HaidLog` = a list of `{ start, end? }` periods; an absent `end` is an ongoing
+pause) and immutable, deterministic helpers: `isPaused`, `currentPeriod`,
+`periodLength`, `startPause` / `endPause` / `togglePauseToday`, and the
+pause-aware streak functions `prayerStreakWithPause` and
+`longestPrayerStreakWithPause`. The log holds at most one open period and never
+overlaps. Everything is unit-tested.
+
+**2. Pauses are transparent to the streak, not breaks.** The streak walk treats
+a paused day as neither extending nor breaking the run, so an active day before
+the pause connects to an active day after it. Paused days are also excluded from
+the "missed" history (rendered as *Paused*, a dashed cell) and naturally drop out
+of the on-time rate (they hold no logged prayers). Crucially, paused prayers are
+**not** added to the qaḍāʾ backlog ([0030](0030-qada-tracker.md)) — menstrual
+prayers are not made up.
+
+**3. A separate domain, behind its own port.** Like the qaḍāʾ work, the pause is
+its own module and **does not touch `prayer-tracker.ts`** — the existing streak
+math is untouched and the UIs opt in by calling the pause-aware functions. It is
+persisted behind a `HaidStore` (`read`/`write`) under `ul.haid`, with a
+`localStorage` web adapter and an `AsyncStorage` mobile adapter
+([0024](0024-local-storage-ports.md), enforced by [0028](0028-persistence-enforcement.md)).
+The web feature glue emits a window event so the tracker page re-renders.
+
+## Consequences
+
+- **Good:** a correctness fix that keeps the tracker honest for menstruating
+  users, 100% local — no backend, no accounts, no PII. The `ul.haid` key is
+  picked up by the key-agnostic backup ([0018](0018-local-data-backup.md)) for
+  free, and the port is the seam for sync (#25).
+- **Scope / deferred:** this ships the **prayer** side of #138. Flagging *fasts*
+  missed during a pause as qaḍāʾ is **not** included: the Ramaḍān tracker is
+  day-number indexed (`Record<number, true>`), not date-based, so mapping a
+  Gregorian pause range to specific fasts to make up needs a date-based fasting
+  tracker that does not exist yet. The issue itself notes this dependency; it is
+  tracked as a follow-up.
+- **Limit & trigger to revisit:** per-device like all local-first data until the
+  export/import bridge (0018) or accounts/sync (#25). When a date-based fasting
+  tracker lands, wire the pause range into fast make-up.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@ through Phases 1–3; later decisions get their own record at the time they're m
 | [0028](0028-persistence-enforcement.md)       | Persistence behind store adapters is lint-enforced (amends 0024) | Accepted |
 | [0029](0029-mobile-notifier.md)               | Mobile notifications: ExpoNotifier behind the Notifier port       | Accepted |
 | [0030](0030-qada-tracker.md)                  | Qaḍāʾ tracker: missed-prayer backlog behind a store port          | Accepted |
+| [0031](0031-haid-pause.md)                    | Ḥayḍ pause: menstrual pause preserves the prayer streak           | Accepted |
 
 ## Writing a new ADR
 

--- a/packages/core/src/haid.test.ts
+++ b/packages/core/src/haid.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  type HaidLog,
+  currentPeriod,
+  endPause,
+  isDatePaused,
+  longestPrayerStreakWithPause,
+  periodLength,
+  prayerStreakWithPause,
+  startPause,
+  streakWithPauses,
+  togglePauseToday,
+} from "./haid";
+import type { PrayerDayLog, PrayerTrackerLog } from "./prayer-tracker";
+
+const COMPLETE: PrayerDayLog = {
+  fajr: "ontime",
+  dhuhr: "ontime",
+  asr: "ontime",
+  maghrib: "ontime",
+  isha: "ontime",
+};
+
+/** Build a tracker log where every listed date is a complete (all-five) day. */
+function completeOn(...dates: string[]): PrayerTrackerLog {
+  return Object.fromEntries(dates.map((d) => [d, COMPLETE]));
+}
+
+describe("isDatePaused", () => {
+  it("matches a closed range inclusively and excludes outside days", () => {
+    const log: HaidLog = [{ start: "2026-06-10", end: "2026-06-15" }];
+    expect(isDatePaused(log, "2026-06-09")).toBe(false);
+    expect(isDatePaused(log, "2026-06-10")).toBe(true);
+    expect(isDatePaused(log, "2026-06-13")).toBe(true);
+    expect(isDatePaused(log, "2026-06-15")).toBe(true);
+    expect(isDatePaused(log, "2026-06-16")).toBe(false);
+  });
+
+  it("treats an open period as covering every day from its start onward", () => {
+    const log: HaidLog = [{ start: "2026-06-10" }];
+    expect(isDatePaused(log, "2026-06-09")).toBe(false);
+    expect(isDatePaused(log, "2026-06-10")).toBe(true);
+    expect(isDatePaused(log, "2030-01-01")).toBe(true);
+  });
+
+  it("is false for an empty log", () => {
+    expect(isDatePaused([], "2026-06-10")).toBe(false);
+  });
+});
+
+describe("currentPeriod", () => {
+  it("finds the open period and is undefined when all are closed", () => {
+    expect(currentPeriod([{ start: "2026-06-01", end: "2026-06-05" }])).toBeUndefined();
+    expect(currentPeriod([{ start: "2026-06-10" }])?.start).toBe("2026-06-10");
+  });
+});
+
+describe("periodLength", () => {
+  it("counts inclusive days for a closed period", () => {
+    expect(periodLength({ start: "2026-06-10", end: "2026-06-10" }, "2026-06-20")).toBe(1);
+    expect(periodLength({ start: "2026-06-10", end: "2026-06-16" }, "2026-06-20")).toBe(7);
+  });
+
+  it("measures an open period up to the asOf date, never below 1", () => {
+    expect(periodLength({ start: "2026-06-10" }, "2026-06-12")).toBe(3);
+    expect(periodLength({ start: "2026-06-10" }, "2026-06-10")).toBe(1);
+    expect(periodLength({ start: "2026-06-10" }, "2026-06-01")).toBe(1);
+  });
+});
+
+describe("startPause", () => {
+  it("opens a new period when none is active", () => {
+    const log = startPause([], "2026-06-10");
+    expect(log).toEqual([{ start: "2026-06-10" }]);
+  });
+
+  it("keeps the log sorted by start", () => {
+    let log = startPause([], "2026-06-10");
+    log = endPause(log, "2026-06-12");
+    const earlier = startPause(log, "2026-05-01");
+    expect(earlier.map((p) => p.start)).toEqual(["2026-05-01", "2026-06-10"]);
+  });
+
+  it("is a no-op while a pause is already ongoing", () => {
+    const log: HaidLog = [{ start: "2026-06-10" }];
+    expect(startPause(log, "2026-06-20")).toBe(log);
+  });
+
+  it("is a no-op when the date already sits in a closed period", () => {
+    const log: HaidLog = [{ start: "2026-06-10", end: "2026-06-15" }];
+    expect(startPause(log, "2026-06-12")).toBe(log);
+  });
+});
+
+describe("endPause", () => {
+  it("closes the ongoing period with the given end date", () => {
+    const log = endPause([{ start: "2026-06-10" }], "2026-06-16");
+    expect(log).toEqual([{ start: "2026-06-10", end: "2026-06-16" }]);
+  });
+
+  it("collapses to a single day when end precedes start", () => {
+    const log = endPause([{ start: "2026-06-10" }], "2026-06-05");
+    expect(log).toEqual([{ start: "2026-06-10", end: "2026-06-10" }]);
+  });
+
+  it("is a no-op when nothing is open", () => {
+    const log: HaidLog = [{ start: "2026-06-10", end: "2026-06-15" }];
+    expect(endPause(log, "2026-06-20")).toBe(log);
+  });
+});
+
+describe("togglePauseToday", () => {
+  it("starts a pause when none is open, then ends it on the next toggle", () => {
+    const started = togglePauseToday([], "2026-06-10");
+    expect(currentPeriod(started)?.start).toBe("2026-06-10");
+    const ended = togglePauseToday(started, "2026-06-16");
+    expect(currentPeriod(ended)).toBeUndefined();
+    expect(ended[0]?.end).toBe("2026-06-16");
+  });
+});
+
+describe("streakWithPauses", () => {
+  const paused = (log: HaidLog) => (d: string) => isDatePaused(log, d);
+
+  it("counts consecutive active days ending today", () => {
+    const dates = ["2026-06-08", "2026-06-09", "2026-06-10"];
+    expect(streakWithPauses(dates, () => false, "2026-06-10")).toBe(3);
+  });
+
+  it("uses yesterday as a grace day when today is blank", () => {
+    const dates = ["2026-06-08", "2026-06-09"];
+    expect(streakWithPauses(dates, () => false, "2026-06-10")).toBe(2);
+  });
+
+  it("breaks on a non-active, non-paused day", () => {
+    const dates = ["2026-06-06", "2026-06-07", "2026-06-10"];
+    // 09 is blank and not paused → streak is just today (10).
+    expect(streakWithPauses(dates, () => false, "2026-06-10")).toBe(1);
+  });
+
+  it("bridges a pause: active days on both sides keep the streak", () => {
+    // Active 06-07, paused 08-10, active 11; today 11.
+    const dates = ["2026-06-06", "2026-06-07", "2026-06-11"];
+    const log: HaidLog = [{ start: "2026-06-08", end: "2026-06-10" }];
+    expect(streakWithPauses(dates, paused(log), "2026-06-11")).toBe(3);
+  });
+
+  it("survives an ongoing pause through today with no break", () => {
+    const dates = ["2026-06-06", "2026-06-07"];
+    const log: HaidLog = [{ start: "2026-06-08" }]; // open, covers today
+    expect(streakWithPauses(dates, paused(log), "2026-06-10")).toBe(2);
+  });
+
+  it("returns 0 when the grace day is also blank", () => {
+    expect(streakWithPauses(["2026-06-01"], () => false, "2026-06-10")).toBe(0);
+  });
+});
+
+describe("prayerStreakWithPause", () => {
+  it("preserves the prayer streak across a ḥayḍ pause", () => {
+    const log = completeOn("2026-06-06", "2026-06-07", "2026-06-11");
+    const haid: HaidLog = [{ start: "2026-06-08", end: "2026-06-10" }];
+    expect(prayerStreakWithPause(log, haid, "2026-06-11")).toBe(3);
+    // Without the pause the gap (08–10) would break it down to just today.
+    expect(prayerStreakWithPause(log, [], "2026-06-11")).toBe(1);
+  });
+});
+
+describe("longestPrayerStreakWithPause", () => {
+  it("is 0 with no complete days", () => {
+    expect(longestPrayerStreakWithPause({}, [])).toBe(0);
+  });
+
+  it("bridges fully-paused gaps but resets on an un-paused gap", () => {
+    const log = completeOn(
+      "2026-06-01",
+      "2026-06-02",
+      // gap 03 paused → bridged
+      "2026-06-04",
+      // gap 05 NOT paused → resets
+      "2026-06-06",
+    );
+    const haid: HaidLog = [{ start: "2026-06-03", end: "2026-06-03" }];
+    // Run 01,02,(03 paused),04 = 3 ; then 06 starts a new run of 1.
+    expect(longestPrayerStreakWithPause(log, haid)).toBe(3);
+  });
+
+  it("matches plain consecutive counting when there are no pauses", () => {
+    const log = completeOn("2026-06-01", "2026-06-02", "2026-06-03");
+    expect(longestPrayerStreakWithPause(log, [])).toBe(3);
+  });
+});

--- a/packages/core/src/haid.ts
+++ b/packages/core/src/haid.ts
@@ -1,0 +1,127 @@
+/**
+ * Ḥayḍ (menstruation) pause domain: date ranges during which prayer tracking is
+ * paused. Paused days don't count as "missed", don't break the streak, and the
+ * prayers in them are **not** owed as qaḍāʾ — per fiqh, menstrual-missed prayers
+ * are not made up (missed *fasts* are a separate, later concern; see #138).
+ *
+ * Pure and deterministic — dates are plain YYYY-MM-DD strings and "today" is
+ * injected, never read from the clock. Persisted locally behind the `HaidStore`
+ * port (ADR 0006, 0024, 0031). A separate domain from the daily prayer log, so
+ * adding it cannot regress the existing tracker (`prayer-tracker.ts`).
+ */
+
+import { addDays, daysBetween } from "./reading-goals";
+import { completeDates, type PrayerTrackerLog } from "./prayer-tracker";
+
+/** One pause period, inclusive of both ends. `end` undefined ⇒ still ongoing. */
+export interface HaidPeriod {
+  /** First paused day, YYYY-MM-DD (inclusive). */
+  start: string;
+  /** Last paused day, YYYY-MM-DD (inclusive); undefined while the pause is open. */
+  end?: string;
+}
+
+/** All pause periods, kept sorted by `start` (oldest → newest). */
+export type HaidLog = HaidPeriod[];
+
+const byStart = (a: HaidPeriod, b: HaidPeriod): number =>
+  a.start < b.start ? -1 : a.start > b.start ? 1 : 0;
+
+/** Whether `date` (YYYY-MM-DD) falls within any pause period. */
+export function isDatePaused(log: HaidLog, date: string): boolean {
+  return log.some((p) => date >= p.start && (p.end === undefined || date <= p.end));
+}
+
+/** The single ongoing (open-ended) period, or `undefined` if none is active. */
+export function currentPeriod(log: HaidLog): HaidPeriod | undefined {
+  return log.find((p) => p.end === undefined);
+}
+
+/** Inclusive length of a period in days, measured to `asOf` while it is open. */
+export function periodLength(period: HaidPeriod, asOf: string): number {
+  const end = period.end ?? asOf;
+  return Math.max(1, daysBetween(period.start, end) + 1);
+}
+
+/**
+ * Begin a pause on `date`. No-op if a pause is already ongoing or `date` already
+ * sits inside a recorded period — so the log holds at most one open period and
+ * never overlaps.
+ */
+export function startPause(log: HaidLog, date: string): HaidLog {
+  if (currentPeriod(log) || isDatePaused(log, date)) return log;
+  return [...log, { start: date }].sort(byStart);
+}
+
+/**
+ * Close the ongoing pause on `date` (inclusive). No-op if no pause is open. An
+ * `end` earlier than the start collapses to a single-day period.
+ */
+export function endPause(log: HaidLog, date: string): HaidLog {
+  const open = currentPeriod(log);
+  if (!open) return log;
+  const end = date < open.start ? open.start : date;
+  return log.map((p) => (p === open ? { ...p, end } : p));
+}
+
+/** One-tap toggle: end the ongoing pause, or start one today. */
+export function togglePauseToday(log: HaidLog, today: string): HaidLog {
+  return currentPeriod(log) ? endPause(log, today) : startPause(log, today);
+}
+
+/** Whether every day strictly between `a` and `b` is paused (a bridged gap). */
+function bridged(a: string, b: string, paused: (date: string) => boolean): boolean {
+  for (let d = addDays(a, 1); d < b; d = addDays(d, 1)) {
+    if (!paused(d)) return false;
+  }
+  return true;
+}
+
+/**
+ * Consecutive active days ending today, walking backwards. Paused days are
+ * transparent — they neither extend nor break the run — so a streak survives a
+ * pause. A non-active, non-paused day ends the run. Today is a grace day: if it
+ * is neither active nor paused, the count starts from yesterday.
+ */
+export function streakWithPauses(
+  activeDates: Iterable<string>,
+  paused: (date: string) => boolean,
+  today: string,
+): number {
+  const set = new Set(activeDates);
+  let cursor = !set.has(today) && !paused(today) ? addDays(today, -1) : today;
+  let streak = 0;
+  for (;;) {
+    if (paused(cursor)) {
+      cursor = addDays(cursor, -1);
+      continue;
+    }
+    if (!set.has(cursor)) return streak;
+    streak++;
+    cursor = addDays(cursor, -1);
+  }
+}
+
+/** The current prayer streak (complete days), preserved across ḥayḍ pauses. */
+export function prayerStreakWithPause(
+  log: PrayerTrackerLog,
+  haid: HaidLog,
+  today: string,
+): number {
+  return streakWithPauses(completeDates(log), (d) => isDatePaused(haid, d), today);
+}
+
+/** The longest prayer streak ever, with fully-paused gaps bridging the run. */
+export function longestPrayerStreakWithPause(log: PrayerTrackerLog, haid: HaidLog): number {
+  const dates = completeDates(log).sort();
+  const paused = (d: string) => isDatePaused(haid, d);
+  let best = 0;
+  let run = 0;
+  let prev: string | null = null;
+  for (const date of dates) {
+    run = prev !== null && bridged(prev, date, paused) ? run + 1 : 1;
+    if (run > best) best = run;
+    prev = date;
+  }
+  return best;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export * from "./hadith";
 export * from "./prayer";
 export * from "./prayer-tracker";
 export * from "./qada";
+export * from "./haid";
 export * from "./qibla";
 export * from "./hijri";
 export * from "./zakat";

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -19,6 +19,7 @@ import type {
 import type { Collection } from "./collections";
 import type { PrayerTrackerLog } from "./prayer-tracker";
 import type { QadaLog } from "./qada";
+import type { HaidLog } from "./haid";
 import type { TasbihRecord } from "./tasbih";
 import type { HifzCard } from "./hifz";
 import type { Coordinates, Madhab, PrayerName, PrayerTimings } from "./prayer";
@@ -257,6 +258,17 @@ export interface PrayerTrackerStore {
 export interface QadaStore {
   read(): Promise<QadaLog>;
   write(log: QadaLog): Promise<void>;
+}
+
+/**
+ * Persists the ḥayḍ (menstruation) pause log on-device (ADR 0024, 0031): the
+ * date ranges during which prayer tracking is paused. Web uses `localStorage`,
+ * mobile `AsyncStorage`; a synced adapter (#25) replaces either without touching
+ * the pause maths (`haid.ts`). `read()` returns an empty log when nothing is set.
+ */
+export interface HaidStore {
+  read(): Promise<HaidLog>;
+  write(log: HaidLog): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Ḥayḍ (menstruation) pause — web + mobile

Refs #138 (prayer side). Second item from the Phase 8 set (epic #152), sibling of the qaḍāʾ tracker (#137 / ADR 0030).

The prayer tracker (ADR 0020) punishes a religiously-correct gap: during menstruation a woman does not pray, and those prayers are **not** made up. Without a pause, the tracker breaks the streak and shows a wall of "missed" days. This adds a ḥayḍ pause that holds the streak and excuses those days.

### What's in it

- **`packages/core/src/haid.ts`** — pure, deterministic domain. `HaidLog` is a list of `{ start, end? }` periods (`end` absent ⇒ ongoing). Helpers: `isDatePaused`, `currentPeriod`, `periodLength`, `startPause` / `endPause` / `togglePauseToday`, and the pause-aware streak fns `prayerStreakWithPause` and `longestPrayerStreakWithPause`. Paused days are **transparent** to the streak — they neither extend nor break a run, and a fully-paused gap bridges two active runs. At most one open period; never overlaps. 100% unit-tested (24 tests).
- **`packages/core/src/ports.ts`** — new `HaidStore` (`read`/`write`) under `ul.haid`, behind a port from day one (ADR 0024/0028); picked up by the key-agnostic backup (ADR 0018) for free.
- **web** — `localStorage` adapter + window-event lib wrapper; a `CyclePause` card on `/tracker` (start/end pause, live "Paused — day N"). `PrayerTracker` now shows the **pause-aware** day/best streak and renders paused days as a dashed **Paused** cell in the 7-day grid.
- **mobile** — `AsyncStorage` adapter + a ḥayḍ section on `PrayerTrackerScreen`, same pause-aware stats and dashed paused cells.
- **Separate domain:** `prayer-tracker.ts` is untouched, so the existing tracker can't regress.

### Design (ADR 0031)

- Paused days excluded from streak-break and "missed", drop out of the on-time rate (no entries), and are **not** added to the prayer qaḍāʾ backlog (menstrual prayers aren't made up).
- Local-first (ADR 0006): no backend, no accounts, no PII; per-device, covered by export/import.

### Verification

- `pnpm lint` ✓ · `pnpm typecheck` ✓ (all packages) · `pnpm test` ✓ (98 files, **558** tests, no threshold violations) · `pnpm build` ✓ (`/tracker` prerenders)
- **Web (live browser):** seeded 4 complete days around an ongoing pause — the day streak holds at **4** (would be 0 without the pause), best streak 4, on-time 100%, and the paused days render dashed in the grid; the card reads "Paused — day 3".
- **Mobile (`PrayerTrackerScreen` via react-native-web):** identical result — streak 4, dashed Paused columns, "Paused — day 3", qaḍāʾ section intact.

### Scope / deferred

This ships the **prayer** side of #138. Flagging *fasts* missed during a pause as qaḍāʾ is **not** included: the Ramaḍān tracker is day-number indexed (`Record<number, true>`), not date-based, so mapping a Gregorian pause range to specific fasts needs a date-based fasting model that doesn't exist yet (the issue itself notes this dependency). #138 stays open for that follow-up.

See ADR **0031** for the full rationale.
