### PR TITLE
feat(profile): achievements/badges engine over existing local data (#142)

### DIFF
--- a/apps/mobile/src/achievements-store.ts
+++ b/apps/mobile/src/achievements-store.ts
@@ -1,0 +1,12 @@
+/**
+ * Mobile `AchievementsStore` adapter (ADR 0024, 0032): the ids of badges already
+ * shown, in AsyncStorage under `ul.badges` (mirrors the web key). Persistence
+ * only — the badge maths lives in `@ummahlibrary/core`.
+ */
+import type { AchievementsStore } from "@ummahlibrary/core";
+import { KEYS, getJSON, setJSON } from "./storage";
+
+export const mobileAchievementsStore: AchievementsStore = {
+  read: () => getJSON<string[]>(KEYS.badges, []),
+  write: (ids) => setJSON(KEYS.badges, ids),
+};

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "../Type";
 import {
+  type BadgeStats,
   type PrayerTrackerLog,
   computeStreak,
+  evaluateBadges,
   longestStreak,
+  newlyUnlocked,
   prayerStreak,
   totalSavedAyahs,
+  unlockedIds,
 } from "@ummahlibrary/core";
 import { Khatam } from "@ummahlibrary/ui";
 import { useTheme, type Palette } from "../theme";
@@ -13,6 +17,7 @@ import { FONT } from "../fonts";
 import { useLibrary } from "../state/LibraryContext";
 import { surahProgressMap } from "../hifz";
 import { KEYS, getJSON } from "../storage";
+import { mobileAchievementsStore as achievementsStore } from "../achievements-store";
 import { localISODate } from "../utils";
 
 /**
@@ -28,6 +33,7 @@ export function ProfileScreen() {
   const [names, setNames] = useState(0);
   const [prayer, setPrayer] = useState({ streak: 0, best: 0 });
   const [reading, setReading] = useState({ pages: 0, streak: 0 });
+  const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
     const today = localISODate(new Date());
@@ -59,16 +65,46 @@ export function ProfileScreen() {
     [String(saved), "Saved verses"],
   ];
 
-  const achievements: [string, string, boolean][] = [
-    ["✦", "First āyah", trackedCount > 0],
-    ["📖", "Memorizer", surahsStarted >= 1],
-    ["🔥", "7-day streak", bestStreak >= 7],
-    ["🌙", "30-day streak", bestStreak >= 30],
-    ["✨", "Ten Names", names >= 10],
-    ["🔖", "Collector", saved >= 5],
-  ];
+  const badgeStats: BadgeStats = {
+    memorized: trackedCount,
+    surahsStarted,
+    prayerStreak: prayer.streak,
+    bestStreak,
+    namesLearned: names,
+    savedVerses: saved,
+  };
+  const badges = evaluateBadges(badgeStats);
+  const earned = badges.filter((b) => b.unlocked).length;
+
+  // Celebrate newly-unlocked badges once (persist the acknowledged ids).
+  useEffect(() => {
+    let cancelled = false;
+    void achievementsStore.read().then((ack) => {
+      if (cancelled) return;
+      const fresh = newlyUnlocked(badgeStats, ack);
+      if (fresh.length > 0) {
+        const first = fresh[0];
+        setToast(
+          fresh.length === 1 && first
+            ? `🎉 Unlocked: ${first.name}`
+            : `🎉 ${fresh.length} new badges unlocked!`,
+        );
+        void achievementsStore.write(unlockedIds(badgeStats));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [trackedCount, surahsStarted, prayer.streak, bestStreak, names, saved]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const id = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(id);
+  }, [toast]);
 
   return (
+    <View style={styles.root}>
     <ScrollView contentContainerStyle={styles.screen}>
       <View style={styles.header}>
         <View style={styles.headerWatermark} pointerEvents="none">
@@ -92,27 +128,46 @@ export function ProfileScreen() {
         ))}
       </View>
 
-      <Text style={styles.sectionLabel}>Achievements</Text>
+      <Text style={styles.sectionLabel}>
+        Achievements · {earned}/{badges.length}
+      </Text>
       <View style={styles.badgeGrid}>
-        {achievements.map(([g, name, got]) => (
-          <View key={name} style={[styles.badge, !got && styles.badgeLocked]}>
-            <View style={[styles.badgeIcon, got ? styles.badgeIconOn : styles.badgeIconOff]}>
-              <Text style={styles.badgeGlyph}>{g}</Text>
+        {badges.map(({ badge, unlocked }) => (
+          <View key={badge.id} style={[styles.badge, !unlocked && styles.badgeLocked]}>
+            <View style={[styles.badgeIcon, unlocked ? styles.badgeIconOn : styles.badgeIconOff]}>
+              <Text style={styles.badgeGlyph}>{badge.glyph}</Text>
             </View>
-            <Text style={styles.badgeName}>{name}</Text>
-            <Text style={[styles.badgeStatus, got && styles.badgeStatusOn]}>
-              {got ? "Unlocked" : "Locked"}
+            <Text style={styles.badgeName}>{badge.name}</Text>
+            <Text style={[styles.badgeStatus, unlocked && styles.badgeStatusOn]}>
+              {unlocked ? "Unlocked" : "Locked"}
             </Text>
           </View>
         ))}
       </View>
     </ScrollView>
+      {toast && (
+        <View style={styles.toast} pointerEvents="none">
+          <View style={styles.toastPill}>
+            <Text style={styles.toastText}>{toast}</Text>
+          </View>
+        </View>
+      )}
+    </View>
   );
 }
 
 function makeStyles(c: Palette) {
   return StyleSheet.create({
+    root: { flex: 1, backgroundColor: c.bg },
     screen: { padding: 18, backgroundColor: c.bg, paddingBottom: 32 },
+    toast: { position: "absolute", left: 16, right: 16, bottom: 24, alignItems: "center" },
+    toastPill: {
+      backgroundColor: c.accent,
+      borderRadius: 999,
+      paddingVertical: 12,
+      paddingHorizontal: 20,
+    },
+    toastText: { color: c.ink, fontFamily: FONT.extrabold, fontSize: 14 },
     header: {
       flexDirection: "row",
       alignItems: "center",

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -35,6 +35,7 @@ export const KEYS = {
   prayerLog: "ul.prayerLog",
   qada: "ul.qada",
   haid: "ul.haid",
+  badges: "ul.badges",
   hijriAdjust: "ul.hijriAdjust",
   zakat: "ul.zakat",
   onboarded: "ul.onboarded",

--- a/apps/web/src/components/ProfileView.tsx
+++ b/apps/web/src/components/ProfileView.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { computeStreak, longestStreak, prayerStreak, totalSavedAyahs } from "@ummahlibrary/core";
+import { type CSSProperties, useEffect, useState } from "react";
+import {
+  type BadgeStats,
+  computeStreak,
+  evaluateBadges,
+  longestStreak,
+  newlyUnlocked,
+  prayerStreak,
+  totalSavedAyahs,
+  unlockedIds,
+} from "@ummahlibrary/core";
 import { N, Khatam } from "@ummahlibrary/ui";
 import { countLearned } from "../lib/asma-store";
 import { allRecords, surahProgressMap } from "../lib/hifz-store";
@@ -9,6 +18,7 @@ import { getStreak } from "../lib/hifz-streak";
 import { readPrayerLog, today } from "../lib/prayer-tracker";
 import { readReadingState } from "../lib/reading-goals";
 import { readCollections } from "../lib/collections";
+import { acknowledge, readAcknowledged } from "../lib/achievements";
 
 interface Stats {
   hifzStreak: number;
@@ -30,6 +40,31 @@ const ZERO: Stats = {
   bestStreak: 0,
 };
 
+const toBadgeStats = (s: Stats): BadgeStats => ({
+  memorized: s.memorized,
+  surahsStarted: s.surahsStarted,
+  prayerStreak: s.prayerStreak,
+  bestStreak: s.bestStreak,
+  namesLearned: s.names,
+  savedVerses: s.saved,
+});
+
+const toastStyle: CSSProperties = {
+  position: "fixed",
+  left: "50%",
+  bottom: 24,
+  transform: "translateX(-50%)",
+  background: N.goldGrad,
+  color: N.ink,
+  fontWeight: 800,
+  fontSize: 14,
+  padding: "12px 20px",
+  borderRadius: 999,
+  boxShadow: "0 8px 30px rgba(0,0,0,0.35)",
+  zIndex: 50,
+  fontFamily: N.ui,
+};
+
 /**
  * "Your journey" — a progress dashboard built entirely from the local-first data
  * the app already keeps (Hifz, prayer log, reading log, names learned,
@@ -38,14 +73,15 @@ const ZERO: Stats = {
  */
 export function ProfileView() {
   const [s, setS] = useState<Stats>(ZERO);
+  const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
     const t = today();
     const hifzStreak = getStreak().count;
-    void Promise.all([readReadingState(), readCollections(), readPrayerLog()]).then(
-      ([reading, collections, log]) => {
+    void Promise.all([readReadingState(), readCollections(), readPrayerLog(), readAcknowledged()]).then(
+      ([reading, collections, log, ack]) => {
         const prayer = prayerStreak(log, t);
-        setS({
+        const next: Stats = {
           hifzStreak,
           memorized: allRecords().length,
           surahsStarted: surahProgressMap(new Date()).size,
@@ -53,10 +89,32 @@ export function ProfileView() {
           names: countLearned(),
           saved: totalSavedAyahs(collections),
           bestStreak: Math.max(hifzStreak, prayer, longestStreak(log), computeStreak(reading.activeDates, t)),
-        });
+        };
+        setS(next);
+
+        const bs = toBadgeStats(next);
+        const fresh = newlyUnlocked(bs, ack);
+        if (fresh.length > 0) {
+          const first = fresh[0];
+          setToast(
+            fresh.length === 1 && first
+              ? `🎉 Unlocked: ${first.name}`
+              : `🎉 ${fresh.length} new badges unlocked!`,
+          );
+          void acknowledge(unlockedIds(bs));
+        }
       },
     );
   }, []);
+
+  useEffect(() => {
+    if (!toast) return;
+    const id = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(id);
+  }, [toast]);
+
+  const badgeProgress = evaluateBadges(toBadgeStats(s));
+  const earned = badgeProgress.filter((b) => b.unlocked).length;
 
   const statCards: [string, string][] = [
     [`${s.hifzStreak} 🔥`, "Hifz streak"],
@@ -65,15 +123,6 @@ export function ProfileView() {
     [String(s.prayerStreak), "Prayer streak"],
     [`${s.names}/99`, "Names learned"],
     [String(s.saved), "Saved verses"],
-  ];
-
-  const badges: [string, string, boolean][] = [
-    ["✦", "First āyah", s.memorized > 0],
-    ["📖", "Memorizer", s.surahsStarted >= 1],
-    ["🔥", "7-day streak", s.bestStreak >= 7],
-    ["🌙", "30-day streak", s.bestStreak >= 30],
-    ["✨", "Ten Names", s.names >= 10],
-    ["🔖", "Collector", s.saved >= 5],
   ];
 
   return (
@@ -152,7 +201,7 @@ export function ProfileView() {
             fontFamily: N.ui,
           }}
         >
-          Achievements
+          Achievements · {earned}/{badgeProgress.length}
         </div>
         <div
           style={{
@@ -161,9 +210,10 @@ export function ProfileView() {
             gap: 12,
           }}
         >
-          {badges.map(([glyph, name, got]) => (
+          {badgeProgress.map(({ badge, unlocked }) => (
             <div
-              key={name}
+              key={badge.id}
+              title={badge.description}
               style={{
                 background: N.card,
                 border: `1px solid ${N.border}`,
@@ -173,7 +223,7 @@ export function ProfileView() {
                 flexDirection: "column",
                 alignItems: "center",
                 gap: 9,
-                opacity: got ? 1 : 0.55,
+                opacity: unlocked ? 1 : 0.55,
               }}
             >
               <div
@@ -184,29 +234,35 @@ export function ProfileView() {
                   display: "grid",
                   placeItems: "center",
                   fontSize: 22,
-                  background: got ? N.goldSoft : "transparent",
-                  border: `1px solid ${got ? N.gold : N.border}`,
+                  background: unlocked ? N.goldSoft : "transparent",
+                  border: `1px solid ${unlocked ? N.gold : N.border}`,
                 }}
               >
-                {glyph}
+                {badge.glyph}
               </div>
               <div style={{ fontSize: 12.5, fontWeight: 700, color: N.fg, textAlign: "center", fontFamily: N.ui }}>
-                {name}
+                {badge.name}
               </div>
               <div
                 style={{
                   fontSize: 10.5,
                   fontWeight: 600,
-                  color: got ? N.gold : N.faint,
+                  color: unlocked ? N.gold : N.faint,
                   fontFamily: N.ui,
                 }}
               >
-                {got ? "Unlocked" : "Locked"}
+                {unlocked ? "Unlocked" : "Locked"}
               </div>
             </div>
           ))}
         </div>
       </div>
+
+      {toast && (
+        <div role="status" style={toastStyle}>
+          {toast}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/achievements-store.ts
+++ b/apps/web/src/lib/achievements-store.ts
@@ -1,0 +1,27 @@
+/**
+ * Web `AchievementsStore` adapter (ADR 0024, 0032): the ids of badges the user
+ * has already been shown, in `localStorage` under `ul.badges`. Persistence only
+ * — the badges themselves are derived from existing local data in
+ * `@ummahlibrary/core`. Mirrors mobile.
+ */
+import type { AchievementsStore } from "@ummahlibrary/core";
+
+const KEY = "ul.badges";
+
+export const webAchievementsStore: AchievementsStore = {
+  read: async () => {
+    try {
+      const raw = localStorage.getItem(KEY);
+      return raw ? (JSON.parse(raw) as string[]) : [];
+    } catch {
+      return [];
+    }
+  },
+  write: async (ids) => {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(ids));
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};

--- a/apps/web/src/lib/achievements.test.ts
+++ b/apps/web/src/lib/achievements.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { acknowledge, readAcknowledged } from "./achievements";
+
+afterEach(() => localStorage.clear());
+
+describe("achievements store (web)", () => {
+  it("starts with nothing acknowledged", async () => {
+    expect(await readAcknowledged()).toEqual([]);
+  });
+
+  it("persists acknowledged badge ids across reads", async () => {
+    await acknowledge(["first-ayah", "streak-7"]);
+    expect(await readAcknowledged()).toEqual(["first-ayah", "streak-7"]);
+    expect(JSON.parse(localStorage.getItem("ul.badges") ?? "[]")).toContain("streak-7");
+  });
+
+  it("falls back to empty when stored JSON is corrupt", async () => {
+    localStorage.setItem("ul.badges", "[not json");
+    expect(await readAcknowledged()).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/achievements.ts
+++ b/apps/web/src/lib/achievements.ts
@@ -1,0 +1,16 @@
+/**
+ * Local-first achievements glue (ADR 0006, 0032): which badges have been
+ * acknowledged (shown via the unlock toast). Persistence goes through the
+ * `AchievementsStore` port (web adapter `webAchievementsStore`, ADR 0024); the
+ * badge maths lives in `@ummahlibrary/core`.
+ */
+import { webAchievementsStore as store } from "./achievements-store";
+
+export function readAcknowledged(): Promise<string[]> {
+  return store.read();
+}
+
+/** Mark a set of badge ids as acknowledged (so they don't re-toast). */
+export async function acknowledge(ids: string[]): Promise<void> {
+  await store.write(ids);
+}

--- a/docs/adr/0032-achievements.md
+++ b/docs/adr/0032-achievements.md
@@ -1,0 +1,51 @@
+# ADR 0032 — Achievements / badges over existing local data
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+The Profile ("Your journey") view already showed a handful of badges, but the
+unlock rules were **hardcoded inline and duplicated** across the web
+(`ProfileView.tsx`) and mobile (`ProfileScreen.tsx`) — drift-prone and untested.
+Muslim Pro ("Stars & Crescents") and Athan ("Hasanah" points) use a reward layer
+to drive habit retention; we have all the signals (hifz, prayer, reading, names,
+collections) but no shared, tested feedback layer (#142, Phase 8 / #152).
+
+We are local-first ([0006](0006-local-first-persistence.md)): **leaderboards and
+groups are out of scope** — they need accounts and server-stored user data.
+
+## Decision
+
+**1. A pure, declarative engine in `core`.** `core/achievements.ts` defines a
+`BadgeStats` snapshot (the local signals), a declarative `BADGES` catalogue where
+each badge unlocks when one `metric` meets a `target`, and `evaluateBadges` /
+`unlockedIds` / `newlyUnlocked` over it. The set is **extended by adding a row**,
+not by writing logic, and the whole thing is unit-tested. Stat values are coerced
+to non-negative, so corrupt storage can't mis-award.
+
+**2. Badges are derived, not stored.** They are recomputed from existing local
+data on every view — there is no badge state to keep in sync. The **only** thing
+persisted is which badges have been *acknowledged* (shown via the unlock toast),
+behind a new `AchievementsStore` (`read`/`write`) under `ul.badges`
+([0024](0024-local-storage-ports.md)/[0028](0028-persistence-enforcement.md)),
+with a `localStorage` web adapter and an `AsyncStorage` mobile adapter. Picked up
+by the key-agnostic backup ([0018](0018-local-data-backup.md)) for free.
+
+**3. Both apps render from the one engine.** Web and mobile Profile views replace
+their inline arrays with `evaluateBadges`, show an "N/total" count, and surface a
+lightweight **in-app toast** for newly-unlocked badges (no OS `Notifier`
+dependency — purely local feedback).
+
+## Consequences
+
+- **Good:** one tested source of truth for the badge set; no duplication or
+  drift; trivially extensible; 100% local. New trackers (qaḍāʾ, ḥayḍ streaks,
+  etc.) can feed `BadgeStats` and earn badges without touching the engine.
+- **Scope:** the toast is in-app only (fires when the Profile view loads), not a
+  push notification — honest for a no-backend app and avoids the `Notifier`
+  surface. Leaderboards remain out of scope (accounts/server).
+- **Limit & trigger to revisit:** acknowledged ids are per-device like all
+  local-first data until the export/import bridge (0018) or sync (#25). If badges
+  ever need richer rules than a single metric ≥ target, extend `Badge` (e.g. a
+  predicate) — the call sites already go through `evaluateBadges`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ through Phases 1–3; later decisions get their own record at the time they're m
 | [0029](0029-mobile-notifier.md)               | Mobile notifications: ExpoNotifier behind the Notifier port       | Accepted |
 | [0030](0030-qada-tracker.md)                  | Qaḍāʾ tracker: missed-prayer backlog behind a store port          | Accepted |
 | [0031](0031-haid-pause.md)                    | Ḥayḍ pause: menstrual pause preserves the prayer streak           | Accepted |
+| [0032](0032-achievements.md)                  | Achievements: declarative badge engine over existing local data   | Accepted |
 
 ## Writing a new ADR
 

--- a/packages/core/src/achievements.test.ts
+++ b/packages/core/src/achievements.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  BADGES,
+  type Badge,
+  type BadgeStats,
+  evaluateBadges,
+  newlyUnlocked,
+  unlockedCount,
+  unlockedIds,
+} from "./achievements";
+
+const ZERO: BadgeStats = {
+  memorized: 0,
+  surahsStarted: 0,
+  prayerStreak: 0,
+  bestStreak: 0,
+  namesLearned: 0,
+  savedVerses: 0,
+};
+
+describe("BADGES catalogue", () => {
+  it("has unique, stable ids and positive targets", () => {
+    const ids = BADGES.map((b) => b.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(BADGES.every((b) => b.target > 0)).toBe(true);
+  });
+});
+
+describe("evaluateBadges", () => {
+  it("locks everything for a fresh user", () => {
+    const result = evaluateBadges(ZERO);
+    expect(result).toHaveLength(BADGES.length);
+    expect(result.every((b) => !b.unlocked)).toBe(true);
+    expect(result.every((b) => b.progress === 0)).toBe(true);
+  });
+
+  it("unlocks a badge when its metric meets the target", () => {
+    const result = evaluateBadges({ ...ZERO, memorized: 1 });
+    const first = result.find((b) => b.badge.id === "first-ayah");
+    expect(first?.unlocked).toBe(true);
+    expect(first?.progress).toBe(1);
+    // A higher-tier badge on the same metric stays locked, with partial progress.
+    const ten = result.find((b) => b.badge.id === "memorizer-10");
+    expect(ten?.unlocked).toBe(false);
+    expect(ten?.progress).toBeCloseTo(0.1);
+  });
+
+  it("treats missing/negative stat values as zero", () => {
+    // A deliberately malformed snapshot (e.g. corrupt storage).
+    const bad = { ...ZERO, memorized: -5 } as BadgeStats;
+    const first = evaluateBadges(bad).find((b) => b.badge.id === "first-ayah");
+    expect(first?.value).toBe(0);
+    expect(first?.unlocked).toBe(false);
+  });
+
+  it("clamps progress at 1 when the value exceeds the target", () => {
+    const result = evaluateBadges({ ...ZERO, savedVerses: 999 });
+    const collector = result.find((b) => b.badge.id === "collector-5");
+    expect(collector?.unlocked).toBe(true);
+    expect(collector?.progress).toBe(1);
+  });
+
+  it("supports a custom catalogue (extensibility)", () => {
+    const custom: Badge[] = [
+      { id: "x", glyph: "x", name: "X", description: "", category: "library", metric: "savedVerses", target: 2 },
+    ];
+    const result = evaluateBadges({ ...ZERO, savedVerses: 2 }, custom);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.unlocked).toBe(true);
+  });
+
+  it("treats a non-positive target as already complete", () => {
+    const custom: Badge[] = [
+      { id: "free", glyph: "·", name: "Free", description: "", category: "library", metric: "savedVerses", target: 0 },
+    ];
+    expect(evaluateBadges(ZERO, custom)[0]?.progress).toBe(1);
+  });
+});
+
+describe("unlockedIds / unlockedCount", () => {
+  it("returns the unlocked ids and their count", () => {
+    const stats = { ...ZERO, memorized: 1, bestStreak: 7 };
+    const ids = unlockedIds(stats);
+    expect(ids).toContain("first-ayah");
+    expect(ids).toContain("streak-7");
+    expect(ids).not.toContain("streak-30");
+    expect(unlockedCount(stats)).toBe(ids.length);
+  });
+});
+
+describe("newlyUnlocked", () => {
+  it("returns unlocked badges not yet acknowledged", () => {
+    const stats = { ...ZERO, memorized: 1, bestStreak: 7 };
+    const fresh = newlyUnlocked(stats, ["first-ayah"]);
+    expect(fresh.map((b) => b.id)).toEqual(["streak-7"]);
+  });
+
+  it("is empty once everything unlocked has been acknowledged", () => {
+    const stats = { ...ZERO, memorized: 1 };
+    expect(newlyUnlocked(stats, unlockedIds(stats))).toEqual([]);
+  });
+});

--- a/packages/core/src/achievements.ts
+++ b/packages/core/src/achievements.ts
@@ -1,0 +1,118 @@
+/**
+ * Achievements / badges: a pure, deterministic reward layer computed over the
+ * habit signals the app already keeps locally (hifz, prayer, reading, names,
+ * collections) — no accounts, no server, no leaderboards (ADR 0006, 0032).
+ *
+ * The catalogue is declarative: each badge unlocks when one metric meets a
+ * target, so the set is extended by adding a row — not by writing logic. Apps
+ * assemble a {@link BadgeStats} snapshot from their stores and call
+ * {@link evaluateBadges}; persistence of which badges have been *acknowledged*
+ * (for the unlock toast) is a separate concern behind the `AchievementsStore`.
+ */
+
+/** The local habit signals badges are scored against. Unknown values are `0`. */
+export interface BadgeStats {
+  /** Āyāt currently memorized (hifz cards). */
+  memorized: number;
+  /** Surahs with any memorization progress. */
+  surahsStarted: number;
+  /** Current prayer streak (days). */
+  prayerStreak: number;
+  /** Best streak across any tracked habit (days). */
+  bestStreak: number;
+  /** Names of Allah learned (0–99). */
+  namesLearned: number;
+  /** Āyāt saved to collections. */
+  savedVerses: number;
+}
+
+export type BadgeCategory = "memorize" | "prayer" | "knowledge" | "library";
+
+/** A single achievement: unlocked when `stats[metric] >= target`. */
+export interface Badge {
+  id: string;
+  glyph: string;
+  name: string;
+  description: string;
+  category: BadgeCategory;
+  metric: keyof BadgeStats;
+  target: number;
+}
+
+/** One badge's standing against a stats snapshot. */
+export interface BadgeProgress {
+  badge: Badge;
+  /** The current value of the badge's metric. */
+  value: number;
+  unlocked: boolean;
+  /** Completion toward the target, clamped to 0–1. */
+  progress: number;
+}
+
+/**
+ * The badge catalogue, in display order. Extend by adding a row; tiers of the
+ * same metric give a sense of progression. Keep ids stable — they are the
+ * persisted "acknowledged" keys.
+ */
+export const BADGES: readonly Badge[] = [
+  { id: "first-ayah", glyph: "✦", name: "First āyah", description: "Memorize your first āyah", category: "memorize", metric: "memorized", target: 1 },
+  { id: "memorizer-10", glyph: "📖", name: "Ten memorized", description: "Memorize 10 āyāt", category: "memorize", metric: "memorized", target: 10 },
+  { id: "memorizer-50", glyph: "📚", name: "Fifty memorized", description: "Memorize 50 āyāt", category: "memorize", metric: "memorized", target: 50 },
+  { id: "surah-starter", glyph: "📗", name: "Surah starter", description: "Begin memorizing a surah", category: "memorize", metric: "surahsStarted", target: 1 },
+  { id: "surah-five", glyph: "📕", name: "Five surahs", description: "Begin five surahs", category: "memorize", metric: "surahsStarted", target: 5 },
+  { id: "streak-7", glyph: "🔥", name: "7-day streak", description: "Keep any habit for 7 days", category: "prayer", metric: "bestStreak", target: 7 },
+  { id: "streak-30", glyph: "🌙", name: "30-day streak", description: "Keep any habit for 30 days", category: "prayer", metric: "bestStreak", target: 30 },
+  { id: "streak-100", glyph: "⭐", name: "100-day streak", description: "Keep any habit for 100 days", category: "prayer", metric: "bestStreak", target: 100 },
+  { id: "prayer-7", glyph: "🕌", name: "Steadfast", description: "A 7-day prayer streak", category: "prayer", metric: "prayerStreak", target: 7 },
+  { id: "names-10", glyph: "✨", name: "Ten Names", description: "Learn 10 of the 99 Names", category: "knowledge", metric: "namesLearned", target: 10 },
+  { id: "names-99", glyph: "🌟", name: "All 99 Names", description: "Learn all 99 Names of Allah", category: "knowledge", metric: "namesLearned", target: 99 },
+  { id: "collector-5", glyph: "🔖", name: "Collector", description: "Save 5 āyāt", category: "library", metric: "savedVerses", target: 5 },
+  { id: "collector-25", glyph: "🗂️", name: "Curator", description: "Save 25 āyāt", category: "library", metric: "savedVerses", target: 25 },
+];
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+/** Score every badge in `catalogue` against a stats snapshot, in catalogue order. */
+export function evaluateBadges(
+  stats: BadgeStats,
+  catalogue: readonly Badge[] = BADGES,
+): BadgeProgress[] {
+  return catalogue.map((badge) => {
+    const value = Math.max(0, stats[badge.metric] ?? 0);
+    return {
+      badge,
+      value,
+      unlocked: value >= badge.target,
+      progress: badge.target <= 0 ? 1 : clamp01(value / badge.target),
+    };
+  });
+}
+
+/** Ids of every currently-unlocked badge. */
+export function unlockedIds(stats: BadgeStats, catalogue: readonly Badge[] = BADGES): string[] {
+  return evaluateBadges(stats, catalogue)
+    .filter((b) => b.unlocked)
+    .map((b) => b.badge.id);
+}
+
+/** How many badges are unlocked. */
+export function unlockedCount(stats: BadgeStats, catalogue: readonly Badge[] = BADGES): number {
+  return unlockedIds(stats, catalogue).length;
+}
+
+/**
+ * Badges unlocked now but not yet acknowledged — the set to celebrate with a
+ * toast. `acknowledged` is the persisted list of ids already shown.
+ */
+export function newlyUnlocked(
+  stats: BadgeStats,
+  acknowledged: Iterable<string>,
+  catalogue: readonly Badge[] = BADGES,
+): Badge[] {
+  const seen = new Set(acknowledged);
+  return evaluateBadges(stats, catalogue)
+    .filter((b) => b.unlocked && !seen.has(b.badge.id))
+    .map((b) => b.badge);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * from "./prayer";
 export * from "./prayer-tracker";
 export * from "./qada";
 export * from "./haid";
+export * from "./achievements";
 export * from "./qibla";
 export * from "./hijri";
 export * from "./zakat";

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -272,6 +272,17 @@ export interface HaidStore {
 }
 
 /**
+ * Persists which achievement badges the user has already been shown (ADR 0024,
+ * 0032), so the unlock toast fires once per badge. The badges themselves are
+ * derived from existing local data (`achievements.ts`), not stored. Web uses
+ * `localStorage`, mobile `AsyncStorage`. `read()` returns `[]` when none seen.
+ */
+export interface AchievementsStore {
+  read(): Promise<string[]>;
+  write(acknowledgedIds: string[]): Promise<void>;
+}
+
+/**
  * Persists the tasbih counter on-device (ADR 0024): the chosen phrase, a running
  * total, and the round size. Web uses `localStorage`, mobile `AsyncStorage`; a
  * synced adapter (#25) replaces either without touching the counter logic


### PR DESCRIPTION
## Achievements / badges — one engine, web + mobile

Closes #142. Phase 8 item (epic #152), sibling of the qaḍāʾ (#137) and ḥayḍ (#138) work.

Both Profile views already showed a handful of badges, but the unlock rules were **hardcoded and duplicated** across web (`ProfileView.tsx`) and mobile (`ProfileScreen.tsx`) — untested and drift-prone. This lifts them into one pure, tested `core` engine and expands the set.

### What's in it

- **`packages/core/src/achievements.ts`** — a **declarative** catalogue (`BADGES`, 13 badges) where each unlocks when one `metric` of a `BadgeStats` snapshot meets a `target`, plus `evaluateBadges` / `unlockedIds` / `newlyUnlocked`. Extended by adding a row, not by writing logic. Stat values coerced non-negative (corrupt storage can't mis-award). **10 tests, 100% coverage.**
- **`packages/core/src/ports.ts`** — new `AchievementsStore` (`read`/`write`) under `ul.badges`. Persists only the **acknowledged** badge ids (so the unlock toast fires once); the badges themselves are **derived, not stored**. ADR 0024/0028; picked up by the key-agnostic backup (0018) for free.
- **web/mobile** — `ProfileView` and `ProfileScreen` render from the engine (with an "N/total" count) and show a lightweight **in-app unlock toast**. No OS `Notifier` dependency. Leaderboards remain out of scope (local-first, ADR 0006).

### Verification

- `pnpm lint` ✓ · `pnpm typecheck` ✓ (8/8) · `pnpm test` ✓ (**100 files, 571 tests**, no threshold violations) · `pnpm build` ✓ (prerenders `/profile`)
- **Mobile (real new bundle, react-native-web):** seeded an 8-day prayer streak + 10 names → Profile shows **"ACHIEVEMENTS · 3/13"**, all 13 badges render, the correct three unlock (**7-day streak**, **Steadfast**, **Ten Names**), and the **"🎉 3 new badges unlocked!" toast** fires.
- Web: the new engine renders (the "N/13" count is live) and the production build prerenders `/profile`. A clean runtime screenshot will come from this PR's **Vercel preview** (the local `.next` got cross-contaminated from repeated dev/build cycles this session — an environment artifact, not a code issue).

See ADR **0032** for the rationale.
