### PR TITLE
feat(prayer): extended times (Imsāk/Midnight/Tahajjud) + high-latitude rules (#140)

### DIFF
--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -67,13 +67,21 @@ export const api = {
     getJson<{ verses: { s: number; a: number; t: string }[] }>(`${BASE}/search/corpus`).then(
       (d) => d.verses,
     ),
-  getPrayerTimes: (params: { lat: number; lng: number; date: string; method: string; madhab: string }) => {
+  getPrayerTimes: (params: {
+    lat: number;
+    lng: number;
+    date: string;
+    method: string;
+    madhab: string;
+    hlr?: string;
+  }) => {
     const q = new URLSearchParams({
       lat: String(params.lat),
       lng: String(params.lng),
       date: params.date,
       method: params.method,
       madhab: params.madhab,
+      ...(params.hlr ? { hlr: params.hlr } : {}),
     });
     return getJson<{ timings: Record<string, string> }>(`${BASE}/prayer-times?${q}`).then(
       (d) => d.timings,

--- a/apps/mobile/src/prayer-settings-store.ts
+++ b/apps/mobile/src/prayer-settings-store.ts
@@ -7,26 +7,32 @@
 import {
   type Coordinates,
   DEFAULT_CALCULATION_METHOD,
+  DEFAULT_HIGH_LATITUDE_RULE,
+  type HighLatitudeRuleId,
   type Madhab,
   type PrayerSettingsStore,
+  isHighLatitudeRule,
 } from "@ummahlibrary/core";
 import { KEYS, getJSON, getString, setJSON, setString } from "./storage";
 
 export const mobilePrayerSettingsStore: PrayerSettingsStore = {
   read: async () => {
-    const [coords, method, madhab] = await Promise.all([
+    const [coords, method, madhab, highLat] = await Promise.all([
       getJSON<Coordinates | null>(KEYS.prayerCoords, null),
       getString(KEYS.prayerMethod),
       getString(KEYS.prayerMadhab),
+      getString(KEYS.prayerHighLat),
     ]);
     return {
       coords,
       method: method ?? DEFAULT_CALCULATION_METHOD,
       madhab: (madhab as Madhab) || "shafi",
+      highLatitudeRule: highLat && isHighLatitudeRule(highLat) ? highLat : DEFAULT_HIGH_LATITUDE_RULE,
     };
   },
   // `null` is stored as JSON null, which read-back resolves to the fallback.
   writeCoords: (coords) => setJSON(KEYS.prayerCoords, coords),
   writeMethod: (method) => setString(KEYS.prayerMethod, method),
   writeMadhab: (madhab) => setString(KEYS.prayerMadhab, madhab),
+  writeHighLatitudeRule: (rule: HighLatitudeRuleId) => setString(KEYS.prayerHighLat, rule),
 };

--- a/apps/mobile/src/prayer-timings-provider.ts
+++ b/apps/mobile/src/prayer-timings-provider.ts
@@ -13,7 +13,7 @@ import { localISODate } from "./utils";
 
 export const mobilePrayerTimingsProvider: PrayerTimingsProvider = {
   getTodaysTimings: async () => {
-    const { coords, method, madhab } = await mobilePrayerSettingsStore.read();
+    const { coords, method, madhab, highLatitudeRule } = await mobilePrayerSettingsStore.read();
     if (!coords) return null;
 
     const date = localISODate(new Date());
@@ -30,6 +30,7 @@ export const mobilePrayerTimingsProvider: PrayerTimingsProvider = {
         date,
         method,
         madhab,
+        hlr: highLatitudeRule,
       })) as PrayerTimings;
       await setJSON(KEYS.adhkarTimings, { date, timings });
       return timings;

--- a/apps/mobile/src/screens/PrayerTimesScreen.tsx
+++ b/apps/mobile/src/screens/PrayerTimesScreen.tsx
@@ -5,12 +5,17 @@ import {
   CALCULATION_METHODS,
   type Coordinates,
   DEFAULT_CALCULATION_METHOD,
+  DEFAULT_HIGH_LATITUDE_RULE,
+  type ExtendedPrayerTimings,
+  HIGH_LATITUDE_RULES,
+  type HighLatitudeRuleId,
   type Madhab,
   MADHABS,
   OBLIGATORY_PRAYERS,
   PRAYER_LABELS,
   type PrayerName,
-  type PrayerTimings,
+  SUPPLEMENTARY_TIMING_LABELS,
+  SUPPLEMENTARY_TIMING_NAMES,
   TIMING_NAMES,
   nextPrayer,
 } from "@ummahlibrary/core";
@@ -49,44 +54,55 @@ export function PrayerTimesScreen() {
   const [coords, setCoords] = useState<Coordinates | null>(null);
   const [method, setMethod] = useState(DEFAULT_CALCULATION_METHOD);
   const [madhab, setMadhab] = useState<Madhab>("shafi");
-  const [timings, setTimings] = useState<PrayerTimings | null>(null);
+  const [highLat, setHighLat] = useState<HighLatitudeRuleId>(DEFAULT_HIGH_LATITUDE_RULE);
+  const [timings, setTimings] = useState<ExtendedPrayerTimings | null>(null);
   const [status, setStatus] = useState<Status>("idle");
   const [now, setNow] = useState(() => new Date());
   const [reminders, setReminders] = useState<PrayerReminderPrefs>({});
   const reqId = useRef(0);
 
-  const fetchTimings = useCallback(async (c: Coordinates, m: string, mad: Madhab) => {
-    const id = ++reqId.current;
-    setStatus("loading");
-    try {
-      const t = await api.getPrayerTimes({
-        lat: c.latitude,
-        lng: c.longitude,
-        date: localISODate(new Date()),
-        method: m,
-        madhab: mad,
-      });
-      if (id !== reqId.current) return;
-      setTimings(t as PrayerTimings);
-      setStatus("ready");
-    } catch {
-      if (id === reqId.current) setStatus("error");
-    }
-  }, []);
+  const fetchTimings = useCallback(
+    async (c: Coordinates, m: string, mad: Madhab, hlr: HighLatitudeRuleId) => {
+      const id = ++reqId.current;
+      setStatus("loading");
+      try {
+        const t = await api.getPrayerTimes({
+          lat: c.latitude,
+          lng: c.longitude,
+          date: localISODate(new Date()),
+          method: m,
+          madhab: mad,
+          hlr,
+        });
+        if (id !== reqId.current) return;
+        setTimings(t as ExtendedPrayerTimings);
+        setStatus("ready");
+      } catch {
+        if (id === reqId.current) setStatus("error");
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     void Promise.all([
       getString(KEYS.prayerMethod),
       getString(KEYS.prayerMadhab),
+      getString(KEYS.prayerHighLat),
       getJSON<Coordinates | null>(KEYS.prayerCoords, null),
-    ]).then(([savedMethod, savedMadhab, savedCoords]) => {
+    ]).then(([savedMethod, savedMadhab, savedHighLat, savedCoords]) => {
       const m = savedMethod ?? DEFAULT_CALCULATION_METHOD;
       const mad = (savedMadhab as Madhab) || "shafi";
+      const hlr =
+        savedHighLat && HIGH_LATITUDE_RULES.some((r) => r.id === savedHighLat)
+          ? (savedHighLat as HighLatitudeRuleId)
+          : DEFAULT_HIGH_LATITUDE_RULE;
       setMethod(m);
       setMadhab(mad);
+      setHighLat(hlr);
       if (savedCoords) {
         setCoords(savedCoords);
-        void fetchTimings(savedCoords, m, mad);
+        void fetchTimings(savedCoords, m, mad, hlr);
       }
     });
     void readPrayerReminderPrefs().then(setReminders);
@@ -106,7 +122,7 @@ export function PrayerTimesScreen() {
       const c: Coordinates = { latitude: pos.coords.latitude, longitude: pos.coords.longitude };
       setCoords(c);
       void setJSON(KEYS.prayerCoords, c);
-      void fetchTimings(c, method, madhab);
+      void fetchTimings(c, method, madhab, highLat);
     } catch {
       setStatus("error");
     }
@@ -115,13 +131,19 @@ export function PrayerTimesScreen() {
   function changeMethod(m: string) {
     setMethod(m);
     void setString(KEYS.prayerMethod, m);
-    if (coords) void fetchTimings(coords, m, madhab);
+    if (coords) void fetchTimings(coords, m, madhab, highLat);
   }
 
   function changeMadhab(m: Madhab) {
     setMadhab(m);
     void setString(KEYS.prayerMadhab, m);
-    if (coords) void fetchTimings(coords, method, m);
+    if (coords) void fetchTimings(coords, method, m, highLat);
+  }
+
+  function changeHighLat(r: HighLatitudeRuleId) {
+    setHighLat(r);
+    void setString(KEYS.prayerHighLat, r);
+    if (coords) void fetchTimings(coords, method, madhab, r);
   }
 
   async function toggleReminder(name: PrayerName) {
@@ -228,6 +250,22 @@ export function PrayerTimesScreen() {
             })}
           </View>
 
+          <Text style={styles.sectionLabel}>Night</Text>
+          <View style={styles.list}>
+            {SUPPLEMENTARY_TIMING_NAMES.map((name, i) => (
+              <View
+                key={name}
+                style={[styles.row, i < SUPPLEMENTARY_TIMING_NAMES.length - 1 && styles.rowDivider]}
+              >
+                <Icon name="moon" size={20} color={colors.muted} sw={1.8} />
+                <Text style={styles.prayerName}>{SUPPLEMENTARY_TIMING_LABELS[name]}</Text>
+                <Text style={styles.prayerTime}>
+                  {timings[name] ? fmtTime(timings[name]) : "—"}
+                </Text>
+              </View>
+            ))}
+          </View>
+
           <View style={styles.controls}>
             <View style={styles.pickerRow}>
               <Text style={styles.label}>Method</Text>
@@ -257,6 +295,23 @@ export function PrayerTimesScreen() {
                   >
                     <Text style={[styles.chipText, m.id === madhab && styles.chipTextOn]}>
                       {m.label}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+
+            <View style={styles.pickerRow}>
+              <Text style={styles.label}>High-latitude rule</Text>
+              <View style={styles.chips}>
+                {HIGH_LATITUDE_RULES.map((r) => (
+                  <Pressable
+                    key={r.id}
+                    style={[styles.chip, r.id === highLat && styles.chipOn]}
+                    onPress={() => changeHighLat(r.id)}
+                  >
+                    <Text style={[styles.chipText, r.id === highLat && styles.chipTextOn]}>
+                      {r.label}
                     </Text>
                   </Pressable>
                 ))}
@@ -321,6 +376,12 @@ function makeStyles(c: Palette) {
       marginVertical: 6,
     },
     heroSub: { color: c.muted, fontSize: 14 },
+    sectionLabel: {
+      color: c.fg,
+      fontSize: 15,
+      fontFamily: FONT.bold,
+      marginBottom: -6,
+    },
     list: {
       backgroundColor: c.bgElev,
       borderRadius: 14,

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -31,6 +31,7 @@ export const KEYS = {
   adhkar: "ul.adhkar",
   prayerMethod: "ul.prayerMethod",
   prayerMadhab: "ul.prayerMadhab",
+  prayerHighLat: "ul.prayerHighLat",
   prayerCoords: "ul.prayerCoords",
   prayerLog: "ul.prayerLog",
   qada: "ul.qada",

--- a/apps/web/src/app/api/v1/prayer-times/route.ts
+++ b/apps/web/src/app/api/v1/prayer-times/route.ts
@@ -1,5 +1,5 @@
 import { prayerTimes } from "@ummahlibrary/api";
-import { isCalculationMethod } from "@ummahlibrary/core";
+import { DEFAULT_HIGH_LATITUDE_RULE, isCalculationMethod, isHighLatitudeRule } from "@ummahlibrary/core";
 import { apiJson } from "../../../../lib/api-response";
 
 // Depends on the caller's coordinates and date, so it can't be prerendered.
@@ -12,6 +12,8 @@ export async function GET(req: Request) {
   const date = url.searchParams.get("date") ?? "";
   const method = url.searchParams.get("method") ?? "MuslimWorldLeague";
   const madhab = url.searchParams.get("madhab") === "hanafi" ? "hanafi" : "shafi";
+  const hlrParam = url.searchParams.get("hlr") ?? "";
+  const highLatitudeRule = isHighLatitudeRule(hlrParam) ? hlrParam : DEFAULT_HIGH_LATITUDE_RULE;
 
   if (!Number.isFinite(lat) || lat < -90 || lat > 90 || !Number.isFinite(lng) || lng < -180 || lng > 180) {
     return apiJson({ error: "bad_coordinates" }, { status: 400 });
@@ -22,6 +24,12 @@ export async function GET(req: Request) {
   const resolvedMethod = isCalculationMethod(method) ? method : "MuslimWorldLeague";
 
   const coordinates = { latitude: lat, longitude: lng };
-  const timings = await prayerTimes.calculate({ coordinates, date, method: resolvedMethod, madhab });
-  return apiJson({ coordinates, date, method: resolvedMethod, madhab, timings });
+  const timings = await prayerTimes.calculate({
+    coordinates,
+    date,
+    method: resolvedMethod,
+    madhab,
+    highLatitudeRule,
+  });
+  return apiJson({ coordinates, date, method: resolvedMethod, madhab, highLatitudeRule, timings });
 }

--- a/apps/web/src/components/PrayerTimesView.tsx
+++ b/apps/web/src/components/PrayerTimesView.tsx
@@ -6,13 +6,18 @@ import {
   CALCULATION_METHODS,
   type Coordinates,
   DEFAULT_CALCULATION_METHOD,
+  DEFAULT_HIGH_LATITUDE_RULE,
+  type ExtendedPrayerTimings,
+  HIGH_LATITUDE_RULES,
+  type HighLatitudeRuleId,
   type Madhab,
   MADHABS,
   type NotifyPermission,
   OBLIGATORY_PRAYERS,
   PRAYER_LABELS,
   type PrayerName,
-  type PrayerTimings,
+  SUPPLEMENTARY_TIMING_LABELS,
+  SUPPLEMENTARY_TIMING_NAMES,
   TIMING_NAMES,
   nextPrayer,
 } from "@ummahlibrary/core";
@@ -49,7 +54,7 @@ interface WeekDay {
   date: Date;
   label: string;
   isToday: boolean;
-  timings: PrayerTimings | null;
+  timings: ExtendedPrayerTimings | null;
 }
 
 /** The seven days of the current week (Mon–Sun) for the "This week" table. */
@@ -80,7 +85,8 @@ export function PrayerTimesView() {
   const [coords, setCoords] = useState<Coordinates | null>(null);
   const [method, setMethod] = useState(DEFAULT_CALCULATION_METHOD);
   const [madhab, setMadhab] = useState<Madhab>("shafi");
-  const [timings, setTimings] = useState<PrayerTimings | null>(null);
+  const [highLat, setHighLat] = useState<HighLatitudeRuleId>(DEFAULT_HIGH_LATITUDE_RULE);
+  const [timings, setTimings] = useState<ExtendedPrayerTimings | null>(null);
   const [week, setWeek] = useState<WeekDay[]>([]);
   const [status, setStatus] = useState<Status>("idle");
   const [now, setNow] = useState(() => new Date());
@@ -91,7 +97,8 @@ export function PrayerTimesView() {
   const getNotifier = () => (notifierRef.current ??= new WebNotifier());
 
   // Fetch the whole current week in parallel; today's card is derived from it.
-  const fetchTimings = useCallback(async (c: Coordinates, m: string, mad: Madhab) => {
+  const fetchTimings = useCallback(
+    async (c: Coordinates, m: string, mad: Madhab, hlr: HighLatitudeRuleId) => {
     const id = ++reqId.current;
     setStatus("loading");
     try {
@@ -104,10 +111,11 @@ export function PrayerTimesView() {
             date: localDate(d.date),
             method: m,
             madhab: mad,
+            hlr,
           });
           const res = await fetch(`/api/v1/prayer-times?${params}`);
           if (!res.ok) return null;
-          return (await res.json()) as { timings: PrayerTimings };
+          return (await res.json()) as { timings: ExtendedPrayerTimings };
         }),
       );
       if (id !== reqId.current) return;
@@ -120,18 +128,23 @@ export function PrayerTimesView() {
     } catch {
       if (id === reqId.current) setStatus("error");
     }
-  }, []);
+    },
+    [],
+  );
 
   // Restore preferences + last location, and load times if we have a location.
   useEffect(() => {
-    void webPrayerSettingsStore.read().then(({ coords: saved, method: m, madhab: mad }) => {
-      setMethod(m);
-      setMadhab(mad);
-      if (saved) {
-        setCoords(saved);
-        void fetchTimings(saved, m, mad);
-      }
-    });
+    void webPrayerSettingsStore
+      .read()
+      .then(({ coords: saved, method: m, madhab: mad, highLatitudeRule: hlr }) => {
+        setMethod(m);
+        setMadhab(mad);
+        setHighLat(hlr);
+        if (saved) {
+          setCoords(saved);
+          void fetchTimings(saved, m, mad, hlr);
+        }
+      });
     void readPrayerReminderPrefs().then(setReminders);
     setPermission(getNotifier().permission());
   }, [fetchTimings]);
@@ -153,7 +166,7 @@ export function PrayerTimesView() {
         const c = { latitude: pos.coords.latitude, longitude: pos.coords.longitude };
         setCoords(c);
         void webPrayerSettingsStore.writeCoords(c);
-        void fetchTimings(c, method, madhab);
+        void fetchTimings(c, method, madhab, highLat);
       },
       () => setStatus("denied"),
       { enableHighAccuracy: false, timeout: 10000, maximumAge: 3600000 },
@@ -163,12 +176,17 @@ export function PrayerTimesView() {
   function changeMethod(m: string) {
     setMethod(m);
     void webPrayerSettingsStore.writeMethod(m);
-    if (coords) void fetchTimings(coords, m, madhab);
+    if (coords) void fetchTimings(coords, m, madhab, highLat);
   }
   function changeMadhab(m: Madhab) {
     setMadhab(m);
     void webPrayerSettingsStore.writeMadhab(m);
-    if (coords) void fetchTimings(coords, method, m);
+    if (coords) void fetchTimings(coords, method, m, highLat);
+  }
+  function changeHighLat(r: HighLatitudeRuleId) {
+    setHighLat(r);
+    void webPrayerSettingsStore.writeHighLatitudeRule(r);
+    if (coords) void fetchTimings(coords, method, madhab, r);
   }
 
   // Flip one prayer's reminder. Asking for notification permission must happen in
@@ -381,6 +399,46 @@ export function PrayerTimesView() {
               );
             })}
           </div>
+
+          <div style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Night</div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+              gap: 12,
+              marginBottom: 24,
+            }}
+          >
+            {SUPPLEMENTARY_TIMING_NAMES.map((name) => (
+              <div
+                key={name}
+                style={{
+                  ...cardStyle,
+                  padding: "16px 18px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                }}
+              >
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div style={{ fontSize: 14.5, fontWeight: 700, color: N.fg }}>
+                    {SUPPLEMENTARY_TIMING_LABELS[name]}
+                  </div>
+                </div>
+                <span
+                  style={{
+                    fontSize: 17,
+                    fontWeight: 700,
+                    color: N.fg,
+                    fontVariantNumeric: "tabular-nums",
+                    flexShrink: 0,
+                  }}
+                >
+                  {timings[name] ? fmtTime(timings[name]) : "—"}
+                </span>
+              </div>
+            ))}
+          </div>
           {OBLIGATORY_PRAYERS.some((p) => reminders[p]) && (
             <p style={{ marginTop: -10, marginBottom: 22, color: N.faint, fontSize: 13 }}>
               {permission === "denied"
@@ -465,6 +523,20 @@ export function PrayerTimesView() {
                 {MADHABS.map((m) => (
                   <option key={m.id} value={m.id}>
                     {m.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <span style={{ fontSize: 12.5, color: N.muted }}>High-latitude rule</span>
+              <select
+                value={highLat}
+                onChange={(e) => changeHighLat(e.target.value as HighLatitudeRuleId)}
+                style={selectStyle}
+              >
+                {HIGH_LATITUDE_RULES.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.label}
                   </option>
                 ))}
               </select>

--- a/apps/web/src/lib/prayer-settings-store.test.ts
+++ b/apps/web/src/lib/prayer-settings-store.test.ts
@@ -10,21 +10,30 @@ describe("webPrayerSettingsStore", () => {
       coords: null,
       method: "MuslimWorldLeague",
       madhab: "shafi",
+      highLatitudeRule: "none",
     });
   });
 
-  it("round-trips coords, method, and madhab under the existing keys", async () => {
+  it("round-trips coords, method, madhab, and the high-latitude rule", async () => {
     await store.writeCoords({ latitude: 21.42, longitude: 39.83 });
     await store.writeMethod("Egyptian");
     await store.writeMadhab("hanafi");
+    await store.writeHighLatitudeRule("SeventhOfTheNight");
 
     expect(await store.read()).toEqual({
       coords: { latitude: 21.42, longitude: 39.83 },
       method: "Egyptian",
       madhab: "hanafi",
+      highLatitudeRule: "SeventhOfTheNight",
     });
     expect(localStorage.getItem("ul.prayerCoords")).toBe('{"latitude":21.42,"longitude":39.83}');
     expect(localStorage.getItem("ul.prayerMethod")).toBe("Egyptian");
+    expect(localStorage.getItem("ul.prayerHighLat")).toBe("SeventhOfTheNight");
+  });
+
+  it("ignores an unknown stored high-latitude rule", async () => {
+    localStorage.setItem("ul.prayerHighLat", "bogus");
+    expect((await store.read()).highLatitudeRule).toBe("none");
   });
 
   it("clears the stored location when coords are written null", async () => {

--- a/apps/web/src/lib/prayer-settings-store.ts
+++ b/apps/web/src/lib/prayer-settings-store.ts
@@ -1,22 +1,30 @@
 /**
  * Web `PrayerSettingsStore` adapter (ADR 0024): the reader's prayer-times
  * location and calculation config in `localStorage` under the existing
- * `ul.prayerCoords` / `ul.prayerMethod` / `ul.prayerMadhab` keys (shared by
- * prayer times, qibla, Ramadan, and reminders). Persistence only — `read()`
- * applies the defaults; a synced adapter (#25) can replace it. Mirrors mobile.
+ * `ul.prayerCoords` / `ul.prayerMethod` / `ul.prayerMadhab` / `ul.prayerHighLat`
+ * keys (shared by prayer times, qibla, Ramadan, and reminders). Persistence
+ * only — `read()` applies the defaults; a synced adapter (#25) can replace it.
+ * Mirrors mobile.
  */
-import type { Coordinates, Madhab, PrayerSettingsStore } from "@ummahlibrary/core";
-import { DEFAULT_CALCULATION_METHOD } from "@ummahlibrary/core";
+import type {
+  Coordinates,
+  HighLatitudeRuleId,
+  Madhab,
+  PrayerSettingsStore,
+} from "@ummahlibrary/core";
+import { DEFAULT_CALCULATION_METHOD, DEFAULT_HIGH_LATITUDE_RULE, isHighLatitudeRule } from "@ummahlibrary/core";
 
 const COORDS_KEY = "ul.prayerCoords";
 const METHOD_KEY = "ul.prayerMethod";
 const MADHAB_KEY = "ul.prayerMadhab";
+const HIGH_LAT_KEY = "ul.prayerHighLat";
 
 export const webPrayerSettingsStore: PrayerSettingsStore = {
   read: async () => {
     let coords: Coordinates | null = null;
     let method = DEFAULT_CALCULATION_METHOD;
     let madhab: Madhab = "shafi";
+    let highLatitudeRule: HighLatitudeRuleId = DEFAULT_HIGH_LATITUDE_RULE;
     try {
       const raw = localStorage.getItem(COORDS_KEY);
       coords = raw ? (JSON.parse(raw) as Coordinates) : null;
@@ -33,7 +41,13 @@ export const webPrayerSettingsStore: PrayerSettingsStore = {
     } catch {
       /* keep default */
     }
-    return { coords, method, madhab };
+    try {
+      const raw = localStorage.getItem(HIGH_LAT_KEY);
+      if (raw && isHighLatitudeRule(raw)) highLatitudeRule = raw;
+    } catch {
+      /* keep default */
+    }
+    return { coords, method, madhab, highLatitudeRule };
   },
   writeCoords: async (coords) => {
     try {
@@ -53,6 +67,13 @@ export const webPrayerSettingsStore: PrayerSettingsStore = {
   writeMadhab: async (madhab) => {
     try {
       localStorage.setItem(MADHAB_KEY, madhab);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  writeHighLatitudeRule: async (rule) => {
+    try {
+      localStorage.setItem(HIGH_LAT_KEY, rule);
     } catch {
       /* storage unavailable */
     }

--- a/apps/web/src/lib/prayer-timings-provider.ts
+++ b/apps/web/src/lib/prayer-timings-provider.ts
@@ -18,7 +18,7 @@ function localDate(d = new Date()): string {
 
 export const webPrayerTimingsProvider: PrayerTimingsProvider = {
   getTodaysTimings: async () => {
-    const { coords, method, madhab } = await webPrayerSettingsStore.read();
+    const { coords, method, madhab, highLatitudeRule } = await webPrayerSettingsStore.read();
     if (!coords) return null;
 
     try {
@@ -37,6 +37,7 @@ export const webPrayerTimingsProvider: PrayerTimingsProvider = {
       date: localDate(),
       method,
       madhab,
+      hlr: highLatitudeRule,
     });
     try {
       const res = await fetch(`/api/v1/prayer-times?${params}`);

--- a/packages/adapters/src/prayer-times.test.ts
+++ b/packages/adapters/src/prayer-times.test.ts
@@ -50,4 +50,41 @@ describe("AdhanPrayerTimes", () => {
     });
     expect(Number.isFinite(new Date(t.fajr).getTime())).toBe(true);
   });
+
+  it("derives the supplementary night markers", async () => {
+    const t = await calc.calculate({
+      coordinates: MAKKAH,
+      date: "2026-01-01",
+      method: "UmmAlQura",
+      madhab: "shafi",
+    });
+    // Imsāk is a fixed 10 minutes before Fajr.
+    expect(new Date(t.fajr).getTime() - new Date(t.imsak).getTime()).toBe(10 * 60_000);
+    // Midnight and the last third fall after Maghrib and run into the next day.
+    const maghrib = new Date(t.maghrib).getTime();
+    expect(new Date(t.midnight).getTime()).toBeGreaterThan(maghrib);
+    expect(new Date(t.lastThird).getTime()).toBeGreaterThan(new Date(t.midnight).getTime());
+  });
+
+  it("reshapes Isha at high latitude via the night-portion rule", async () => {
+    // London in midsummer: the standard angle pushes Isha very late; the
+    // one-seventh-of-the-night rule pulls it earlier into a real night.
+    const LONDON = { latitude: 51.5074, longitude: -0.1278 };
+    const q = { coordinates: LONDON, date: "2026-06-21", method: "MuslimWorldLeague", madhab: "shafi" } as const;
+    const standard = await calc.calculate(q);
+    const ruled = await calc.calculate({ ...q, highLatitudeRule: "SeventhOfTheNight" });
+    expect(Number.isFinite(new Date(standard.isha).getTime())).toBe(true);
+    expect(Number.isFinite(new Date(ruled.isha).getTime())).toBe(true);
+    // The rule changes the result, moving Isha earlier.
+    expect(ruled.isha).not.toBe(standard.isha);
+    expect(new Date(ruled.isha).getTime()).toBeLessThan(new Date(standard.isha).getTime());
+  });
+
+  it("leaves the result unchanged at a normal latitude when a rule is set", async () => {
+    const q = { coordinates: MAKKAH, date: "2026-01-01", method: "UmmAlQura", madhab: "shafi" } as const;
+    const plain = await calc.calculate(q);
+    const ruled = await calc.calculate({ ...q, highLatitudeRule: "TwilightAngle" });
+    expect(ruled.isha).toBe(plain.isha);
+    expect(ruled.fajr).toBe(plain.fajr);
+  });
 });

--- a/packages/adapters/src/prayer-times.ts
+++ b/packages/adapters/src/prayer-times.ts
@@ -2,11 +2,18 @@ import {
   CalculationMethod,
   type CalculationParameters,
   Coordinates,
+  HighLatitudeRule,
   Madhab,
   PrayerTimes,
+  SunnahTimes,
 } from "adhan";
-import type { PrayerTimesCalculator, PrayerTimesQuery, PrayerTimings } from "@ummahlibrary/core";
-import { DEFAULT_CALCULATION_METHOD } from "@ummahlibrary/core";
+import type {
+  ExtendedPrayerTimings,
+  HighLatitudeRuleId,
+  PrayerTimesCalculator,
+  PrayerTimesQuery,
+} from "@ummahlibrary/core";
+import { DEFAULT_CALCULATION_METHOD, imsakFromFajr } from "@ummahlibrary/core";
 
 /** Method id → the `adhan` preset factory. Keys match `core.CALCULATION_METHODS`. */
 const METHOD_FACTORIES: Record<string, () => CalculationParameters> = {
@@ -24,30 +31,54 @@ const METHOD_FACTORIES: Record<string, () => CalculationParameters> = {
   MoonsightingCommittee: CalculationMethod.MoonsightingCommittee,
 };
 
+/** Rule id → `adhan`'s `HighLatitudeRule`. `"none"` (and unknown) leaves the default. */
+const HIGH_LATITUDE_RULES: Partial<
+  Record<HighLatitudeRuleId, CalculationParameters["highLatitudeRule"]>
+> = {
+  MiddleOfTheNight: HighLatitudeRule.MiddleOfTheNight,
+  SeventhOfTheNight: HighLatitudeRule.SeventhOfTheNight,
+  TwilightAngle: HighLatitudeRule.TwilightAngle,
+};
+
 /**
  * `PrayerTimesCalculator` backed by the `adhan` library (ADR 0012). The
  * calculation is pure and local — no network — but lives in an adapter so the
- * astronomy stays a swappable detail behind the core port.
+ * astronomy stays a swappable detail behind the core port. Alongside the five
+ * prayers + sunrise it derives the supplementary night markers: Imsāk (a fixed
+ * offset before Fajr, in `core`) and Islamic midnight / last third of the night
+ * (`adhan`'s `SunnahTimes`, which spans into the next day's Fajr).
  */
 export class AdhanPrayerTimes implements PrayerTimesCalculator {
-  calculate(query: PrayerTimesQuery): Promise<PrayerTimings> {
-    const { coordinates, date, method, madhab } = query;
+  calculate(query: PrayerTimesQuery): Promise<ExtendedPrayerTimings> {
+    const { coordinates, date, method, madhab, highLatitudeRule } = query;
     const params = (METHOD_FACTORIES[method] ?? METHOD_FACTORIES[DEFAULT_CALCULATION_METHOD]!)();
     params.madhab = madhab === "hanafi" ? Madhab.Hanafi : Madhab.Shafi;
+    const rule = highLatitudeRule && HIGH_LATITUDE_RULES[highLatitudeRule];
+    if (rule) params.highLatitudeRule = rule;
 
     const coords = new Coordinates(coordinates.latitude, coordinates.longitude);
     // Anchor on noon UTC of the requested calendar date so the day used for the
     // sun position is stable regardless of the server's timezone.
     const when = new Date(`${date}T12:00:00Z`);
     const t = new PrayerTimes(coords, when, params);
+    const sunnah = new SunnahTimes(t);
+    const fajr = t.fajr.toISOString();
+
+    // The Sunnah times span into the next day's Fajr, so near the polar circle
+    // they can be invalid even when today's prayers are not; `.toISOString()`
+    // throws on an invalid Date, so fall back to an empty string the UI skips.
+    const iso = (d: Date) => (Number.isNaN(d.getTime()) ? "" : d.toISOString());
 
     return Promise.resolve({
-      fajr: t.fajr.toISOString(),
+      fajr,
       sunrise: t.sunrise.toISOString(),
       dhuhr: t.dhuhr.toISOString(),
       asr: t.asr.toISOString(),
       maghrib: t.maghrib.toISOString(),
       isha: t.isha.toISOString(),
+      imsak: imsakFromFajr(fajr),
+      midnight: iso(sunnah.middleOfTheNight),
+      lastThird: iso(sunnah.lastThirdOfTheNight),
     });
   }
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -22,7 +22,14 @@ import type { QadaLog } from "./qada";
 import type { HaidLog } from "./haid";
 import type { TasbihRecord } from "./tasbih";
 import type { HifzCard } from "./hifz";
-import type { Coordinates, Madhab, PrayerName, PrayerTimings } from "./prayer";
+import type {
+  Coordinates,
+  ExtendedPrayerTimings,
+  HighLatitudeRuleId,
+  Madhab,
+  PrayerName,
+  PrayerTimings,
+} from "./prayer";
 import type { ActivePlan, PlanTemplate } from "./reading-plans";
 import type { KhatmaPlan } from "./reading-goals";
 
@@ -69,15 +76,19 @@ export interface PrayerTimesQuery {
   /** A calculation-method id (see `CALCULATION_METHODS`). */
   method: string;
   madhab: Madhab;
+  /** High-latitude night-portion rule (see `HIGH_LATITUDE_RULES`); defaults to `"none"`. */
+  highLatitudeRule?: HighLatitudeRuleId;
 }
 
 /**
  * Computes prayer times from coordinates, a date and a method. The astronomy is
  * an external concern (the `adhan` library) kept behind this port so the app
- * depends only on the contract — see ADR 0012.
+ * depends only on the contract — see ADR 0012. The result carries the five
+ * prayers + sunrise plus the supplementary night markers (Imsāk, midnight, last
+ * third); callers needing only the prayers read it as {@link PrayerTimings}.
  */
 export interface PrayerTimesCalculator {
-  calculate(query: PrayerTimesQuery): Promise<PrayerTimings>;
+  calculate(query: PrayerTimesQuery): Promise<ExtendedPrayerTimings>;
 }
 
 /** Platform-neutral notification permission state (no DOM dependency). */
@@ -333,20 +344,24 @@ export interface PrayerSettings {
   method: string;
   /** Juristic madhab for the ʿAsr time. */
   madhab: Madhab;
+  /** High-latitude night-portion rule (see `HIGH_LATITUDE_RULES`). */
+  highLatitudeRule: HighLatitudeRuleId;
 }
 
 /**
  * Persists the reader's prayer-times location and calculation config on-device
- * (ADR 0024): coordinates, calculation method, and madhab — shared by prayer
- * times, qibla, Ramadan, and reminders. Web uses `localStorage`, mobile
- * `AsyncStorage`; a synced adapter (#25) replaces either without touching the
- * prayer-times UI. `read()` applies the defaults; one method per stored key.
+ * (ADR 0024): coordinates, calculation method, madhab, and high-latitude rule —
+ * shared by prayer times, qibla, Ramadan, and reminders. Web uses
+ * `localStorage`, mobile `AsyncStorage`; a synced adapter (#25) replaces either
+ * without touching the prayer-times UI. `read()` applies the defaults; one
+ * setting per stored key.
  */
 export interface PrayerSettingsStore {
   read(): Promise<PrayerSettings>;
   writeCoords(coords: Coordinates | null): Promise<void>;
   writeMethod(method: string): Promise<void>;
   writeMadhab(madhab: Madhab): Promise<void>;
+  writeHighLatitudeRule(rule: HighLatitudeRuleId): Promise<void>;
 }
 
 /**

--- a/packages/core/src/prayer.test.ts
+++ b/packages/core/src/prayer.test.ts
@@ -2,8 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
   CALCULATION_METHODS,
   DEFAULT_CALCULATION_METHOD,
+  DEFAULT_HIGH_LATITUDE_RULE,
+  HIGH_LATITUDE_RULES,
+  IMSAK_OFFSET_MINUTES,
   type PrayerTimings,
+  SUPPLEMENTARY_TIMING_LABELS,
+  SUPPLEMENTARY_TIMING_NAMES,
+  imsakFromFajr,
   isCalculationMethod,
+  isHighLatitudeRule,
   nextPrayer,
   prayerReminders,
 } from "./prayer";
@@ -26,6 +33,47 @@ describe("CALCULATION_METHODS", () => {
 
   it("rejects an unknown method id", () => {
     expect(isCalculationMethod("NotAMethod")).toBe(false);
+  });
+});
+
+describe("imsakFromFajr", () => {
+  it("places Imsāk the default offset before Fajr", () => {
+    expect(imsakFromFajr(timings.fajr)).toBe("2026-06-07T02:50:00.000Z");
+  });
+
+  it("honours a custom offset", () => {
+    expect(imsakFromFajr(timings.fajr, 30)).toBe("2026-06-07T02:30:00.000Z");
+  });
+
+  it("defaults to the published offset constant", () => {
+    const expected = new Date(
+      new Date(timings.fajr).getTime() - IMSAK_OFFSET_MINUTES * 60_000,
+    ).toISOString();
+    expect(imsakFromFajr(timings.fajr)).toBe(expected);
+  });
+});
+
+describe("HIGH_LATITUDE_RULES", () => {
+  it("offers the default rule and rejects unknown ids", () => {
+    expect(isHighLatitudeRule(DEFAULT_HIGH_LATITUDE_RULE)).toBe(true);
+    expect(isHighLatitudeRule("NotARule")).toBe(false);
+  });
+
+  it("includes the three adhan rules plus 'none'", () => {
+    expect(HIGH_LATITUDE_RULES.map((r) => r.id)).toEqual([
+      "none",
+      "MiddleOfTheNight",
+      "SeventhOfTheNight",
+      "TwilightAngle",
+    ]);
+  });
+});
+
+describe("supplementary timings", () => {
+  it("labels every supplementary marker", () => {
+    for (const name of SUPPLEMENTARY_TIMING_NAMES) {
+      expect(SUPPLEMENTARY_TIMING_LABELS[name]).toBeTruthy();
+    }
   });
 });
 

--- a/packages/core/src/prayer.ts
+++ b/packages/core/src/prayer.ts
@@ -36,6 +36,38 @@ export const PRAYER_LABELS: Record<PrayerName, string> = {
 /** A day's computed times as ISO-8601 instants (UTC), one per timing. */
 export type PrayerTimings = Record<PrayerName, string>;
 
+/**
+ * Computed night markers beyond the five prayers + sunrise: the pre-dawn
+ * fasting cut-off (Imsāk), Islamic midnight, and the start of the last third of
+ * the night (the preferred window for Tahajjud). These are *not* tracked or
+ * reminded like the obligatory prayers, so they sit outside {@link PrayerName}.
+ */
+export const SUPPLEMENTARY_TIMING_NAMES = ["imsak", "midnight", "lastThird"] as const;
+export type SupplementaryTimingName = (typeof SUPPLEMENTARY_TIMING_NAMES)[number];
+
+export const SUPPLEMENTARY_TIMING_LABELS: Record<SupplementaryTimingName, string> = {
+  imsak: "Imsāk",
+  midnight: "Islamic midnight",
+  lastThird: "Last third (Tahajjud)",
+};
+
+/** The supplementary night markers as ISO-8601 instants (UTC). */
+export type SupplementaryTimings = Record<SupplementaryTimingName, string>;
+
+/** The five prayers + sunrise, plus the supplementary night markers. */
+export type ExtendedPrayerTimings = PrayerTimings & SupplementaryTimings;
+
+/**
+ * Imsāk precedes Fajr by this many minutes — the common fixed precautionary
+ * offset used when a method carries no Imsāk angle of its own.
+ */
+export const IMSAK_OFFSET_MINUTES = 10;
+
+/** Imsāk as the instant `offsetMinutes` before Fajr. Pure. */
+export function imsakFromFajr(fajrIso: string, offsetMinutes = IMSAK_OFFSET_MINUTES): string {
+  return new Date(new Date(fajrIso).getTime() - offsetMinutes * 60_000).toISOString();
+}
+
 /** The madhab affects the Asr time (Hanafi uses the later shadow length). */
 export type Madhab = "shafi" | "hanafi";
 
@@ -71,6 +103,33 @@ export const DEFAULT_CALCULATION_METHOD = "MuslimWorldLeague";
 /** Whether a method id is one we offer (used to validate API input). */
 export function isCalculationMethod(id: string): boolean {
   return CALCULATION_METHODS.some((m) => m.id === id);
+}
+
+/**
+ * How to resolve Fajr/Isha where, in high summer, the sun never reaches the
+ * required depression angle and the pure calculation has no answer. `"none"`
+ * keeps the raw method (correct for most latitudes); the others split the night
+ * into portions. Ids map to `adhan`'s `HighLatitudeRule` in the adapter.
+ */
+export type HighLatitudeRuleId = "none" | "MiddleOfTheNight" | "SeventhOfTheNight" | "TwilightAngle";
+
+export interface HighLatitudeRuleInfo {
+  id: HighLatitudeRuleId;
+  label: string;
+}
+
+export const HIGH_LATITUDE_RULES: readonly HighLatitudeRuleInfo[] = [
+  { id: "none", label: "None (standard)" },
+  { id: "MiddleOfTheNight", label: "Middle of the night" },
+  { id: "SeventhOfTheNight", label: "One-seventh of the night" },
+  { id: "TwilightAngle", label: "Angle-based" },
+];
+
+export const DEFAULT_HIGH_LATITUDE_RULE: HighLatitudeRuleId = "none";
+
+/** Whether an id is one of the offered high-latitude rules (validates API input). */
+export function isHighLatitudeRule(id: string): id is HighLatitudeRuleId {
+  return HIGH_LATITUDE_RULES.some((r) => r.id === id);
 }
 
 /**


### PR DESCRIPTION
Closes #140.

## What
Surfaces the prayer-times engine's remaining computed markers — **Imsāk, Islamic midnight, and the last third of the night (Tahajjud)** — and exposes **high-latitude adjustment rules** (Middle of the Night / One-Seventh / Angle-Based) for users far from the equator. All pure calculation via the existing `adhan` adapter — no data, no network, no account (Tier 1).

## Changes
- **core** (`prayer.ts`): supplementary night markers (`imsak`/`midnight`/`lastThird`) kept *outside* the `PrayerName` union so prayer tracking/reminders are unaffected; pure `imsakFromFajr()` (Fajr − 10 min); `HIGH_LATITUDE_RULES` catalogue + `isHighLatitudeRule()`.
- **ports**: `PrayerTimesQuery.highLatitudeRule`; calculator returns the superset `ExtendedPrayerTimings` (existing `PrayerTimings` callers unchanged); `PrayerSettings`(+`Store`) carry the rule.
- **adapter**: maps the rule to `adhan`, derives Imsāk + `SunnahTimes`, and guards invalid Dates near the polar circle so the route can't 500.
- **web + mobile**: a "Night" section for the three markers and a high-latitude rule picker, persisted via the settings store and threaded through the API route + shared timings provider (reminders / Ramadan / home cards stay consistent).

## Tests
- core: Imsāk offset, rule catalogue, supplementary labels.
- adapter: Sunnah-times ordering, rule reshapes Isha at high latitude (London midsummer), no-op at normal latitude (Makkah). Verified `adhan` behavior empirically before pinning assertions.

## Loop
`pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` all pass locally; `/prayer-times` still prerenders static.

## Notes
- No new ADR: this extends the existing prayer-times port (ADR 0012) and settings store (ADR 0024) — a config-level feature, not a new architectural decision.
- The supplementary-times UI is geolocation-gated.