### PR TITLE
feat(core): Islamic events calendar with upcoming-event countdown (#143)

### DIFF
--- a/apps/mobile/src/screens/HijriCalendarScreen.tsx
+++ b/apps/mobile/src/screens/HijriCalendarScreen.tsx
@@ -2,10 +2,13 @@ import { useEffect, useMemo, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "../Type";
 import {
   type HijriDate,
+  type UpcomingIslamicEvent,
   gregorianToHijri,
   hijriMonth,
   hijriMonthLength,
   hijriToGregorian,
+  islamicEventsInMonth,
+  upcomingIslamicEvents,
 } from "@ummahlibrary/core";
 import { KEYS, getString, setString } from "../storage";
 import { useTheme, type Palette } from "../theme";
@@ -13,6 +16,23 @@ import { weekdayOfGregorian } from "../utils";
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
 const ADJUST_OPTIONS = [-2, -1, 0, 1, 2] as const;
+
+/** "Today" / "Tomorrow" / "in N days" for an event countdown. */
+function countdownLabel(daysUntil: number): string {
+  if (daysUntil === 0) return "Today";
+  if (daysUntil === 1) return "Tomorrow";
+  return `in ${daysUntil} days`;
+}
+
+function gregorianFull(g: { year: number; month: number; day: number }): string {
+  return new Date(Date.UTC(g.year, g.month - 1, g.day)).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
 
 function todayGregorian() {
   const d = new Date();
@@ -74,12 +94,43 @@ export function HijriCalendarScreen() {
     return out;
   }, [view, adjust]);
 
+  const upcoming = useMemo<UpcomingIslamicEvent[]>(
+    () => upcomingIslamicEvents(todayGregorian(), 5, adjust),
+    [adjust],
+  );
+
   if (!view || !today) return null;
 
   const month = hijriMonth(view.month);
+  const monthEvents = islamicEventsInMonth(view.month);
+  const nextEvent = upcoming[0];
 
   return (
     <ScrollView contentContainerStyle={styles.screen}>
+      {nextEvent && (
+        <View style={styles.upcoming}>
+          <View style={styles.nextCard}>
+            <Text style={styles.nextLabel}>Next observance</Text>
+            <View style={styles.nextRow}>
+              <View style={styles.flex1}>
+                <Text style={styles.nextName}>{nextEvent.event.name}</Text>
+                <Text style={styles.nextSub}>{gregorianFull(nextEvent.gregorian)}</Text>
+              </View>
+              <Text style={styles.nextCountdown}>{countdownLabel(nextEvent.daysUntil)}</Text>
+            </View>
+          </View>
+          {upcoming.slice(1).map((u) => (
+            <View key={u.event.id} style={styles.eventRow}>
+              <View style={styles.flex1}>
+                <Text style={styles.eventName}>{u.event.name}</Text>
+                <Text style={styles.eventDate}>{gregorianFull(u.gregorian)}</Text>
+              </View>
+              <Text style={styles.eventCountdown}>{countdownLabel(u.daysUntil)}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
       <View style={styles.nav}>
         <Pressable style={styles.navBtn} onPress={() => step(-1)} accessibilityLabel="Previous month">
           <Text style={styles.navArrow}>‹</Text>
@@ -110,6 +161,28 @@ export function HijriCalendarScreen() {
         })}
       </View>
 
+      <Text style={styles.sectionLabel}>Sacred dates this month</Text>
+      {monthEvents.length === 0 ? (
+        <Text style={styles.note}>No major observances fall in this month.</Text>
+      ) : (
+        <View style={styles.monthList}>
+          {monthEvents.map((e, i) => (
+            <View
+              key={e.id}
+              style={[styles.monthRow, i < monthEvents.length - 1 && styles.monthRowDivider]}
+            >
+              <View style={styles.dayBadge}>
+                <Text style={styles.dayBadgeText}>{e.day}</Text>
+              </View>
+              <View style={styles.flex1}>
+                <Text style={styles.eventName}>{e.name}</Text>
+                <Text style={styles.eventDate}>{e.note}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      )}
+
       <View style={styles.adjustSection}>
         <Text style={styles.adjustLabel}>
           Date adjustment ({adjust > 0 ? `+${adjust}` : adjust} day{Math.abs(adjust) === 1 ? "" : "s"})
@@ -139,6 +212,70 @@ export function HijriCalendarScreen() {
 function makeStyles(c: Palette) {
   return StyleSheet.create({
     screen: { padding: 16, backgroundColor: c.bg },
+    flex1: { flex: 1, minWidth: 0 },
+    upcoming: { marginBottom: 20, gap: 10 },
+    nextCard: {
+      backgroundColor: c.bgElev,
+      borderWidth: 1,
+      borderColor: c.accent,
+      borderRadius: 14,
+      padding: 16,
+    },
+    nextLabel: {
+      color: c.faint,
+      fontSize: 11,
+      fontWeight: "700",
+      letterSpacing: 1,
+      textTransform: "uppercase",
+      marginBottom: 6,
+    },
+    nextRow: { flexDirection: "row", alignItems: "center", gap: 12 },
+    nextName: { color: c.fg, fontSize: 18, fontWeight: "800" },
+    nextSub: { color: c.muted, fontSize: 13, marginTop: 2 },
+    nextCountdown: { color: c.accent, fontSize: 16, fontWeight: "800" },
+    eventRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+      backgroundColor: c.bgElev,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 12,
+      paddingHorizontal: 14,
+      paddingVertical: 12,
+    },
+    eventName: { color: c.fg, fontSize: 15, fontWeight: "700" },
+    eventDate: { color: c.faint, fontSize: 12, marginTop: 1 },
+    eventCountdown: { color: c.accent, fontSize: 13, fontWeight: "700" },
+    sectionLabel: {
+      color: c.faint,
+      fontSize: 12,
+      fontWeight: "700",
+      letterSpacing: 1,
+      textTransform: "uppercase",
+      marginBottom: 10,
+    },
+    monthList: {
+      backgroundColor: c.bgElev,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 14,
+      marginBottom: 24,
+      overflow: "hidden",
+    },
+    monthRow: { flexDirection: "row", alignItems: "center", gap: 12, padding: 14 },
+    monthRowDivider: { borderBottomWidth: 1, borderBottomColor: c.borderSoft },
+    dayBadge: {
+      width: 40,
+      height: 40,
+      borderRadius: 10,
+      backgroundColor: c.accentSoft,
+      borderWidth: 1,
+      borderColor: c.accent,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    dayBadgeText: { color: c.accent, fontSize: 15, fontWeight: "800" },
     nav: { flexDirection: "row", alignItems: "center", marginBottom: 16 },
     navBtn: {
       paddingHorizontal: 12,

--- a/apps/web/src/components/HijriCalendar.tsx
+++ b/apps/web/src/components/HijriCalendar.tsx
@@ -3,10 +3,13 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   type HijriDate,
+  type UpcomingIslamicEvent,
   gregorianToHijri,
   hijriMonth,
   hijriMonthLength,
   hijriToGregorian,
+  islamicEventsInMonth,
+  upcomingIslamicEvents,
 } from "@ummahlibrary/core";
 import { readHijriAdjust, writeHijriAdjust } from "../lib/hijri";
 import { N } from "@ummahlibrary/ui";
@@ -14,33 +17,26 @@ import { N } from "@ummahlibrary/ui";
 const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 const lcard = { background: N.card, border: `1px solid ${N.border}`, borderRadius: 16 } as const;
 
-/**
- * Well-established Islamic observances by fixed Hijri date (month 1–12 → day).
- * Presentational reference data for the "sacred dates" panel; the dates are
- * widely agreed (the festivals themselves follow local sighting).
- */
-const SACRED_DATES: Record<number, { day: number; name: string; note: string }[]> = {
-  1: [
-    { day: 1, name: "Islamic New Year", note: "Start of Muḥarram" },
-    { day: 10, name: "ʿĀshūrāʾ", note: "A day of fasting" },
-  ],
-  3: [{ day: 12, name: "Mawlid an-Nabī ﷺ", note: "Birth of the Prophet" }],
-  7: [{ day: 27, name: "Al-Isrāʾ wal-Miʿrāj", note: "The Night Journey" }],
-  8: [{ day: 15, name: "Laylat al-Barāʾah", note: "Mid-Shaʿbān night" }],
-  9: [
-    { day: 1, name: "First of Ramaḍān", note: "Fasting begins" },
-    { day: 27, name: "Laylat al-Qadr", note: "Sought in the last ten nights" },
-  ],
-  10: [{ day: 1, name: "ʿĪd al-Fiṭr", note: "Festival of breaking the fast" }],
-  12: [
-    { day: 9, name: "Day of ʿArafah", note: "The standing at ʿArafah" },
-    { day: 10, name: "ʿĪd al-Aḍḥā", note: "Festival of the sacrifice" },
-  ],
-};
-
 function localToday(): { year: number; month: number; day: number } {
   const d = new Date();
   return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+}
+
+/** "Today" / "Tomorrow" / "in N days" for an event countdown. */
+function countdownLabel(daysUntil: number): string {
+  if (daysUntil === 0) return "Today";
+  if (daysUntil === 1) return "Tomorrow";
+  return `in ${daysUntil} days`;
+}
+
+function gregorianFull(g: { year: number; month: number; day: number }): string {
+  return new Date(Date.UTC(g.year, g.month - 1, g.day)).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
 }
 
 /** JS weekday (0=Sun) for a Gregorian civil date, via UTC to avoid DST drift. */
@@ -109,16 +105,126 @@ export function HijriCalendar() {
     return out;
   }, [view, adjust]);
 
+  const upcoming = useMemo<UpcomingIslamicEvent[]>(
+    () => upcomingIslamicEvents(localToday(), 5, adjust),
+    [adjust],
+  );
+
   if (!view || !todayHijri) return <p style={{ color: N.muted, fontFamily: N.ui }}>Loading the calendar…</p>;
 
   const month = hijriMonth(view.month);
-  const events = SACRED_DATES[view.month] ?? [];
+  const events = islamicEventsInMonth(view.month);
   const eventDays = new Set(events.map((e) => e.day));
+  const nextEvent = upcoming[0];
   const isToday = (d: number) =>
     todayHijri.year === view.year && todayHijri.month === view.month && todayHijri.day === d;
 
   return (
     <div>
+      {/* Upcoming events + next-event countdown */}
+      {nextEvent && (
+        <div style={{ marginBottom: 22 }}>
+          <div
+            style={{
+              ...lcard,
+              padding: "18px 20px",
+              marginBottom: 12,
+              background: `linear-gradient(135deg, ${N.cardHi}, ${N.card})`,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 16,
+              flexWrap: "wrap",
+            }}
+          >
+            <div style={{ minWidth: 0 }}>
+              <div
+                style={{
+                  fontSize: 11.5,
+                  letterSpacing: 1,
+                  textTransform: "uppercase",
+                  color: N.faint,
+                  fontWeight: 700,
+                  fontFamily: N.ui,
+                }}
+              >
+                Next observance
+              </div>
+              <div style={{ fontSize: 20, fontWeight: 800, color: N.fg, fontFamily: N.ui, marginTop: 3 }}>
+                {nextEvent.event.name}
+              </div>
+              <div style={{ fontSize: 13, color: N.faint, fontFamily: N.ui, marginTop: 2 }}>
+                {gregorianFull(nextEvent.gregorian)} · {nextEvent.event.note}
+              </div>
+            </div>
+            <div
+              style={{
+                fontSize: 22,
+                fontWeight: 800,
+                color: N.gold,
+                fontFamily: N.ui,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {countdownLabel(nextEvent.daysUntil)}
+            </div>
+          </div>
+          {upcoming.length > 1 && (
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(220px,1fr))",
+                gap: 10,
+              }}
+            >
+              {upcoming.slice(1).map((u) => (
+                <div
+                  key={u.event.id}
+                  style={{
+                    ...lcard,
+                    padding: "12px 14px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 10,
+                  }}
+                >
+                  <div style={{ minWidth: 0 }}>
+                    <div
+                      style={{
+                        fontSize: 14,
+                        fontWeight: 700,
+                        color: N.fg,
+                        fontFamily: N.ui,
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
+                    >
+                      {u.event.name}
+                    </div>
+                    <div style={{ fontSize: 12, color: N.faint, fontFamily: N.ui }}>
+                      {gregorianFull(u.gregorian)}
+                    </div>
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 12.5,
+                      fontWeight: 700,
+                      color: N.gold,
+                      fontFamily: N.ui,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {countdownLabel(u.daysUntil)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Month nav */}
       <div
         style={{

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export * from "./haid";
 export * from "./achievements";
 export * from "./qibla";
 export * from "./hijri";
+export * from "./islamic-events";
 export * from "./zakat";
 export * from "./adhkar";
 export * from "./duas";

--- a/packages/core/src/islamic-events.test.ts
+++ b/packages/core/src/islamic-events.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  ISLAMIC_EVENTS,
+  islamicEventsInMonth,
+  upcomingIslamicEvents,
+} from "./islamic-events";
+
+describe("ISLAMIC_EVENTS", () => {
+  it("has unique ids and valid Hijri month/day", () => {
+    const ids = ISLAMIC_EVENTS.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const e of ISLAMIC_EVENTS) {
+      expect(e.month).toBeGreaterThanOrEqual(1);
+      expect(e.month).toBeLessThanOrEqual(12);
+      expect(e.day).toBeGreaterThanOrEqual(1);
+      expect(e.day).toBeLessThanOrEqual(30);
+    }
+  });
+
+  it("is ordered by Hijri month then day", () => {
+    const keys = ISLAMIC_EVENTS.map((e) => e.month * 100 + e.day);
+    expect(keys).toEqual([...keys].sort((a, b) => a - b));
+  });
+});
+
+describe("islamicEventsInMonth", () => {
+  it("returns the observances for a month, in day order", () => {
+    const m1 = islamicEventsInMonth(1).map((e) => e.id);
+    expect(m1).toEqual(["islamic-new-year", "ashura"]);
+    expect(islamicEventsInMonth(12).map((e) => e.id)).toEqual(["arafah", "eid-al-adha"]);
+  });
+
+  it("returns nothing for a month with no major observance", () => {
+    expect(islamicEventsInMonth(2)).toEqual([]);
+  });
+});
+
+describe("upcomingIslamicEvents", () => {
+  const today = { year: 2026, month: 6, day: 22 };
+
+  it("resolves the next events soonest-first with a day countdown", () => {
+    const up = upcomingIslamicEvents(today, 3);
+    expect(up.map((u) => u.event.id)).toEqual(["ashura", "mawlid", "isra-miraj"]);
+    const next = up[0]!;
+    expect(next.daysUntil).toBe(4);
+    expect(next.gregorian).toEqual({ year: 2026, month: 6, day: 26 });
+    expect(next.hijri).toEqual({ year: 1448, month: 1, day: 10 });
+  });
+
+  it("never returns a past event and stays sorted", () => {
+    const up = upcomingIslamicEvents(today);
+    expect(up).toHaveLength(ISLAMIC_EVENTS.length);
+    for (const u of up) expect(u.daysUntil).toBeGreaterThanOrEqual(0);
+    const days = up.map((u) => u.daysUntil);
+    expect(days).toEqual([...days].sort((a, b) => a - b));
+  });
+
+  it("keeps each resolved date on the event's own Hijri month/day", () => {
+    for (const u of upcomingIslamicEvents(today)) {
+      expect(u.hijri.month).toBe(u.event.month);
+      expect(u.hijri.day).toBe(u.event.day);
+    }
+  });
+
+  it("counts an event that falls today as zero days away", () => {
+    // ʿĀshūrāʾ 1448 lands on 2026-06-26 (computed above).
+    const onAshura = { year: 2026, month: 6, day: 26 };
+    const first = upcomingIslamicEvents(onAshura, 1)[0]!;
+    expect(first.event.id).toBe("ashura");
+    expect(first.daysUntil).toBe(0);
+  });
+
+  it("respects the requested count and is deterministic", () => {
+    expect(upcomingIslamicEvents(today, 2)).toHaveLength(2);
+    expect(upcomingIslamicEvents(today, 0)).toHaveLength(0);
+    expect(upcomingIslamicEvents(today, 5)).toEqual(upcomingIslamicEvents(today, 5));
+  });
+
+  it("threads the sighting adjustment through to the resolved dates", () => {
+    const base = upcomingIslamicEvents(today, 1, 0)[0]!;
+    const shifted = upcomingIslamicEvents(today, 1, 1)[0]!;
+    // A +1-day adjustment moves the Gregorian date of the same event one day earlier.
+    expect(shifted.event.id).toBe(base.event.id);
+    expect(shifted.gregorian).toEqual({ year: 2026, month: 6, day: 25 });
+  });
+});

--- a/packages/core/src/islamic-events.ts
+++ b/packages/core/src/islamic-events.ts
@@ -1,0 +1,116 @@
+/**
+ * Islamic (Hijri) events — a small static table of well-established observances
+ * by fixed Hijri date, plus a pure resolver that turns them into the upcoming
+ * Gregorian occurrences with a day countdown.
+ *
+ * Like the rest of `core` this is deterministic and clock-injected: the caller
+ * passes "today" as a {@link GregorianDate}, so there is no I/O and no hidden
+ * `Date.now()`. The dates are factual calendar markers (no interpretive
+ * content); the tabular Hijri calendar can sit ±1 day from a local sighting,
+ * which is why every function takes the same `adjustmentDays` offset the rest of
+ * the calendar uses (see `hijri.ts`).
+ */
+
+import type { GregorianDate, HijriDate } from "./hijri";
+import { gregorianToHijri, hijriToGregorian } from "./hijri";
+
+/** One observance, pinned to a fixed Hijri month and day. */
+export interface IslamicEvent {
+  /** Stable id (kebab-case), e.g. `"eid-al-fitr"`. */
+  id: string;
+  /** Hijri month, 1–12. */
+  month: number;
+  /** Hijri day of the month. */
+  day: number;
+  /** Transliterated name shown to the reader. */
+  name: string;
+  /** One-line description. */
+  note: string;
+}
+
+/**
+ * Major observances by fixed Hijri date, in calendar order. The festivals
+ * themselves follow a local sighting; these are the widely-agreed tabular dates.
+ */
+export const ISLAMIC_EVENTS: readonly IslamicEvent[] = [
+  { id: "islamic-new-year", month: 1, day: 1, name: "Islamic New Year", note: "Start of Muḥarram" },
+  { id: "ashura", month: 1, day: 10, name: "ʿĀshūrāʾ", note: "A day of fasting" },
+  { id: "mawlid", month: 3, day: 12, name: "Mawlid an-Nabī ﷺ", note: "Birth of the Prophet" },
+  { id: "isra-miraj", month: 7, day: 27, name: "Al-Isrāʾ wal-Miʿrāj", note: "The Night Journey" },
+  { id: "laylat-al-baraah", month: 8, day: 15, name: "Laylat al-Barāʾah", note: "Mid-Shaʿbān night" },
+  { id: "ramadan-begins", month: 9, day: 1, name: "First of Ramaḍān", note: "Fasting begins" },
+  { id: "laylat-al-qadr", month: 9, day: 27, name: "Laylat al-Qadr", note: "Sought in the last ten nights" },
+  { id: "eid-al-fitr", month: 10, day: 1, name: "ʿĪd al-Fiṭr", note: "Festival of breaking the fast" },
+  { id: "arafah", month: 12, day: 9, name: "Day of ʿArafah", note: "The standing at ʿArafah" },
+  { id: "eid-al-adha", month: 12, day: 10, name: "ʿĪd al-Aḍḥā", note: "Festival of the sacrifice" },
+];
+
+/** The events that fall in a given Hijri month (1–12), in day order. */
+export function islamicEventsInMonth(month: number): IslamicEvent[] {
+  return ISLAMIC_EVENTS.filter((e) => e.month === month);
+}
+
+/** An event resolved to its next Gregorian occurrence. */
+export interface UpcomingIslamicEvent {
+  event: IslamicEvent;
+  /** The resolved Hijri date, carrying the year it next falls in. */
+  hijri: HijriDate;
+  /** Its Gregorian civil date. */
+  gregorian: GregorianDate;
+  /** Whole days from `today` to the event (0 = today, 1 = tomorrow). */
+  daysUntil: number;
+}
+
+/**
+ * Proleptic Gregorian day number (a Julian Day Number) for a civil date — pure
+ * integer arithmetic, no `Date`. Mirrors the conversion in `hijri.ts` so day
+ * differences are exact regardless of timezone.
+ */
+function dayNumber({ year, month, day }: GregorianDate): number {
+  const a = Math.floor((14 - month) / 12);
+  const y = year + 4800 - a;
+  const m = month + 12 * a - 3;
+  return (
+    day +
+    Math.floor((153 * m + 2) / 5) +
+    365 * y +
+    Math.floor(y / 4) -
+    Math.floor(y / 100) +
+    Math.floor(y / 400) -
+    32045
+  );
+}
+
+/**
+ * The next `count` Islamic events at or after `today`, soonest first, each with
+ * the Gregorian date it next falls on and the number of days until then. An
+ * event that has already passed this Hijri year rolls over to the next one.
+ */
+export function upcomingIslamicEvents(
+  today: GregorianDate,
+  count: number = ISLAMIC_EVENTS.length,
+  adjustmentDays = 0,
+): UpcomingIslamicEvent[] {
+  const todayHijri = gregorianToHijri(today, adjustmentDays);
+  const todayNum = dayNumber(today);
+
+  const resolved = ISLAMIC_EVENTS.map((event) => {
+    // This Hijri year, else the next, is always at or after today.
+    let chosen: { hijri: HijriDate; gregorian: GregorianDate; num: number } | null = null;
+    for (const year of [todayHijri.year, todayHijri.year + 1]) {
+      const hijri = { year, month: event.month, day: event.day };
+      const gregorian = hijriToGregorian(hijri, adjustmentDays);
+      const num = dayNumber(gregorian);
+      if (num >= todayNum) {
+        chosen = { hijri, gregorian, num };
+        break;
+      }
+    }
+    // `chosen` is non-null: next year's date is always in the future.
+    const { hijri, gregorian, num } = chosen!;
+    return { event, hijri, gregorian, daysUntil: num - todayNum };
+  });
+
+  resolved.sort((a, b) => a.daysUntil - b.daysUntil);
+  return resolved.slice(0, Math.max(0, count));
+}


### PR DESCRIPTION
Part of #143.

## What
Adds an **Islamic (Hijri) events** layer over the existing calendar — Islamic New Year, ʿĀshūrāʾ, Mawlid, Isrāʾ wal-Miʿrāj, Laylat al-Barāʾah, First of Ramaḍān, Laylat al-Qadr, ʿĪd al-Fiṭr, Day of ʿArafah, ʿĪd al-Aḍḥā — with a **next-event countdown** and the upcoming list. Fixed factual dates only; no network, no data dependency, no account (Tier 1).

## Changes
- **core** (`islamic-events.ts`): a static event table by Hijri month/day, `islamicEventsInMonth()`, and `upcomingIslamicEvents(today, n, adjust)` — resolves each event to its next Gregorian occurrence with a whole-day countdown. Pure, clock-injected, with the same sighting `adjustmentDays` the rest of the calendar uses.
- **web** (`HijriCalendar`): the per-month "sacred dates" panel now sources the **core** table (the duplicated inline copy is removed), plus a "Next observance" countdown banner and the following events.
- **mobile** (`HijriCalendarScreen`): gains the upcoming-events countdown **and** a "sacred dates this month" list — previously absent, now at parity with web.
- **tests**: core resolver — ordering, never returns past events, day countdown, `count`, determinism, and the sighting adjustment threading through.

## Loop
`pnpm lint`, `pnpm typecheck`, `pnpm exec vitest run` (591 tests), `pnpm build` all pass locally.

## Scope note
Per-event **push reminders** are deferred. Web reminders use in-page timers that can't fire for events weeks/months out, so a meaningful version needs the mobile-only scheduled-notification path (ExpoNotifier). Tracked as a follow-up on #143; the calendar + countdown ships here.

## Notes
- No new ADR: this extends the existing Hijri calendar (ADR 0014) with a pure core module — no new dependency edge or delivery mode.
- The events table consolidates data that was previously hardcoded inline in the web component.