### PR TITLE
fix(calendar): drop the duplicate per-month events list (#143)

### DIFF
--- a/apps/mobile/src/screens/HijriCalendarScreen.tsx
+++ b/apps/mobile/src/screens/HijriCalendarScreen.tsx
@@ -102,7 +102,7 @@ export function HijriCalendarScreen() {
   if (!view || !today) return null;
 
   const month = hijriMonth(view.month);
-  const monthEvents = islamicEventsInMonth(view.month);
+  const eventDays = new Set(islamicEventsInMonth(view.month).map((e) => e.day));
   const nextEvent = upcoming[0];
 
   return (
@@ -152,36 +152,16 @@ export function HijriCalendarScreen() {
           if (cell === null) return <View key={`pad-${i}`} style={styles.cell} />;
           const isToday =
             today.year === view.year && today.month === view.month && today.day === cell.day;
+          const isEvent = eventDays.has(cell.day);
           return (
-            <View key={cell.day} style={[styles.cell, isToday && styles.cellToday]}>
+            <View key={cell.day} style={[styles.cell, isToday && styles.cellToday, isEvent && !isToday && styles.cellEvent]}>
               <Text style={[styles.dayNum, isToday && styles.dayNumToday]}>{cell.day}</Text>
               <Text style={[styles.gregLabel, isToday && styles.gregLabelToday]}>{cell.gregLabel}</Text>
+              {isEvent && !isToday && <View style={styles.eventDot} />}
             </View>
           );
         })}
       </View>
-
-      <Text style={styles.sectionLabel}>Sacred dates this month</Text>
-      {monthEvents.length === 0 ? (
-        <Text style={styles.note}>No major observances fall in this month.</Text>
-      ) : (
-        <View style={styles.monthList}>
-          {monthEvents.map((e, i) => (
-            <View
-              key={e.id}
-              style={[styles.monthRow, i < monthEvents.length - 1 && styles.monthRowDivider]}
-            >
-              <View style={styles.dayBadge}>
-                <Text style={styles.dayBadgeText}>{e.day}</Text>
-              </View>
-              <View style={styles.flex1}>
-                <Text style={styles.eventName}>{e.name}</Text>
-                <Text style={styles.eventDate}>{e.note}</Text>
-              </View>
-            </View>
-          ))}
-        </View>
-      )}
 
       <View style={styles.adjustSection}>
         <Text style={styles.adjustLabel}>
@@ -247,35 +227,6 @@ function makeStyles(c: Palette) {
     eventName: { color: c.fg, fontSize: 15, fontWeight: "700" },
     eventDate: { color: c.faint, fontSize: 12, marginTop: 1 },
     eventCountdown: { color: c.accent, fontSize: 13, fontWeight: "700" },
-    sectionLabel: {
-      color: c.faint,
-      fontSize: 12,
-      fontWeight: "700",
-      letterSpacing: 1,
-      textTransform: "uppercase",
-      marginBottom: 10,
-    },
-    monthList: {
-      backgroundColor: c.bgElev,
-      borderWidth: 1,
-      borderColor: c.border,
-      borderRadius: 14,
-      marginBottom: 24,
-      overflow: "hidden",
-    },
-    monthRow: { flexDirection: "row", alignItems: "center", gap: 12, padding: 14 },
-    monthRowDivider: { borderBottomWidth: 1, borderBottomColor: c.borderSoft },
-    dayBadge: {
-      width: 40,
-      height: 40,
-      borderRadius: 10,
-      backgroundColor: c.accentSoft,
-      borderWidth: 1,
-      borderColor: c.accent,
-      alignItems: "center",
-      justifyContent: "center",
-    },
-    dayBadgeText: { color: c.accent, fontSize: 15, fontWeight: "800" },
     nav: { flexDirection: "row", alignItems: "center", marginBottom: 16 },
     navBtn: {
       paddingHorizontal: 12,
@@ -312,6 +263,15 @@ function makeStyles(c: Palette) {
       alignItems: "center",
       justifyContent: "center",
       borderRadius: 9,
+    },
+    cellEvent: { backgroundColor: c.accentSoft },
+    eventDot: {
+      position: "absolute",
+      bottom: 4,
+      width: 4,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: c.accent,
     },
     cellToday: { backgroundColor: c.accent },
     dayNum: { color: c.fg, fontSize: 13, fontWeight: "600" },

--- a/apps/web/src/components/HijriCalendar.tsx
+++ b/apps/web/src/components/HijriCalendar.tsx
@@ -344,62 +344,8 @@ export function HijriCalendar() {
           </div>
         </div>
 
-        {/* Sacred dates + adjustment */}
+        {/* Sighting adjustment */}
         <div>
-          <div
-            style={{
-              fontSize: 12,
-              letterSpacing: 1,
-              textTransform: "uppercase",
-              color: N.faint,
-              fontWeight: 700,
-              marginBottom: 12,
-              fontFamily: N.ui,
-            }}
-          >
-            Sacred dates this month
-          </div>
-          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-            {events.length === 0 && (
-              <div style={{ ...lcard, padding: "16px 18px", fontSize: 13.5, color: N.faint, fontFamily: N.ui }}>
-                No major observances fall in this month.
-              </div>
-            )}
-            {events.map((e) => (
-              <div
-                key={e.day}
-                style={{
-                  ...lcard,
-                  padding: "16px 18px",
-                  display: "flex",
-                  gap: 14,
-                  alignItems: "center",
-                  borderColor: isToday(e.day) ? N.gold : N.border,
-                }}
-              >
-                <div
-                  style={{
-                    width: 46,
-                    height: 46,
-                    borderRadius: 11,
-                    background: N.goldSoft,
-                    border: `1px solid ${N.gold}`,
-                    display: "grid",
-                    placeItems: "center",
-                    flexShrink: 0,
-                  }}
-                >
-                  <span style={{ fontSize: 17, fontWeight: 800, color: N.gold, fontFamily: N.ui }}>{e.day}</span>
-                </div>
-                <div>
-                  <div style={{ fontSize: 15, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>{e.name}</div>
-                  <div style={{ fontSize: 12.5, color: N.faint, marginTop: 1, fontFamily: N.ui }}>{e.note}</div>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* Sighting adjustment */}
           <div
             style={{
               fontSize: 12,


### PR DESCRIPTION
Follow-up to #158.

## Problem
The events layer showed the same observance **twice** on the calendar page: once in the global **"Upcoming"** countdown list and again in the per-month **"Sacred dates this month"** list. On mobile (where everything stacks) it was obvious — e.g. ʿĀshūrāʾ appeared in both. The two lists answer different questions (chronological year-ahead vs. currently-viewed month), so they overlap whenever a viewed month contains an upcoming event — which is the default current-month case.

## Fix
Keep **one** textual events surface — the "Upcoming" countdown — and let the **calendar grid** carry the per-month detail via day markers.

- **web**: remove the "Sacred dates this month" panel. The grid already dots event days, so per-month detail is preserved without the redundant list.
- **mobile**: remove the same list and **add event dots to the grid** (it had none), bringing it to parity with web — so each platform has exactly one events list + a marked-up grid.

Pure presentation change — the core events table/resolver and its tests are untouched.

## Verification
- Re-rendered the web `/calendar` at phone width via CDP: ʿĀshūrāʾ now appears once (the "Next observance" hero), days 1 and 10 are dotted in the grid, and the duplicate list is gone.
- `pnpm lint`, `pnpm typecheck`, `pnpm exec vitest run` (core + calendar tests) pass. Local `pnpm build` is blocked only by Google-Fonts egress timeouts in this sandbox (environmental); CI builds with network access.