### PR TITLE
fix(calendar): month-scoped observances with a clear marker legend (#143)

### DIFF
--- a/apps/mobile/src/screens/HijriCalendarScreen.tsx
+++ b/apps/mobile/src/screens/HijriCalendarScreen.tsx
@@ -2,13 +2,12 @@ import { useEffect, useMemo, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "../Type";
 import {
   type HijriDate,
-  type UpcomingIslamicEvent,
+  type MonthlyIslamicEvent,
   gregorianToHijri,
   hijriMonth,
   hijriMonthLength,
   hijriToGregorian,
-  islamicEventsInMonth,
-  upcomingIslamicEvents,
+  islamicEventsForMonth,
 } from "@ummahlibrary/core";
 import { KEYS, getString, setString } from "../storage";
 import { useTheme, type Palette } from "../theme";
@@ -94,43 +93,23 @@ export function HijriCalendarScreen() {
     return out;
   }, [view, adjust]);
 
-  const upcoming = useMemo<UpcomingIslamicEvent[]>(
-    () => upcomingIslamicEvents(todayGregorian(), 5, adjust),
-    [adjust],
+  // The viewed month's observances — one labelled source for the grid dots and
+  // the panel below it.
+  const monthly = useMemo<MonthlyIslamicEvent[]>(
+    () => (view ? islamicEventsForMonth(view.year, view.month, todayGregorian(), adjust) : []),
+    [view, adjust],
   );
 
   if (!view || !today) return null;
 
   const month = hijriMonth(view.month);
-  const eventDays = new Set(islamicEventsInMonth(view.month).map((e) => e.day));
-  const nextEvent = upcoming[0];
+  const eventDays = new Set(monthly.map((m) => m.event.day));
+  const nextId = monthly
+    .filter((m) => m.daysUntil >= 0)
+    .sort((a, b) => a.daysUntil - b.daysUntil)[0]?.event.id;
 
   return (
     <ScrollView contentContainerStyle={styles.screen}>
-      {nextEvent && (
-        <View style={styles.upcoming}>
-          <View style={styles.nextCard}>
-            <Text style={styles.nextLabel}>Next observance</Text>
-            <View style={styles.nextRow}>
-              <View style={styles.flex1}>
-                <Text style={styles.nextName}>{nextEvent.event.name}</Text>
-                <Text style={styles.nextSub}>{gregorianFull(nextEvent.gregorian)}</Text>
-              </View>
-              <Text style={styles.nextCountdown}>{countdownLabel(nextEvent.daysUntil)}</Text>
-            </View>
-          </View>
-          {upcoming.slice(1).map((u) => (
-            <View key={u.event.id} style={styles.eventRow}>
-              <View style={styles.flex1}>
-                <Text style={styles.eventName}>{u.event.name}</Text>
-                <Text style={styles.eventDate}>{gregorianFull(u.gregorian)}</Text>
-              </View>
-              <Text style={styles.eventCountdown}>{countdownLabel(u.daysUntil)}</Text>
-            </View>
-          ))}
-        </View>
-      )}
-
       <View style={styles.nav}>
         <Pressable style={styles.navBtn} onPress={() => step(-1)} accessibilityLabel="Previous month">
           <Text style={styles.navArrow}>‹</Text>
@@ -154,7 +133,7 @@ export function HijriCalendarScreen() {
             today.year === view.year && today.month === view.month && today.day === cell.day;
           const isEvent = eventDays.has(cell.day);
           return (
-            <View key={cell.day} style={[styles.cell, isToday && styles.cellToday, isEvent && !isToday && styles.cellEvent]}>
+            <View key={cell.day} style={[styles.cell, isToday && styles.cellToday]}>
               <Text style={[styles.dayNum, isToday && styles.dayNumToday]}>{cell.day}</Text>
               <Text style={[styles.gregLabel, isToday && styles.gregLabelToday]}>{cell.gregLabel}</Text>
               {isEvent && !isToday && <View style={styles.eventDot} />}
@@ -162,6 +141,43 @@ export function HijriCalendarScreen() {
           );
         })}
       </View>
+
+      <View style={styles.legend}>
+        <View style={styles.legendItem}>
+          <View style={styles.legendDot} />
+          <Text style={styles.legendText}>Observance</Text>
+        </View>
+        <View style={styles.legendItem}>
+          <View style={styles.legendToday} />
+          <Text style={styles.legendText}>Today</Text>
+        </View>
+      </View>
+
+      <Text style={styles.sectionLabel}>Observances this month</Text>
+      {monthly.length === 0 ? (
+        <Text style={styles.note}>No major observances fall in this month.</Text>
+      ) : (
+        <View style={styles.monthList}>
+          {monthly.map((m) => {
+            const up = m.daysUntil >= 0;
+            return (
+              <View
+                key={m.event.id}
+                style={[styles.monthRow, m.event.id === nextId && styles.monthRowNext]}
+              >
+                <View style={styles.dayBadge}>
+                  <Text style={styles.dayBadgeText}>{m.event.day}</Text>
+                </View>
+                <View style={styles.flex1}>
+                  <Text style={styles.eventName}>{m.event.name}</Text>
+                  <Text style={styles.eventDate}>{gregorianFull(m.gregorian)} · {m.event.note}</Text>
+                </View>
+                {up && <Text style={styles.eventCountdown}>{countdownLabel(m.daysUntil)}</Text>}
+              </View>
+            );
+          })}
+        </View>
+      )}
 
       <View style={styles.adjustSection}>
         <Text style={styles.adjustLabel}>
@@ -193,40 +209,6 @@ function makeStyles(c: Palette) {
   return StyleSheet.create({
     screen: { padding: 16, backgroundColor: c.bg },
     flex1: { flex: 1, minWidth: 0 },
-    upcoming: { marginBottom: 20, gap: 10 },
-    nextCard: {
-      backgroundColor: c.bgElev,
-      borderWidth: 1,
-      borderColor: c.accent,
-      borderRadius: 14,
-      padding: 16,
-    },
-    nextLabel: {
-      color: c.faint,
-      fontSize: 11,
-      fontWeight: "700",
-      letterSpacing: 1,
-      textTransform: "uppercase",
-      marginBottom: 6,
-    },
-    nextRow: { flexDirection: "row", alignItems: "center", gap: 12 },
-    nextName: { color: c.fg, fontSize: 18, fontWeight: "800" },
-    nextSub: { color: c.muted, fontSize: 13, marginTop: 2 },
-    nextCountdown: { color: c.accent, fontSize: 16, fontWeight: "800" },
-    eventRow: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 12,
-      backgroundColor: c.bgElev,
-      borderWidth: 1,
-      borderColor: c.border,
-      borderRadius: 12,
-      paddingHorizontal: 14,
-      paddingVertical: 12,
-    },
-    eventName: { color: c.fg, fontSize: 15, fontWeight: "700" },
-    eventDate: { color: c.faint, fontSize: 12, marginTop: 1 },
-    eventCountdown: { color: c.accent, fontSize: 13, fontWeight: "700" },
     nav: { flexDirection: "row", alignItems: "center", marginBottom: 16 },
     navBtn: {
       paddingHorizontal: 12,
@@ -242,7 +224,7 @@ function makeStyles(c: Palette) {
     grid: {
       flexDirection: "row",
       flexWrap: "wrap",
-      marginBottom: 24,
+      marginBottom: 12,
       backgroundColor: c.bgElev,
       borderWidth: 1,
       borderColor: c.border,
@@ -264,7 +246,6 @@ function makeStyles(c: Palette) {
       justifyContent: "center",
       borderRadius: 9,
     },
-    cellEvent: { backgroundColor: c.accentSoft },
     eventDot: {
       position: "absolute",
       bottom: 4,
@@ -278,6 +259,46 @@ function makeStyles(c: Palette) {
     dayNumToday: { color: c.ink, fontWeight: "800" },
     gregLabel: { color: c.faint, fontSize: 8 },
     gregLabelToday: { color: c.ink },
+    legend: { flexDirection: "row", gap: 18, alignItems: "center", marginBottom: 22 },
+    legendItem: { flexDirection: "row", alignItems: "center", gap: 6 },
+    legendDot: { width: 6, height: 6, borderRadius: 3, backgroundColor: c.accent },
+    legendToday: { width: 12, height: 12, borderRadius: 4, backgroundColor: c.accent },
+    legendText: { color: c.faint, fontSize: 12 },
+    sectionLabel: {
+      color: c.faint,
+      fontSize: 12,
+      fontWeight: "700",
+      letterSpacing: 1,
+      textTransform: "uppercase",
+      marginBottom: 10,
+    },
+    monthList: { gap: 10, marginBottom: 24 },
+    monthRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+      backgroundColor: c.bgElev,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 12,
+      paddingHorizontal: 14,
+      paddingVertical: 12,
+    },
+    monthRowNext: { borderColor: c.accent },
+    dayBadge: {
+      width: 40,
+      height: 40,
+      borderRadius: 10,
+      backgroundColor: c.accentSoft,
+      borderWidth: 1,
+      borderColor: c.accent,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    dayBadgeText: { color: c.accent, fontSize: 15, fontWeight: "800" },
+    eventName: { color: c.fg, fontSize: 15, fontWeight: "700" },
+    eventDate: { color: c.faint, fontSize: 12, marginTop: 1 },
+    eventCountdown: { color: c.accent, fontSize: 13, fontWeight: "700" },
     adjustSection: { gap: 10 },
     adjustLabel: { color: c.fg, fontSize: 13, fontWeight: "600" },
     chips: { flexDirection: "row", gap: 8 },

--- a/apps/web/src/components/HijriCalendar.tsx
+++ b/apps/web/src/components/HijriCalendar.tsx
@@ -3,19 +3,26 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   type HijriDate,
-  type UpcomingIslamicEvent,
+  type MonthlyIslamicEvent,
   gregorianToHijri,
   hijriMonth,
   hijriMonthLength,
   hijriToGregorian,
-  islamicEventsInMonth,
-  upcomingIslamicEvents,
+  islamicEventsForMonth,
 } from "@ummahlibrary/core";
 import { readHijriAdjust, writeHijriAdjust } from "../lib/hijri";
 import { N } from "@ummahlibrary/ui";
 
 const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 const lcard = { background: N.card, border: `1px solid ${N.border}`, borderRadius: 16 } as const;
+const sectionLabel = {
+  fontSize: 12,
+  letterSpacing: 1,
+  textTransform: "uppercase",
+  color: N.faint,
+  fontWeight: 700,
+  fontFamily: N.ui,
+} as const;
 
 function localToday(): { year: number; month: number; day: number } {
   const d = new Date();
@@ -105,126 +112,26 @@ export function HijriCalendar() {
     return out;
   }, [view, adjust]);
 
-  const upcoming = useMemo<UpcomingIslamicEvent[]>(
-    () => upcomingIslamicEvents(localToday(), 5, adjust),
-    [adjust],
+  // The viewed month's observances, resolved to dates + countdowns — the single
+  // labelled source for both the grid markers and the panel beside it.
+  const monthly = useMemo<MonthlyIslamicEvent[]>(
+    () => (view ? islamicEventsForMonth(view.year, view.month, localToday(), adjust) : []),
+    [view, adjust],
   );
 
   if (!view || !todayHijri) return <p style={{ color: N.muted, fontFamily: N.ui }}>Loading the calendar…</p>;
 
   const month = hijriMonth(view.month);
-  const events = islamicEventsInMonth(view.month);
-  const eventDays = new Set(events.map((e) => e.day));
-  const nextEvent = upcoming[0];
+  const eventDays = new Set(monthly.map((m) => m.event.day));
+  // The soonest still-upcoming observance in this month, highlighted as "next".
+  const nextId = monthly
+    .filter((m) => m.daysUntil >= 0)
+    .sort((a, b) => a.daysUntil - b.daysUntil)[0]?.event.id;
   const isToday = (d: number) =>
     todayHijri.year === view.year && todayHijri.month === view.month && todayHijri.day === d;
 
   return (
     <div>
-      {/* Upcoming events + next-event countdown */}
-      {nextEvent && (
-        <div style={{ marginBottom: 22 }}>
-          <div
-            style={{
-              ...lcard,
-              padding: "18px 20px",
-              marginBottom: 12,
-              background: `linear-gradient(135deg, ${N.cardHi}, ${N.card})`,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 16,
-              flexWrap: "wrap",
-            }}
-          >
-            <div style={{ minWidth: 0 }}>
-              <div
-                style={{
-                  fontSize: 11.5,
-                  letterSpacing: 1,
-                  textTransform: "uppercase",
-                  color: N.faint,
-                  fontWeight: 700,
-                  fontFamily: N.ui,
-                }}
-              >
-                Next observance
-              </div>
-              <div style={{ fontSize: 20, fontWeight: 800, color: N.fg, fontFamily: N.ui, marginTop: 3 }}>
-                {nextEvent.event.name}
-              </div>
-              <div style={{ fontSize: 13, color: N.faint, fontFamily: N.ui, marginTop: 2 }}>
-                {gregorianFull(nextEvent.gregorian)} · {nextEvent.event.note}
-              </div>
-            </div>
-            <div
-              style={{
-                fontSize: 22,
-                fontWeight: 800,
-                color: N.gold,
-                fontFamily: N.ui,
-                whiteSpace: "nowrap",
-              }}
-            >
-              {countdownLabel(nextEvent.daysUntil)}
-            </div>
-          </div>
-          {upcoming.length > 1 && (
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fit, minmax(220px,1fr))",
-                gap: 10,
-              }}
-            >
-              {upcoming.slice(1).map((u) => (
-                <div
-                  key={u.event.id}
-                  style={{
-                    ...lcard,
-                    padding: "12px 14px",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    gap: 10,
-                  }}
-                >
-                  <div style={{ minWidth: 0 }}>
-                    <div
-                      style={{
-                        fontSize: 14,
-                        fontWeight: 700,
-                        color: N.fg,
-                        fontFamily: N.ui,
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                      }}
-                    >
-                      {u.event.name}
-                    </div>
-                    <div style={{ fontSize: 12, color: N.faint, fontFamily: N.ui }}>
-                      {gregorianFull(u.gregorian)}
-                    </div>
-                  </div>
-                  <div
-                    style={{
-                      fontSize: 12.5,
-                      fontWeight: 700,
-                      color: N.gold,
-                      fontFamily: N.ui,
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {countdownLabel(u.daysUntil)}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
       {/* Month nav */}
       <div
         style={{
@@ -281,7 +188,7 @@ export function HijriCalendar() {
         </button>
       </div>
 
-      {/* Two-pane: grid + sacred dates */}
+      {/* Two-pane: grid + this month's observances */}
       <div
         style={{
           display: "grid",
@@ -310,15 +217,15 @@ export function HijriCalendar() {
               return (
                 <div
                   key={cell.day}
-                  title={cell.greg}
+                  title={ev ? `${cell.greg} · observance` : cell.greg}
                   style={{
                     aspectRatio: "1",
                     borderRadius: 10,
                     display: "grid",
                     placeItems: "center",
                     position: "relative",
-                    background: today ? N.goldGrad : ev ? N.goldSoft : "transparent",
-                    border: `1px solid ${today ? "transparent" : ev ? N.gold : N.borderSoft}`,
+                    background: today ? N.goldGrad : "transparent",
+                    border: `1px solid ${today ? "transparent" : N.borderSoft}`,
                     color: today ? N.ink : N.fg,
                     fontWeight: today ? 800 : 500,
                     fontSize: 14.5,
@@ -342,21 +249,101 @@ export function HijriCalendar() {
               );
             })}
           </div>
-        </div>
 
-        {/* Sighting adjustment */}
-        <div>
+          {/* Legend */}
           <div
             style={{
+              display: "flex",
+              gap: 18,
+              marginTop: 16,
               fontSize: 12,
-              letterSpacing: 1,
-              textTransform: "uppercase",
               color: N.faint,
-              fontWeight: 700,
-              margin: "22px 0 12px",
               fontFamily: N.ui,
+              alignItems: "center",
             }}
           >
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+              <span style={{ width: 6, height: 6, borderRadius: 3, background: N.gold }} />
+              Observance
+            </span>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+              <span
+                style={{ width: 12, height: 12, borderRadius: 4, background: N.goldGrad }}
+              />
+              Today
+            </span>
+          </div>
+        </div>
+
+        {/* This month's observances + sighting adjustment */}
+        <div>
+          <div style={{ ...sectionLabel, marginBottom: 12 }}>Observances this month</div>
+          {monthly.length === 0 ? (
+            <div style={{ ...lcard, padding: "16px 18px", fontSize: 13.5, color: N.faint, fontFamily: N.ui }}>
+              No major observances fall in this month.
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              {monthly.map((m) => {
+                const isNext = m.event.id === nextId;
+                const upcoming = m.daysUntil >= 0;
+                return (
+                  <div
+                    key={m.event.id}
+                    style={{
+                      ...lcard,
+                      padding: "14px 16px",
+                      display: "flex",
+                      gap: 14,
+                      alignItems: "center",
+                      borderColor: isNext ? N.gold : N.border,
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: 44,
+                        height: 44,
+                        borderRadius: 11,
+                        background: N.goldSoft,
+                        border: `1px solid ${N.gold}`,
+                        display: "grid",
+                        placeItems: "center",
+                        flexShrink: 0,
+                      }}
+                    >
+                      <span style={{ fontSize: 16, fontWeight: 800, color: N.gold, fontFamily: N.ui }}>
+                        {m.event.day}
+                      </span>
+                    </div>
+                    <div style={{ minWidth: 0, flex: 1 }}>
+                      <div style={{ fontSize: 14.5, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>
+                        {m.event.name}
+                      </div>
+                      <div style={{ fontSize: 12.5, color: N.faint, marginTop: 1, fontFamily: N.ui }}>
+                        {gregorianFull(m.gregorian)} · {m.event.note}
+                      </div>
+                    </div>
+                    {upcoming && (
+                      <div
+                        style={{
+                          fontSize: 12.5,
+                          fontWeight: 700,
+                          color: N.gold,
+                          fontFamily: N.ui,
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {countdownLabel(m.daysUntil)}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Sighting adjustment */}
+          <div style={{ ...sectionLabel, margin: "22px 0 12px" }}>
             Date adjustment ({adjust > 0 ? `+${adjust}` : adjust} day{Math.abs(adjust) === 1 ? "" : "s"})
           </div>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>

--- a/packages/core/src/islamic-events.test.ts
+++ b/packages/core/src/islamic-events.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ISLAMIC_EVENTS,
+  islamicEventsForMonth,
   islamicEventsInMonth,
   upcomingIslamicEvents,
 } from "./islamic-events";
@@ -82,5 +83,33 @@ describe("upcomingIslamicEvents", () => {
     // A +1-day adjustment moves the Gregorian date of the same event one day earlier.
     expect(shifted.event.id).toBe(base.event.id);
     expect(shifted.gregorian).toEqual({ year: 2026, month: 6, day: 25 });
+  });
+});
+
+describe("islamicEventsForMonth", () => {
+  const today = { year: 2026, month: 6, day: 22 };
+
+  it("resolves a month's observances with a signed countdown", () => {
+    // Muḥarram 1448: New Year (1) has passed, ʿĀshūrāʾ (10) is 4 days away.
+    const m = islamicEventsForMonth(1448, 1, today);
+    expect(m.map((e) => e.event.id)).toEqual(["islamic-new-year", "ashura"]);
+    expect(m[0]!.daysUntil).toBeLessThan(0); // New Year already passed
+    expect(m[1]!.daysUntil).toBe(4); // ʿĀshūrāʾ upcoming
+    expect(m[1]!.gregorian).toEqual({ year: 2026, month: 6, day: 26 });
+  });
+
+  it("stays in day order and is empty for a month with no observance", () => {
+    expect(islamicEventsForMonth(1448, 12, today).map((e) => e.event.id)).toEqual([
+      "arafah",
+      "eid-al-adha",
+    ]);
+    expect(islamicEventsForMonth(1448, 2, today)).toEqual([]);
+  });
+
+  it("resolves the same event later in a future Hijri year", () => {
+    const thisYear = islamicEventsForMonth(1448, 1, today)[1]!; // ʿĀshūrāʾ 1448
+    const nextYear = islamicEventsForMonth(1449, 1, today)[1]!; // ʿĀshūrāʾ 1449
+    expect(nextYear.daysUntil).toBeGreaterThan(thisYear.daysUntil);
+    expect(nextYear.gregorian.year).toBe(2027);
   });
 });

--- a/packages/core/src/islamic-events.ts
+++ b/packages/core/src/islamic-events.ts
@@ -114,3 +114,34 @@ export function upcomingIslamicEvents(
   resolved.sort((a, b) => a.daysUntil - b.daysUntil);
   return resolved.slice(0, Math.max(0, count));
 }
+
+/** An observance resolved within a specific Hijri month, with a signed countdown. */
+export interface MonthlyIslamicEvent {
+  event: IslamicEvent;
+  /** Gregorian date of the event in the requested Hijri year. */
+  gregorian: GregorianDate;
+  /** Whole days from `today`: negative if already passed, 0 = today. */
+  daysUntil: number;
+}
+
+/**
+ * The observances in a given Hijri month (of a specific Hijri year), in day
+ * order, each resolved to its Gregorian date with a signed day countdown from
+ * `today`. This is the labelled companion to a month grid: every marker the grid
+ * draws has a named row here, in the same scope. Pure; the clock is injected.
+ */
+export function islamicEventsForMonth(
+  hijriYear: number,
+  hijriMonth: number,
+  today: GregorianDate,
+  adjustmentDays = 0,
+): MonthlyIslamicEvent[] {
+  const todayNum = dayNumber(today);
+  return islamicEventsInMonth(hijriMonth).map((event) => {
+    const gregorian = hijriToGregorian(
+      { year: hijriYear, month: hijriMonth, day: event.day },
+      adjustmentDays,
+    );
+    return { event, gregorian, daysUntil: dayNumber(gregorian) - todayNum };
+  });
+}


### PR DESCRIPTION
Follow-up to #159. Resolves the "what do the highlighted dates represent?" confusion.

## The problem
The page mixed **two scopes**: a global **"Upcoming"** list (future-only, across the year) sitting above a month grid that marked **all** of the viewed month's observances (past included). Three inconsistencies fell out of that:
1. A marked day could map to nothing on screen — e.g. **1 Muḥarram (Islamic New Year)** was dotted on the grid but, being past, never appeared in the future-only list.
2. **Today** (gold fill) and **observance** (gold outline + dot) both read as gold, with no legend to tell them apart.
3. The top list showed events from *other* months while the grid showed *this* one — no connective tissue.

## Research
Calendar-UX guidance is consistent: users shouldn't have to decode a calendar — differentiate today / selected / event by **shape and label, not colour alone**, and every marker should map to something named on screen ([Eleken](https://www.eleken.co/blog-posts/calendar-ui), [Page Flows](https://pageflows.com/resources/exploring-calendar-design/)). The Islamic-calendar apps that do this well keep the month's observances listed **next to the grid they belong to** ([Muslim Pro](https://app.muslimpro.com/islamic-calendar)).

## The fix — one scope: the viewed month
- **core**: `islamicEventsForMonth(year, month, today, adjust)` — the viewed month's observances resolved to Gregorian dates with a signed day countdown. One pure, tested source for both the grid dots and the panel.
- **web + mobile**: replace the global "Upcoming" cards with an **"Observances this month"** panel that names every marked day (countdown on upcoming ones, the soonest emphasised). Grid markers are now a **dot only** — today keeps the solid fill — and a **`● Observance · ▣ Today`** legend explains them. The panel fills the previously-empty right column.

Grid and list now share one scope, so they can never disagree; every marker has a name.

`upcomingIslamicEvents` is retained (public API for the deferred reminders follow-up).

## Verification
- Re-rendered web `/calendar` (desktop, via CDP): today = filled day; days 1 & 10 = dots; legend present; panel lists "Islamic New Year (Jun 17, past)" and "ʿĀshūrāʾ — in 3 days" (emphasised). No orphan markers.
- `pnpm lint`, `pnpm typecheck`, `pnpm exec vitest run` (core 13 + suite), `pnpm build` (1599 pages) all pass.