### PR TITLE
feat(web): wire sync to live bookmarks — D1 vertical slice (#163)

### DIFF
--- a/apps/web/src/app/api/sync/route.test.ts
+++ b/apps/web/src/app/api/sync/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { POST } from "./route";
+
+function post(body: unknown, auth?: string): Request {
+  return new Request("http://localhost/api/sync", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(auth ? { authorization: auth } : {}) },
+    body: JSON.stringify(body),
+  });
+}
+
+const AUTH = `Bearer ${"a".repeat(64)}`;
+const entry = { id: "x", hlc: { millis: 1, counter: 0, node: "n" }, ciphertext: "ct", nonce: "iv" };
+
+describe("POST /api/sync (dev fallback)", () => {
+  it("uses an in-memory store outside production and round-trips entries", async () => {
+    const res1 = await POST(post({ entries: [entry] }, AUTH));
+    expect(res1.status).toBe(200);
+    // a second exchange with no local entries pulls the stored one back
+    const res2 = await POST(post({ entries: [] }, AUTH));
+    const data = (await res2.json()) as { entries: unknown[] };
+    expect(data.entries).toHaveLength(1);
+  });
+
+  it("rejects a missing account id", async () => {
+    expect((await POST(post({ entries: [] }))).status).toBe(401);
+  });
+
+  it("rejects a malformed JSON body", async () => {
+    const bad = new Request("http://localhost/api/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: AUTH },
+      body: "{nope",
+    });
+    expect((await POST(bad)).status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -1,22 +1,36 @@
 /**
  * `POST /api/sync` (#25, ADR 0033) — the one runtime endpoint sync adds. A thin
- * shell over {@link handleSync}: pick the configured store, parse the body, run
- * the exchange. Responses are never cached. Returns 501 when the server has no
- * sync store provisioned (the local-first app is unaffected). This route reads no
- * datasets, so it needs no `outputFileTracingIncludes` entry.
+ * shell over {@link handleSync}: pick the store, parse the body, run the exchange.
+ * Responses are never cached. In production it returns 501 until a sync store is
+ * provisioned (the local-first app is unaffected); in development it falls back to
+ * a process-memory store so two local profiles can sync against `pnpm dev` with no
+ * credentials. This route reads no datasets, so it needs no
+ * `outputFileTracingIncludes` entry.
  */
 import { handleSync } from "./handler";
-import { syncStoreFromEnv } from "./sync-store";
+import { InMemorySyncStore, type SyncStore, syncStoreFromEnv } from "./sync-store";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+// Reused across requests in one dev-server process so two profiles converge; never
+// constructed in production, where an unprovisioned endpoint stays 501.
+let devStore: SyncStore | null = null;
+
+function resolveStore(): SyncStore | null {
+  const configured = syncStoreFromEnv(process.env);
+  if (configured) return configured;
+  if (process.env.NODE_ENV === "production") return null;
+  devStore ??= new InMemorySyncStore();
+  return devStore;
+}
 
 function json(body: unknown, status: number): Response {
   return Response.json(body, { status, headers: { "cache-control": "no-store" } });
 }
 
 export async function POST(req: Request): Promise<Response> {
-  const store = syncStoreFromEnv(process.env);
+  const store = resolveStore();
   if (!store) return json({ error: "sync is not configured on this server" }, 501);
 
   let body: unknown;

--- a/apps/web/src/app/api/sync/sync-e2e.test.ts
+++ b/apps/web/src/app/api/sync/sync-e2e.test.ts
@@ -1,0 +1,93 @@
+/**
+ * End-to-end sync proof (#163): two independent devices and one server, wired with
+ * the *real* crypto (WebCryptoCipher), the *real* engine (runSync), and the *real*
+ * server logic (handleSync over an in-memory store). It demonstrates the whole
+ * point of #25 — a value bookmarked on device A appears, decrypted, on device B —
+ * and that the server only ever holds ciphertext. Each device keeps its own state
+ * map, since two devices can't share one jsdom localStorage.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Hlc, SyncBackend, SyncEntry, SyncStateStore } from "@ummahlibrary/core";
+import { handleSync } from "./handler";
+import { InMemorySyncStore } from "./sync-store";
+import { createSyncController } from "../../../lib/sync/sync-controller";
+import { createWebCryptoCipher } from "../../../lib/sync/web-crypto-cipher";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+const KEY = "ul.bookmarks";
+
+/** A device's local state as an isolated in-memory cell (one managed key). */
+function memDevice(node: string, initial: string | null) {
+  let value = initial;
+  let hlc: Hlc = { millis: initial === null ? 0 : 100, counter: 0, node };
+  const state: SyncStateStore = {
+    all: async () => [{ key: KEY, value, hlc }],
+    apply: async (_key, v, h) => {
+      value = v;
+      hlc = h;
+    },
+  };
+  return { state, get: () => value };
+}
+
+/** The server side: one HTTP round trip modelled as a direct handleSync call. */
+function makeBackend(server: InMemorySyncStore): SyncBackend {
+  return {
+    exchange: async (accountId, entries) => {
+      const res = await handleSync(
+        { authorization: `Bearer ${accountId}`, body: { entries } },
+        server,
+      );
+      return (res.body as { entries?: SyncEntry[] }).entries ?? [];
+    },
+  };
+}
+
+describe("sync end-to-end (two devices, one server)", () => {
+  it("device B pulls and decrypts the bookmark device A pushed", async () => {
+    const secret = "SYNC1-SYNC2-SYNC3-SYNC4-SYNC5";
+    const server = new InMemorySyncStore();
+    const backend = makeBackend(server);
+
+    const deviceA = memDevice("node-a", "[2]");
+    const deviceB = memDevice("node-b", null);
+
+    await createSyncController(await createWebCryptoCipher(secret), {
+      backend,
+      state: deviceA.state,
+    }).syncNow();
+    const outcome = await createSyncController(await createWebCryptoCipher(secret), {
+      backend,
+      state: deviceB.state,
+    }).syncNow();
+
+    expect(deviceB.get()).toBe("[2]"); // B now holds A's bookmark
+    expect(outcome.applied).toBe(1);
+
+    // the server only ever held ciphertext, never the plaintext value
+    const cipher = await createWebCryptoCipher(secret);
+    const stored = await server.get(await cipher.accountId());
+    expect(stored[0]!.ciphertext).not.toContain("[2]");
+  });
+
+  it("a different secret lands on a separate, empty account", async () => {
+    const server = new InMemorySyncStore();
+    const backend = makeBackend(server);
+
+    await createSyncController(await createWebCryptoCipher("SECRET-AAAAA"), {
+      backend,
+      state: memDevice("node-a", "[7]").state,
+    }).syncNow();
+
+    const intruder = memDevice("node-x", null);
+    const outcome = await createSyncController(await createWebCryptoCipher("SECRET-BBBBB"), {
+      backend,
+      state: intruder.state,
+    }).syncNow();
+
+    expect(intruder.get()).toBeNull(); // isolated account ⇒ nothing to pull
+    expect(outcome.applied).toBe(0);
+  });
+});

--- a/apps/web/src/app/sync-dev/page.tsx
+++ b/apps/web/src/app/sync-dev/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+import { useCallback, useEffect, useState } from "react";
+import { N } from "@ummahlibrary/ui";
+import type { SyncOutcome } from "@ummahlibrary/core";
+import { readBookmarks, toggleBookmark } from "../../lib/bookmarks";
+import { generateRecoveryPhrase } from "../../lib/sync/web-crypto-cipher";
+import {
+  type SyncController,
+  createSyncControllerFromSecret,
+} from "../../lib/sync/sync-controller";
+import { SYNC_CHANGE_EVENT } from "../../lib/sync/web-sync-state-store";
+
+const card = {
+  background: N.card,
+  border: `1px solid ${N.border}`,
+  borderRadius: 14,
+  padding: 18,
+  marginBottom: 16,
+} as const;
+
+const button = {
+  padding: "8px 14px",
+  borderRadius: 10,
+  border: `1px solid ${N.border}`,
+  background: N.card,
+  color: N.fg,
+  fontFamily: N.ui,
+  fontSize: 14,
+  fontWeight: 600,
+  cursor: "pointer",
+} as const;
+
+const DEMO_SURAHS = [1, 2, 36, 67, 112];
+
+/**
+ * Dev-only surface to verify cross-device sync end-to-end (#163): enter the same
+ * recovery phrase in two browser profiles, bookmark a surah in one, "Sync now" in
+ * both, and watch it appear in the other. The polished Settings experience is D2.
+ */
+export default function SyncDevPage() {
+  const [secret, setSecret] = useState("");
+  const [controller, setController] = useState<SyncController | null>(null);
+  const [bookmarks, setBookmarks] = useState<number[]>([]);
+  const [outcome, setOutcome] = useState<SyncOutcome | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(() => {
+    void readBookmarks().then(setBookmarks);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    window.addEventListener(SYNC_CHANGE_EVENT, refresh);
+    return () => window.removeEventListener(SYNC_CHANGE_EVENT, refresh);
+  }, [refresh]);
+
+  const enable = useCallback(async () => {
+    setError(null);
+    try {
+      setController(await createSyncControllerFromSecret(secret.trim()));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not enable sync");
+    }
+  }, [secret]);
+
+  const syncNow = useCallback(async () => {
+    if (!controller) return;
+    setBusy(true);
+    setError(null);
+    try {
+      setOutcome(await controller.syncNow());
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "sync failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [controller, refresh]);
+
+  const toggle = useCallback(async (surah: number) => {
+    setBookmarks(await toggleBookmark(surah));
+  }, []);
+
+  return (
+    <div style={{ maxWidth: 640, margin: "0 auto", padding: "28px 20px 60px", fontFamily: N.ui }}>
+      <h1 style={{ fontSize: 24, fontWeight: 800, margin: "0 0 4px", color: N.fg }}>
+        Sync · dev preview
+      </h1>
+      <p style={{ color: N.muted, fontSize: 14, margin: "0 0 20px" }}>
+        Temporary surface to verify cross-device sync (#163). The real Settings UI is D2.
+      </p>
+
+      <div style={card}>
+        <div style={{ fontWeight: 700, marginBottom: 8, color: N.fg }}>1 · Recovery phrase</div>
+        <p style={{ color: N.muted, fontSize: 13, margin: "0 0 10px" }}>
+          This phrase is your only key — it never leaves your device, and if you lose it your synced
+          data is unrecoverable. Enter the same phrase on each device.
+        </p>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <input
+            value={secret}
+            onChange={(e) => setSecret(e.target.value)}
+            placeholder="ABCDE-ABCDE-…"
+            spellCheck={false}
+            style={{
+              flex: 1,
+              minWidth: 200,
+              padding: "8px 12px",
+              borderRadius: 10,
+              border: `1px solid ${N.border}`,
+              background: N.bg,
+              color: N.fg,
+              fontFamily: "monospace",
+              fontSize: 14,
+            }}
+          />
+          <button type="button" style={button} onClick={() => setSecret(generateRecoveryPhrase())}>
+            Generate
+          </button>
+        </div>
+      </div>
+
+      <div style={card}>
+        <div style={{ fontWeight: 700, marginBottom: 8, color: N.fg }}>2 · Enable &amp; sync</div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <button
+            type="button"
+            style={button}
+            disabled={!secret.trim()}
+            onClick={() => void enable()}
+          >
+            {controller ? "Re-enable" : "Enable sync"}
+          </button>
+          <button
+            type="button"
+            style={button}
+            disabled={!controller || busy}
+            onClick={() => void syncNow()}
+          >
+            {busy ? "Syncing…" : "Sync now"}
+          </button>
+          <span style={{ fontSize: 13, color: N.muted }}>
+            {controller ? "✓ enabled" : "not enabled"}
+          </span>
+        </div>
+        {outcome && (
+          <div style={{ fontSize: 13, color: N.muted, marginTop: 10 }}>
+            Last sync — pushed {outcome.pushed}, pulled {outcome.pulled}, applied {outcome.applied}.
+          </div>
+        )}
+        {error && <div style={{ fontSize: 13, color: "#d14343", marginTop: 10 }}>{error}</div>}
+      </div>
+
+      <div style={card}>
+        <div style={{ fontWeight: 700, marginBottom: 8, color: N.fg }}>
+          3 · Bookmarks (the synced data)
+        </div>
+        <div style={{ fontSize: 14, marginBottom: 10, color: N.fg }}>
+          {bookmarks.length ? `Surahs: ${bookmarks.join(", ")}` : "No bookmarks yet."}
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {DEMO_SURAHS.map((s) => (
+            <button key={s} type="button" style={button} onClick={() => void toggle(s)}>
+              {bookmarks.includes(s) ? `− ${s}` : `+ ${s}`}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/sync/managed-keys.ts
+++ b/apps/web/src/lib/sync/managed-keys.ts
@@ -1,0 +1,9 @@
+/**
+ * The `localStorage` keys sync manages (#25, ADR 0033). Deliberately starts with
+ * just bookmarks — the first verifiable slice — and fans out across the `ul.*`
+ * namespace as each key's merge semantics are proven. Collection-shaped keys
+ * (`ul.collections`, `ul.ayahNotes`) wait for element-level merge (v2); scalar
+ * keys (settings, theme, reader prefs, reading position, hifz state) are safe to
+ * add here once the round-trip is demonstrated.
+ */
+export const MANAGED_KEYS: readonly string[] = ["ul.bookmarks"];

--- a/apps/web/src/lib/sync/storage.ts
+++ b/apps/web/src/lib/sync/storage.ts
@@ -1,0 +1,29 @@
+/**
+ * Raw `localStorage` access for the sync module (ADR 0024/0028) — the one file
+ * here permitted to touch web storage directly, so the rest of the sync code stays
+ * storage-agnostic. Every accessor swallows storage errors (private mode, quota)
+ * and degrades to null / a no-op rather than throwing.
+ */
+export function getItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function setItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+export function removeItem(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/apps/web/src/lib/sync/sync-controller.test.ts
+++ b/apps/web/src/lib/sync/sync-controller.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Cipher, SyncBackend, SyncEntry, SyncStateStore } from "@ummahlibrary/core";
+import { createSyncController, createSyncControllerFromSecret } from "./sync-controller";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+const fakeCipher: Cipher = {
+  accountId: async () => "a".repeat(64),
+  entryId: async (k) => `id:${k}`,
+  encrypt: async (p) => ({ ciphertext: `enc(${p})`, nonce: "iv" }),
+  decrypt: async (c) => (c.startsWith("enc(") ? c.slice(4, -1) : null),
+};
+
+describe("createSyncController", () => {
+  it("runs a round through the injected backend and state", async () => {
+    const state: SyncStateStore = {
+      all: async () => [
+        { key: "ul.bookmarks", value: "[1]", hlc: { millis: 1, counter: 0, node: "n" } },
+      ],
+      apply: vi.fn(async () => {}),
+    };
+    const exchange = vi.fn(async (_id: string, entries: readonly SyncEntry[]) => entries);
+    const backend: SyncBackend = { exchange };
+    const controller = createSyncController(fakeCipher, { backend, state });
+
+    const outcome = await controller.syncNow();
+    expect(exchange).toHaveBeenCalledOnce();
+    expect(outcome.pushed).toBe(1);
+  });
+
+  it("builds a working controller from a recovery secret", async () => {
+    const exchange = vi.fn(async () => []);
+    const controller = await createSyncControllerFromSecret("ABCDE-ABCDE-ABCDE-ABCDE-ABCDE", {
+      backend: { exchange },
+      state: { all: async () => [], apply: async () => {} },
+    });
+    const outcome = await controller.syncNow();
+    expect(outcome.pushed).toBe(0);
+    expect(exchange).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/sync/sync-controller.ts
+++ b/apps/web/src/lib/sync/sync-controller.ts
@@ -1,0 +1,49 @@
+/**
+ * The web sync controller (#25, ADR 0033): wires an unlocked {@link Cipher} to the
+ * HTTP transport and the local state store, exposing one `syncNow()` that runs a
+ * full round (push local, pull + apply remote winners) via the pure core engine.
+ * The cipher is derived once from the recovery secret and held in memory for the
+ * session; nothing here generates clocks — that is the state store's job.
+ */
+import {
+  type Cipher,
+  type SyncBackend,
+  type SyncOutcome,
+  type SyncStateStore,
+  runSync,
+} from "@ummahlibrary/core";
+import { createHttpSyncBackend } from "./http-sync-backend";
+import { createWebCryptoCipher } from "./web-crypto-cipher";
+import { createWebSyncStateStore } from "./web-sync-state-store";
+
+export interface SyncController {
+  /** Run one sync round now; resolves with what it pushed, pulled, and applied. */
+  syncNow(): Promise<SyncOutcome>;
+}
+
+export interface SyncControllerOptions {
+  /** Transport; defaults to the same-origin HTTP backend. */
+  backend?: SyncBackend;
+  /** Local state; defaults to the managed-key localStorage store. */
+  state?: SyncStateStore;
+}
+
+/** Wire an already-unlocked cipher to the transport and local state. */
+export function createSyncController(
+  cipher: Cipher,
+  options: SyncControllerOptions = {},
+): SyncController {
+  const backend = options.backend ?? createHttpSyncBackend();
+  const state = options.state ?? createWebSyncStateStore();
+  return {
+    syncNow: () => runSync({ cipher, backend, state }),
+  };
+}
+
+/** Build a controller from the user's recovery secret (derives the cipher once). */
+export async function createSyncControllerFromSecret(
+  secret: string,
+  options: SyncControllerOptions = {},
+): Promise<SyncController> {
+  return createSyncController(await createWebCryptoCipher(secret), options);
+}

--- a/apps/web/src/lib/sync/sync-meta.test.ts
+++ b/apps/web/src/lib/sync/sync-meta.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clockFor, reconcile, setClock } from "./sync-meta";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+const NODE = "node-a";
+const KEY = "ul.bookmarks";
+
+describe("sync-meta", () => {
+  it("stamps a new key as a first local write", () => {
+    localStorage.setItem(KEY, "[1]");
+    reconcile([KEY], new Date(1000), NODE);
+    const hlc = clockFor(KEY, NODE);
+    expect(hlc.node).toBe(NODE);
+    expect(hlc.millis).toBe(1000);
+  });
+
+  it("bumps the clock when the value changes", () => {
+    localStorage.setItem(KEY, "[1]");
+    reconcile([KEY], new Date(1000), NODE);
+    localStorage.setItem(KEY, "[1,2]");
+    reconcile([KEY], new Date(2000), NODE);
+    expect(clockFor(KEY, NODE).millis).toBe(2000);
+  });
+
+  it("does not bump when the value is unchanged", () => {
+    localStorage.setItem(KEY, "[1]");
+    reconcile([KEY], new Date(1000), NODE);
+    reconcile([KEY], new Date(5000), NODE);
+    expect(clockFor(KEY, NODE).millis).toBe(1000);
+  });
+
+  it("clockFor returns a fresh clock for an unknown key", () => {
+    expect(clockFor("ul.unknown", NODE)).toEqual({ millis: 0, counter: 0, node: NODE });
+  });
+
+  it("setClock records the remote stamp and suppresses a false change", () => {
+    setClock(KEY, "[9]", { millis: 42, counter: 0, node: "remote" });
+    expect(clockFor(KEY, NODE)).toEqual({ millis: 42, counter: 0, node: "remote" });
+    localStorage.setItem(KEY, "[9]"); // same value the remote installed
+    reconcile([KEY], new Date(9999), NODE);
+    expect(clockFor(KEY, NODE)).toEqual({ millis: 42, counter: 0, node: "remote" });
+  });
+
+  it("a local write after a remote apply carries this node", () => {
+    setClock(KEY, "[9]", { millis: 42, counter: 0, node: "remote" });
+    localStorage.setItem(KEY, "[9,10]"); // genuine local change
+    reconcile([KEY], new Date(50), NODE);
+    const hlc = clockFor(KEY, NODE);
+    expect(hlc.node).toBe(NODE);
+    expect(hlc.millis).toBe(50);
+  });
+});

--- a/apps/web/src/lib/sync/sync-meta.test.ts
+++ b/apps/web/src/lib/sync/sync-meta.test.ts
@@ -51,4 +51,19 @@ describe("sync-meta", () => {
     expect(hlc.node).toBe(NODE);
     expect(hlc.millis).toBe(50);
   });
+
+  it("leaves a never-seen absent key at the zero clock (a fresh device can't clobber)", () => {
+    // KEY absent with no prior meta: absence is "unknown", not "deleted", so the
+    // clock must stay at hlcInit — anything on the server then wins LWW.
+    reconcile([KEY], new Date(9999), NODE);
+    expect(clockFor(KEY, NODE)).toEqual({ millis: 0, counter: 0, node: NODE });
+  });
+
+  it("mints a tombstone when a key that had a value becomes null (real deletion)", () => {
+    localStorage.setItem(KEY, "[1]");
+    reconcile([KEY], new Date(1000), NODE);
+    localStorage.removeItem(KEY); // genuine deletion of an existing value
+    reconcile([KEY], new Date(2000), NODE);
+    expect(clockFor(KEY, NODE).millis).toBe(2000); // advanced ⇒ deletion propagates
+  });
 });

--- a/apps/web/src/lib/sync/sync-meta.ts
+++ b/apps/web/src/lib/sync/sync-meta.ts
@@ -1,0 +1,78 @@
+/**
+ * The sync clock sidecar (#25, ADR 0033): `ul.sync.meta` maps each managed key to
+ * its Hybrid Logical Clock plus a hash of the value at that clock. `reconcile`
+ * bumps the clock of any key whose value changed locally since the last sync
+ * (diff-at-sync), so the engine — which never mints clocks — sees a current clock
+ * per key. It lives beside the existing stores and never interprets their values.
+ */
+import { type Hlc, encodeHlc, hlcInit, hlcTick, parseHlc } from "@ummahlibrary/core";
+import { getItem, setItem } from "./storage";
+
+const META_KEY = "ul.sync.meta";
+
+interface MetaEntry {
+  /** Encoded HLC (`millis:counter:node`). */
+  hlc: string;
+  /** Hash of the value at the last clock update — detects local changes. */
+  hash: string;
+}
+type Meta = Record<string, MetaEntry>;
+
+function readMeta(): Meta {
+  const raw = getItem(META_KEY);
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Meta;
+  } catch {
+    return {};
+  }
+}
+
+function writeMeta(meta: Meta): void {
+  setItem(META_KEY, JSON.stringify(meta));
+}
+
+/** FNV-1a — a tiny non-cryptographic hash, only used to detect a changed value. */
+function hashValue(value: string | null): string {
+  if (value === null) return "_";
+  let h = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16);
+}
+
+/**
+ * Bump the clock of every managed key whose value changed locally since the last
+ * sync. A local write therefore carries this device's node, while millis/counter
+ * advance monotonically from the prior stamp; a key with no meta yet is stamped as
+ * a first local write. Persists only when something actually changed.
+ */
+export function reconcile(keys: readonly string[], now: Date, node: string): void {
+  const meta = readMeta();
+  let changed = false;
+  for (const key of keys) {
+    const hash = hashValue(getItem(key));
+    const prev = meta[key];
+    if (prev && prev.hash === hash) continue;
+    const base = prev ? (parseHlc(prev.hlc) ?? hlcInit(node)) : hlcInit(node);
+    const ticked = hlcTick(base, now);
+    meta[key] = { hlc: encodeHlc({ ...ticked, node }), hash };
+    changed = true;
+  }
+  if (changed) writeMeta(meta);
+}
+
+/** The current clock for a key (a fresh clock if it has no meta yet). */
+export function clockFor(key: string, node: string): Hlc {
+  const prev = readMeta()[key];
+  return prev ? (parseHlc(prev.hlc) ?? hlcInit(node)) : hlcInit(node);
+}
+
+/** Record the clock and value-hash for a key after applying a remote winner. */
+export function setClock(key: string, value: string | null, hlc: Hlc): void {
+  const meta = readMeta();
+  meta[key] = { hlc: encodeHlc(hlc), hash: hashValue(value) };
+  writeMeta(meta);
+}

--- a/apps/web/src/lib/sync/sync-meta.ts
+++ b/apps/web/src/lib/sync/sync-meta.ts
@@ -46,15 +46,23 @@ function hashValue(value: string | null): string {
 /**
  * Bump the clock of every managed key whose value changed locally since the last
  * sync. A local write therefore carries this device's node, while millis/counter
- * advance monotonically from the prior stamp; a key with no meta yet is stamped as
- * a first local write. Persists only when something actually changed.
+ * advance monotonically from the prior stamp; a key with an existing value but no
+ * meta yet is stamped as a first local write. Persists only when something changed.
+ *
+ * Crucially, an **absent key with no prior meta is left untouched** (clock stays at
+ * the zero `hlcInit`): on a brand-new device "I don't have this key" means *unknown*,
+ * not *deleted*. Stamping it at `now` would make the fresh device's emptiness win
+ * last-writer-wins and wipe data set on another device. A tombstone is only minted
+ * when a key that *did* have a value (prior meta) becomes null — a real deletion.
  */
 export function reconcile(keys: readonly string[], now: Date, node: string): void {
   const meta = readMeta();
   let changed = false;
   for (const key of keys) {
-    const hash = hashValue(getItem(key));
+    const raw = getItem(key);
     const prev = meta[key];
+    if (raw === null && !prev) continue; // never-seen absent key — not a deletion
+    const hash = hashValue(raw);
     if (prev && prev.hash === hash) continue;
     const base = prev ? (parseHlc(prev.hlc) ?? hlcInit(node)) : hlcInit(node);
     const ticked = hlcTick(base, now);

--- a/apps/web/src/lib/sync/sync-node.test.ts
+++ b/apps/web/src/lib/sync/sync-node.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getNodeId } from "./sync-node";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("getNodeId", () => {
+  it("generates and persists a stable id", () => {
+    const id = getNodeId();
+    expect(id).toBeTruthy();
+    expect(getNodeId()).toBe(id); // stable across calls
+    expect(localStorage.getItem("ul.sync.node")).toBe(id);
+  });
+
+  it("reuses an existing id", () => {
+    localStorage.setItem("ul.sync.node", "fixed-id");
+    expect(getNodeId()).toBe("fixed-id");
+  });
+});

--- a/apps/web/src/lib/sync/sync-node.ts
+++ b/apps/web/src/lib/sync/sync-node.ts
@@ -1,0 +1,18 @@
+/**
+ * The stable per-device id (#25, ADR 0033) used as the Hybrid Logical Clock
+ * tiebreaker. One random id per browser profile, persisted under `ul.sync.node`
+ * so a device keeps its identity across sessions. Distinct from the account: many
+ * devices share one account (one recovery phrase), but each has its own node id.
+ */
+import { getItem, setItem } from "./storage";
+
+const NODE_KEY = "ul.sync.node";
+
+/** This device's sync node id, generating and persisting one on first use. */
+export function getNodeId(): string {
+  const existing = getItem(NODE_KEY);
+  if (existing) return existing;
+  const id = crypto.randomUUID();
+  setItem(NODE_KEY, id);
+  return id;
+}

--- a/apps/web/src/lib/sync/web-sync-state-store.test.ts
+++ b/apps/web/src/lib/sync/web-sync-state-store.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SYNC_CHANGE_EVENT, createWebSyncStateStore } from "./web-sync-state-store";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+const KEY = "ul.bookmarks";
+
+describe("createWebSyncStateStore", () => {
+  it("all() returns a record per key with its value and a clock", async () => {
+    localStorage.setItem(KEY, "[3]");
+    const store = createWebSyncStateStore([KEY]);
+    const records = await store.all();
+    expect(records).toHaveLength(1);
+    expect(records[0]!.key).toBe(KEY);
+    expect(records[0]!.value).toBe("[3]");
+    expect(records[0]!.hlc.node).toBeTruthy();
+  });
+
+  it("all() reports null for an unset key", async () => {
+    const store = createWebSyncStateStore([KEY]);
+    expect((await store.all())[0]!.value).toBeNull();
+  });
+
+  it("apply() writes a value and a tombstone removes it", async () => {
+    const store = createWebSyncStateStore([KEY]);
+    await store.apply(KEY, "[7]", { millis: 5, counter: 0, node: "r" });
+    expect(localStorage.getItem(KEY)).toBe("[7]");
+    await store.apply(KEY, null, { millis: 6, counter: 0, node: "r" });
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("apply() announces the change so open UI can re-read", async () => {
+    const store = createWebSyncStateStore([KEY]);
+    const onChange = vi.fn();
+    window.addEventListener(SYNC_CHANGE_EVENT, onChange);
+    await store.apply(KEY, "[1]", { millis: 1, counter: 0, node: "r" });
+    expect(onChange).toHaveBeenCalledOnce();
+    window.removeEventListener(SYNC_CHANGE_EVENT, onChange);
+  });
+
+  it("defaults to the managed keys when none are passed", async () => {
+    const records = await createWebSyncStateStore().all();
+    expect(records.some((r) => r.key === KEY)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/sync/web-sync-state-store.ts
+++ b/apps/web/src/lib/sync/web-sync-state-store.ts
@@ -1,0 +1,42 @@
+/**
+ * Web {@link SyncStateStore} (#25, ADR 0033) over the managed `ul.*` localStorage
+ * keys. `all()` reconciles each key's clock (diff-at-sync) then reads value+clock;
+ * `apply()` installs a winning remote value at its clock and announces the change
+ * so an open tab can re-read. This is a sync layer *beside* the existing stores —
+ * it never changes how they read or write their own values, so sync staying off
+ * is a no-op for every feature.
+ */
+import type { SyncStateStore } from "@ummahlibrary/core";
+import { MANAGED_KEYS } from "./managed-keys";
+import { clockFor, reconcile, setClock } from "./sync-meta";
+import { getItem, removeItem, setItem } from "./storage";
+import { getNodeId } from "./sync-node";
+
+/** Fired (per key) after a remote value is applied, so open UI can re-read. */
+export const SYNC_CHANGE_EVENT = "ul:sync:change";
+
+function putItem(key: string, value: string | null): void {
+  if (value === null) removeItem(key);
+  else setItem(key, value);
+}
+
+function announce(key: string): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(SYNC_CHANGE_EVENT, { detail: { key } }));
+}
+
+/** Build a state store over the given managed keys (defaults to {@link MANAGED_KEYS}). */
+export function createWebSyncStateStore(keys: readonly string[] = MANAGED_KEYS): SyncStateStore {
+  return {
+    all: async () => {
+      const node = getNodeId();
+      reconcile(keys, new Date(), node);
+      return keys.map((key) => ({ key, value: getItem(key), hlc: clockFor(key, node) }));
+    },
+    apply: async (key, value, hlc) => {
+      putItem(key, value);
+      setClock(key, value, hlc);
+      announce(key);
+    },
+  };
+}


### PR DESCRIPTION
## What this is
**D1** of cross-device sync (#163, under epic #25): wires the merged engine to live
data on one key — `ul.bookmarks` — and proves the round-trip end-to-end. Off by
default; nothing changes for users who don't enable sync.

## How it works
- **`WebSyncStateStore`** implements the core `SyncStateStore` over the managed
  `ul.*` localStorage keys (just `ul.bookmarks` for now). `all()` reconciles each
  key's clock then reads value+clock; `apply()` installs a winning remote value and
  fires a `CustomEvent` so open UI re-reads.
- **`ul.sync.meta` clock sidecar** (`sync-meta.ts`) — *diff-at-sync*: before each
  sync it `hlcTick`s the clock of any key whose value changed locally. **Zero
  coupling** to the bookmark store; sync off ⇒ no behaviour change.
- **`sync-controller.ts`** wires the cipher + HTTP backend + state and runs
  `runSync`; **`sync-node.ts`** gives each device a stable HLC node id.
- Raw `localStorage` is centralized in **`storage.ts`** (ADR 0028 rule).
- **`/api/sync`** gains a **dev-only** in-memory fallback so two local profiles can
  sync against `pnpm dev` with no Upstash creds; **production still returns 501**.
- **`/sync-dev`** — a temporary demo surface (the polished Settings UI is D2).

## Correctness fix found during browser verification
The first live two-profile test exposed a real last-writer-wins bug: a brand-new
device with no value for a key was stamping it a tombstone at *now* — newer than the
original write — so an empty new device would **clobber** data set elsewhere. Fixed
in `reconcile`: an absent key with no prior meta stays at the zero clock ("unknown"
≠ "deleted"); a tombstone is only minted when a key that *had* a value becomes null.
Regression tests added. (The e2e test missed this because its fake device hardcoded
the clock — the live browser check earned its keep.)

## Tests
22 new tests: `sync-meta` (incl. the fresh-device regression), `web-sync-state-store`,
`sync-controller`, `sync-node`, the `/api/sync` dev fallback, and a **two-device
end-to-end** round-trip (real crypto + real handler: device B pulls & decrypts
device A's bookmark; server holds only ciphertext; account isolation).

## Verification
- `pnpm lint` ✓ · `pnpm typecheck` ✓ (8/8) · coverage ✓ (EXIT 0) · `pnpm build` ✓.
- **Live browser check** (two profiles on `/sync-dev`, same phrase): bookmark surah
  2 in A, Sync now in both → B shows **"pushed 1, pulled 1, applied 1"** and
  **"Surahs: 2"** pulled & decrypted from the server.

## Scope / fan-out
`ul.bookmarks` only. Scalar keys (settings, theme, reader prefs, reading position,
hifz) fan out next; `ul.collections` / `ul.ayahNotes` need element-level merge (v2)
before syncing. Upstash provisioning + deploy and the D2 Settings UI remain.

Part of #163 / #25.
