### PR TITLE
feat(web): fan out sync to reader & prayer settings + last-read (#25)

### DIFF
--- a/apps/web/src/app/sync-dev/page.tsx
+++ b/apps/web/src/app/sync-dev/page.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { N } from "@ummahlibrary/ui";
 import type { SyncOutcome } from "@ummahlibrary/core";
 import { readBookmarks, toggleBookmark } from "../../lib/bookmarks";
+import { readLastRead, writeLastRead } from "../../lib/reader-prefs-store";
 import { generateRecoveryPhrase } from "../../lib/sync/web-crypto-cipher";
 import {
   type SyncController,
@@ -41,12 +42,14 @@ export default function SyncDevPage() {
   const [secret, setSecret] = useState("");
   const [controller, setController] = useState<SyncController | null>(null);
   const [bookmarks, setBookmarks] = useState<number[]>([]);
+  const [lastRead, setLastRead] = useState<number | null>(null);
   const [outcome, setOutcome] = useState<SyncOutcome | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   const refresh = useCallback(() => {
     void readBookmarks().then(setBookmarks);
+    setLastRead(readLastRead());
   }, []);
 
   useEffect(() => {
@@ -80,6 +83,11 @@ export default function SyncDevPage() {
 
   const toggle = useCallback(async (surah: number) => {
     setBookmarks(await toggleBookmark(surah));
+  }, []);
+
+  const setLast = useCallback((surah: number) => {
+    writeLastRead(surah);
+    setLastRead(surah);
   }, []);
 
   return (
@@ -163,6 +171,22 @@ export default function SyncDevPage() {
           {DEMO_SURAHS.map((s) => (
             <button key={s} type="button" style={button} onClick={() => void toggle(s)}>
               {bookmarks.includes(s) ? `− ${s}` : `+ ${s}`}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div style={card}>
+        <div style={{ fontWeight: 700, marginBottom: 8, color: N.fg }}>
+          4 · Last-read position (a synced setting)
+        </div>
+        <div style={{ fontSize: 14, marginBottom: 10, color: N.fg }}>
+          {lastRead ? `Last read: surah ${lastRead}` : "No last-read position yet."}
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {[2, 18, 36].map((s) => (
+            <button key={s} type="button" style={button} onClick={() => setLast(s)}>
+              Set {s}
             </button>
           ))}
         </div>

--- a/apps/web/src/lib/sync/managed-keys.test.ts
+++ b/apps/web/src/lib/sync/managed-keys.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { MANAGED_KEYS } from "./managed-keys";
+
+describe("MANAGED_KEYS", () => {
+  it("syncs bookmarks and the core scalar settings", () => {
+    for (const key of [
+      "ul.bookmarks",
+      "ul.theme",
+      "ul.lastRead",
+      "ul.reciter",
+      "ul.scale",
+      "ul.prayerMethod",
+      "ul.prayerCoords",
+    ]) {
+      expect(MANAGED_KEYS).toContain(key);
+    }
+  });
+
+  it("never syncs the sync sidecar itself (would be a feedback loop)", () => {
+    expect(MANAGED_KEYS).not.toContain("ul.sync.meta");
+    expect(MANAGED_KEYS).not.toContain("ul.sync.node");
+  });
+
+  it("excludes collection/log/counter keys that need element-level merge (v2)", () => {
+    for (const key of [
+      "ul.collections",
+      "ul.ayahNotes",
+      "ul.hifz",
+      "ul.hifz.streak",
+      "ul.prayerLog",
+      "ul.qada",
+      "ul.haid",
+      "ul.tasbih2",
+      "ul.searchHistory",
+      "ul.badges",
+      "ul.readingLog",
+    ]) {
+      expect(MANAGED_KEYS).not.toContain(key);
+    }
+  });
+
+  it("excludes device-local flags", () => {
+    expect(MANAGED_KEYS).not.toContain("ul.onboarded");
+  });
+
+  it("has no duplicates", () => {
+    expect(new Set(MANAGED_KEYS).size).toBe(MANAGED_KEYS.length);
+  });
+});

--- a/apps/web/src/lib/sync/managed-keys.ts
+++ b/apps/web/src/lib/sync/managed-keys.ts
@@ -1,9 +1,41 @@
 /**
- * The `localStorage` keys sync manages (#25, ADR 0033). Deliberately starts with
- * just bookmarks — the first verifiable slice — and fans out across the `ul.*`
- * namespace as each key's merge semantics are proven. Collection-shaped keys
- * (`ul.collections`, `ul.ayahNotes`) wait for element-level merge (v2); scalar
- * keys (settings, theme, reader prefs, reading position, hifz state) are safe to
- * add here once the round-trip is demonstrated.
+ * The localStorage keys sync manages (#25, ADR 0033). These are the keys where
+ * whole-value last-writer-wins is the *correct* semantic — single-value settings,
+ * preferences, the last-read position, and the prayer/calendar configuration — so
+ * the most recent change on any device simply wins.
+ *
+ * Deliberately EXCLUDED, pending v2 element-level merge (two devices edit different
+ * entries concurrently, which whole-value LWW would clobber): `ul.collections`,
+ * `ul.ayahNotes`, `ul.hifz`(+`.streak`), the prayer/qada/haid/ramadan logs, the
+ * reading-goal logs and active plan, the tasbih/adhkar counters, `ul.asmaLearned`,
+ * `ul.badges`, and `ul.searchHistory`. Also excluded: the sync sidecar itself
+ * (`ul.sync.*` — it must never sync), device-local flags (`ul.onboarded`), and the
+ * per-page scroll offsets (sessionStorage). Notification preferences are held back
+ * too, since scheduling is per-device.
+ *
+ * `ul.bookmarks` is included as a v1 list: concurrent adds on two offline devices
+ * can still lose one until element-merge lands — an accepted v1 limitation.
  */
-export const MANAGED_KEYS: readonly string[] = ["ul.bookmarks"];
+export const MANAGED_KEYS: readonly string[] = [
+  // Saved library (v1 list)
+  "ul.bookmarks",
+  // Reader preferences
+  "ul.editions",
+  "ul.readingMode",
+  "ul.readingTranslation",
+  "ul.tafsir",
+  "ul.reciter",
+  "ul.scale",
+  "ul.wbw",
+  "ul.loop",
+  // Last-read position — "continue where you left off" across devices
+  "ul.lastRead",
+  // Theme
+  "ul.theme",
+  // Calendar + prayer-times configuration
+  "ul.hijriAdjust",
+  "ul.prayerMethod",
+  "ul.prayerMadhab",
+  "ul.prayerHighLat",
+  "ul.prayerCoords",
+];


### PR DESCRIPTION
## What this is
Fans cross-device sync out beyond bookmarks (#25) to the keys where whole-value
last-writer-wins is the *correct* semantic: reader preferences, the last-read
position, theme, and prayer/calendar configuration. Builds directly on the D1
machinery (#163) — it just expands the managed keyset; no new sync mechanics.

## Now synced (16 keys)
- **Library:** bookmarks (v1 list)
- **Reader prefs:** editions, reading mode, reading translation, tafsir, reciter,
  font scale, word-by-word, audio loop
- **Last-read position** — "continue where you left off" on another device
- **Theme**
- **Prayer / calendar:** method, madhab, high-latitude rule, coordinates, hijri adjust

## Deliberately NOT synced (need v2 element-level merge)
Collections, ayah notes, hifz cards/streak, the prayer/qada/haid/ramadan logs, the
reading-goal logs & active plan, tasbih/adhkar counters, asma-learned, badges, and
search history — two devices edit different entries concurrently, which whole-value
LWW would clobber. Also excluded: the sync sidecar (`ul.sync.*`), device-local flags
(`ul.onboarded`), and per-page scroll. A **guard test** (`managed-keys.test.ts`)
locks this classification so a key can't be added unsafely by accident.

## Tests & verification
- 5 new guard tests; full loop green (lint ✓ · typecheck 8/8 ✓ · coverage ✓ · build ✓).
- **Live browser check** (two profiles, same phrase): device A sets a bookmark *and*
  a last-read position → device B pulls **both** ("applied 2" across the 16 keys:
  "Surahs: 2" + "Last read: surah 18"). The `/sync-dev` page gained a last-read card
  to demonstrate a synced setting.

## Note
Sync is still off by default. An open tab reflects an incoming setting on its next
read/navigation (live in-tab refresh across every feature is future work). Next:
Upstash provisioning + deploy, and the D2 Settings UI.

Part of #25.
