### PR TITLE
fix(test): make `pnpm test` work for core/data/adapters/mobile

### DIFF
--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Local project config so `vitest run` (per-package, via `turbo run test`) uses
+ * THIS config instead of walking up and discovering the root `vitest.workspace.ts`
+ * — whose sibling-package paths resolve relative to the package dir and fail
+ * (e.g. `packages/<pkg>/packages/core`). The unified, coverage-gated run still
+ * goes through the root workspace via `pnpm test:coverage`. Node env (pure logic).
+ */
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/adapters/vitest.config.ts
+++ b/packages/adapters/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Local project config so `vitest run` (per-package, via `turbo run test`) uses
+ * THIS config instead of walking up and discovering the root `vitest.workspace.ts`
+ * — whose sibling-package paths resolve relative to the package dir and fail
+ * (e.g. `packages/<pkg>/packages/core`). The unified, coverage-gated run still
+ * goes through the root workspace via `pnpm test:coverage`. Node env (pure logic).
+ */
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Local project config so `vitest run` (per-package, via `turbo run test`) uses
+ * THIS config instead of walking up and discovering the root `vitest.workspace.ts`
+ * — whose sibling-package paths resolve relative to the package dir and fail
+ * (e.g. `packages/<pkg>/packages/core`). The unified, coverage-gated run still
+ * goes through the root workspace via `pnpm test:coverage`. Node env (pure logic).
+ */
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/data/vitest.config.ts
+++ b/packages/data/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Local project config so `vitest run` (per-package, via `turbo run test`) uses
+ * THIS config instead of walking up and discovering the root `vitest.workspace.ts`
+ * — whose sibling-package paths resolve relative to the package dir and fail
+ * (e.g. `packages/<pkg>/packages/core`). The unified, coverage-gated run still
+ * goes through the root workspace via `pnpm test:coverage`. Node env (pure logic).
+ */
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Problem

`pnpm test` (the `turbo run test` in the CLAUDE.md loop) fails for the four packages **without** a local vitest config — `core`, `data`, `adapters`, `mobile`. Their per-package `vitest run` walks up, discovers the root `vitest.workspace.ts`, and resolves its sibling-package paths **relative to the package dir**, e.g.:

```
Workspace config file "../../vitest.workspace.ts" references a non-existing file
or a directory: .../packages/adapters/packages/core
```

So `turbo run test` exits non-zero even though the code is fine. The packages that already have a local config (`apps/web`, `apps/extension`, `packages/ui`) work because `vitest run` uses the local config in project mode and never discovers the workspace.

## Fix

Add a minimal local `vitest.config.ts` to each of the four packages (node env, `include: ["src/**/*.test.ts"]`), matching the existing pattern. `vitest run` now uses it in project mode. The unified, coverage-gated run is unchanged — it still goes through the root workspace via `pnpm test:coverage`.

## Verification

- **`pnpm test` (turbo):** now **7/7 packages pass** (was failing on core/data/adapters/mobile).
- **`pnpm test:coverage` (workspace):** unchanged — **685 tests**, coverage thresholds intact (core 99.63/96.25, data 90.44/85.71, etc.).
- **`pnpm lint` / `pnpm typecheck` / `pnpm build`:** green.

Independent of the QA hardening PR (#167); either can merge first.
