### PR TITLE
feat(extension): cross-device sync + /api/sync CORS (D3, #25)

### DIFF
--- a/apps/extension/src/Popup.tsx
+++ b/apps/extension/src/Popup.tsx
@@ -21,6 +21,8 @@ import {
   type Locale,
 } from "./lib/locale";
 import { MESSAGES, type MessageKey } from "./lib/messages";
+import { syncIfEnabled } from "./lib/sync/sync-runtime";
+import { SyncPanel } from "./SyncPanel";
 
 const PAD = 16;
 
@@ -37,6 +39,18 @@ export function Popup() {
       setLocale(code);
       applyLocale(code);
     });
+    // Cross-device sync (#25), if the user has opted in — a no-op otherwise.
+    // Failures (offline, server unprovisioned) are swallowed; local-first carries on.
+    void syncIfEnabled()
+      .then((outcome) => {
+        // A pulled theme is now in storage + the mirror — reflect it without a reopen.
+        if (outcome && outcome.applied > 0)
+          void getStoredTheme().then((key) => {
+            setTheme(key);
+            applyTheme(key);
+          });
+      })
+      .catch(() => {});
   }, []);
 
   function changeTheme(key: ThemeKey) {
@@ -56,6 +70,7 @@ export function Popup() {
       <Header />
       <VerseOfDay t={t} />
       <SurahJump t={t} />
+      <SyncPanel />
       <Footer theme={theme} onTheme={changeTheme} locale={locale} onLocale={changeLocale} t={t} />
     </main>
   );

--- a/apps/extension/src/SyncPanel.tsx
+++ b/apps/extension/src/SyncPanel.tsx
@@ -1,0 +1,287 @@
+/**
+ * "Sync across devices" panel for the popup (#25, ADR 0033) — the extension's
+ * counterpart to the web `SyncSettings`. Collapsed to a single row by default to
+ * keep the popup uncluttered; expands to set up or manage opt-in, end-to-end-
+ * encrypted sync (generate/enter a recovery phrase, on/off, reveal/copy, sync now).
+ * The extension only syncs the prefs it shares with the web/mobile apps — the
+ * theme and the Hijri-date adjustment. The phrase is the only key; losing it means
+ * the synced data can't be recovered, which the panel states plainly.
+ */
+import { useEffect, useState } from "react";
+import { N } from "@ummahlibrary/ui";
+import type { SyncOutcome } from "@ummahlibrary/core";
+import { generateRecoveryPhrase } from "./lib/sync/web-crypto-cipher";
+import {
+  disableSync,
+  enableSync,
+  isSyncEnabled,
+  readSyncSecret,
+} from "./lib/sync/sync-settings";
+import { resetSyncRuntime, syncIfEnabled } from "./lib/sync/sync-runtime";
+
+const SERVER_DOWN = "Couldn’t reach the sync server — your data is safe on this device.";
+const DANGER = "#E5736B";
+
+function outcomeMessage(outcome: SyncOutcome | null): string {
+  if (!outcome) return "Sync is off.";
+  if (outcome.applied === 0) return "Up to date.";
+  const n = outcome.applied;
+  return `Synced — ${n} item${n === 1 ? "" : "s"} brought in.`;
+}
+
+const LABEL_STYLE = {
+  fontSize: 10.5,
+  letterSpacing: 1.2,
+  textTransform: "uppercase",
+  color: N.gold,
+  fontWeight: 700,
+  fontFamily: N.ui,
+} as const;
+
+const primaryBtn = {
+  padding: "8px 14px",
+  borderRadius: 9,
+  border: "1px solid transparent",
+  background: N.gold,
+  color: N.ink,
+  fontWeight: 700,
+  fontSize: 12.5,
+  cursor: "pointer",
+  fontFamily: N.ui,
+} as const;
+
+const secondaryBtn = {
+  padding: "8px 12px",
+  borderRadius: 9,
+  border: `1px solid ${N.border}`,
+  background: N.bg2,
+  color: N.fg,
+  fontWeight: 600,
+  fontSize: 12.5,
+  cursor: "pointer",
+  fontFamily: N.ui,
+} as const;
+
+export function SyncPanel() {
+  const [open, setOpen] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [secret, setSecret] = useState<string | null>(null);
+  const [phrase, setPhrase] = useState("");
+  const [reveal, setReveal] = useState(false);
+  const [confirmOff, setConfirmOff] = useState(false);
+  const [status, setStatus] = useState<{ ok: boolean; message: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    void Promise.all([isSyncEnabled(), readSyncSecret()]).then(([on, s]) => {
+      setEnabled(on);
+      setSecret(s);
+    });
+  }, []);
+
+  async function turnOn() {
+    const s = phrase.trim();
+    if (!s) return;
+    setBusy(true);
+    setStatus(null);
+    try {
+      // Inside the try so a failed storage write can't wedge the panel (stuck
+      // "busy", no status) — chrome.storage.set can reject (quota, or the context
+      // being invalidated by a reload while the popup is open).
+      await enableSync(s);
+      resetSyncRuntime();
+      setEnabled(true);
+      setSecret(s);
+      setStatus({ ok: true, message: outcomeMessage(await syncIfEnabled()) });
+    } catch {
+      setStatus({ ok: false, message: SERVER_DOWN });
+    } finally {
+      setBusy(false);
+      setPhrase("");
+    }
+  }
+
+  async function syncNow() {
+    setBusy(true);
+    setStatus(null);
+    try {
+      setStatus({ ok: true, message: outcomeMessage(await syncIfEnabled()) });
+    } catch {
+      setStatus({ ok: false, message: SERVER_DOWN });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function turnOff() {
+    void disableSync();
+    resetSyncRuntime();
+    setEnabled(false);
+    setSecret(null);
+    setReveal(false);
+    setConfirmOff(false);
+    setStatus(null);
+  }
+
+  function copyPhrase() {
+    if (secret) void navigator.clipboard?.writeText(secret).catch(() => {});
+  }
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          background: "transparent",
+          border: "none",
+          padding: 0,
+          cursor: "pointer",
+        }}
+      >
+        <span style={LABEL_STYLE}>Sync across devices</span>
+        <span style={{ fontSize: 11, color: enabled ? N.gold : N.muted, fontFamily: N.ui }}>
+          {enabled ? "On" : "Off"} {open ? "▴" : "▾"}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          style={{
+            background: N.card,
+            border: `1px solid ${N.border}`,
+            borderRadius: 12,
+            padding: 12,
+            display: "flex",
+            flexDirection: "column",
+            gap: 10,
+          }}
+        >
+          <p style={{ margin: 0, fontSize: 11.5, lineHeight: 1.5, color: N.muted, fontFamily: N.ui }}>
+            Keep your theme and Hijri-date setting in step with the Ummah Library app and website —
+            end-to-end encrypted, no account.
+          </p>
+
+          {enabled ? (
+            <>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <button
+                  type="button"
+                  style={{ ...primaryBtn, opacity: busy ? 0.6 : 1 }}
+                  disabled={busy}
+                  onClick={() => void syncNow()}
+                >
+                  {busy ? "Syncing…" : "Sync now"}
+                </button>
+                <button type="button" style={secondaryBtn} onClick={() => setReveal((r) => !r)}>
+                  {reveal ? "Hide phrase" : "Show phrase"}
+                </button>
+              </div>
+              {reveal && secret && (
+                <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                  <code
+                    style={{
+                      flex: 1,
+                      minWidth: 140,
+                      padding: "6px 9px",
+                      borderRadius: 8,
+                      background: N.bg2,
+                      border: `1px solid ${N.border}`,
+                      color: N.fg,
+                      fontFamily: "monospace",
+                      fontSize: 12,
+                    }}
+                  >
+                    {secret}
+                  </code>
+                  <button type="button" style={secondaryBtn} onClick={copyPhrase}>
+                    Copy
+                  </button>
+                </div>
+              )}
+              {confirmOff ? (
+                <button
+                  type="button"
+                  style={{ ...secondaryBtn, color: DANGER, alignSelf: "flex-start" }}
+                  onClick={turnOff}
+                >
+                  Tap again to turn off sync
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  style={{
+                    background: "transparent",
+                    border: "none",
+                    color: DANGER,
+                    fontSize: 12,
+                    fontFamily: N.ui,
+                    cursor: "pointer",
+                    alignSelf: "flex-start",
+                    padding: 0,
+                  }}
+                  onClick={() => setConfirmOff(true)}
+                >
+                  Turn off sync
+                </button>
+              )}
+            </>
+          ) : (
+            <>
+              <input
+                value={phrase}
+                onChange={(e) => setPhrase(e.target.value)}
+                placeholder="Enter or generate a phrase"
+                aria-label="Recovery phrase"
+                spellCheck={false}
+                autoCapitalize="characters"
+                style={{
+                  background: N.bg2,
+                  color: N.fg,
+                  border: `1px solid ${N.border}`,
+                  borderRadius: 9,
+                  padding: "8px 10px",
+                  fontSize: 12.5,
+                  fontFamily: "monospace",
+                  outline: "none",
+                }}
+              />
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <button
+                  type="button"
+                  style={secondaryBtn}
+                  onClick={() => setPhrase(generateRecoveryPhrase())}
+                >
+                  Generate
+                </button>
+                <button
+                  type="button"
+                  style={{ ...primaryBtn, opacity: phrase.trim() && !busy ? 1 : 0.5 }}
+                  disabled={!phrase.trim() || busy}
+                  onClick={() => void turnOn()}
+                >
+                  {busy ? "Turning on…" : "Turn on sync"}
+                </button>
+              </div>
+            </>
+          )}
+
+          {status && (
+            <p style={{ margin: 0, fontSize: 11.5, color: status.ok ? N.gold : DANGER, fontFamily: N.ui }}>
+              {status.message}
+            </p>
+          )}
+
+          <p style={{ margin: 0, fontSize: 10.5, lineHeight: 1.5, color: N.faint, fontFamily: N.ui }}>
+            ⚠ Your phrase is the only key — we can’t recover it. If you lose it, the synced data
+            can’t be decrypted.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/extension/src/lib/storage.ts
+++ b/apps/extension/src/lib/storage.ts
@@ -51,8 +51,23 @@ async function write(area: Area, key: string, value: unknown): Promise<void> {
   }
 }
 
+async function remove(area: Area, key: string): Promise<void> {
+  const ca = chromeArea(area);
+  if (ca) {
+    await ca.remove(key);
+    return;
+  }
+  try {
+    localStorage.removeItem(NS + key);
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
+}
+
 export const getPref = <T>(key: string, fallback: T): Promise<T> => read("sync", key, fallback);
 export const setPref = (key: string, value: unknown): Promise<void> => write("sync", key, value);
 
 export const getCache = <T>(key: string, fallback: T): Promise<T> => read("local", key, fallback);
 export const setCache = (key: string, value: unknown): Promise<void> => write("local", key, value);
+/** Forget a device-local value entirely (used to erase the sync secret on disable). */
+export const removeCache = (key: string): Promise<void> => remove("local", key);

--- a/apps/extension/src/lib/sync/ext-sync-state-store.test.ts
+++ b/apps/extension/src/lib/sync/ext-sync-state-store.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Extension SyncStateStore tests (#25, ADR 0033). The store bridges the shared
+ * `ul.*` sync keys to the extension's own `chrome.storage.sync` prefs and value
+ * formats. Verifies presence-aware reads (a never-set pref is `null`, not its
+ * default, so a fresh install can't clobber another device) and that applying a
+ * remote winner writes it back into the extension's storage.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MANAGED_KEYS } from "@ummahlibrary/core";
+import { getPref, setPref } from "../storage";
+import { EXT_MANAGED, createExtSyncStateStore } from "./ext-sync-state-store";
+
+function area() {
+  const store: Record<string, unknown> = {};
+  return {
+    store,
+    get: (key: string) => Promise.resolve(key in store ? { [key]: store[key] } : {}),
+    set: (obj: Record<string, unknown>) => {
+      Object.assign(store, obj);
+      return Promise.resolve();
+    },
+    remove: (key: string) => {
+      delete store[key];
+      return Promise.resolve();
+    },
+  };
+}
+beforeEach(() => {
+  (globalThis as { chrome?: unknown }).chrome = { storage: { sync: area(), local: area() } };
+});
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+  localStorage.clear();
+});
+
+describe("EXT_MANAGED", () => {
+  it("syncs exactly theme + hijriAdjust, and is a subset of the shared contract", () => {
+    expect([...EXT_MANAGED].sort()).toEqual(["ul.hijriAdjust", "ul.theme"]);
+    for (const k of EXT_MANAGED) expect(MANAGED_KEYS).toContain(k);
+  });
+});
+
+describe("createExtSyncStateStore", () => {
+  it("reads set prefs as the shared serialized values", async () => {
+    await setPref("theme", "emerald");
+    await setPref("hijriAdjust", 2);
+    const recs = await createExtSyncStateStore().all();
+    const byKey = Object.fromEntries(recs.map((r) => [r.key, r.value]));
+    expect(byKey["ul.theme"]).toBe("emerald");
+    expect(byKey["ul.hijriAdjust"]).toBe("2"); // web stores String(n)
+    expect(recs.find((r) => r.key === "ul.theme")!.hlc.millis).toBeGreaterThan(0);
+  });
+
+  it("reports a never-set pref as null at the zero clock (no clobber)", async () => {
+    const recs = await createExtSyncStateStore().all();
+    for (const r of recs) {
+      expect(r.value).toBeNull();
+      expect(r.hlc).toEqual({ millis: 0, counter: 0, node: r.hlc.node });
+      expect(r.hlc.node.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("applies a remote theme + hijriAdjust back into the extension's own storage", async () => {
+    const store = createExtSyncStateStore();
+    await store.apply("ul.theme", "midnight", { millis: 9, counter: 0, node: "peer" });
+    await store.apply("ul.hijriAdjust", "1", { millis: 9, counter: 0, node: "peer" });
+    expect(await getPref("theme", "x")).toBe("midnight");
+    expect(await getPref("hijriAdjust", 0)).toBe(1); // parsed back to a number
+  });
+
+  it("clamps an out-of-range hijriAdjust to the project-wide [-2, 2] domain on apply", async () => {
+    await createExtSyncStateStore().apply("ul.hijriAdjust", "5", { millis: 1, counter: 0, node: "p" });
+    expect(await getPref("hijriAdjust", 0)).toBe(2);
+  });
+
+  it("ignores a non-finite hijriAdjust rather than writing garbage", async () => {
+    await createExtSyncStateStore().apply("ul.hijriAdjust", "NaN", { millis: 1, counter: 0, node: "p" });
+    expect(await getPref("hijriAdjust", 0)).toBe(0); // unchanged
+  });
+
+  it("rejects an unknown theme value rather than persisting/propagating it", async () => {
+    await setPref("theme", "emerald");
+    await createExtSyncStateStore().apply("ul.theme", "not-a-theme", { millis: 9, counter: 0, node: "p" });
+    expect(await getPref("theme", "x")).toBe("emerald"); // unchanged
+  });
+
+  it("does not resurrect/re-push a value after a tombstone apply (meta stays consistent)", async () => {
+    await setPref("theme", "emerald");
+    const store = createExtSyncStateStore();
+    await store.all(); // establish local meta for ul.theme
+    const peer = { millis: 9_000_000, counter: 0, node: "peer" };
+    await store.apply("ul.theme", null, peer); // deletion winner: bridge no-ops, keeps "emerald"
+    const theme = (await store.all()).find((r) => r.key === "ul.theme")!;
+    expect(theme.value).toBe("emerald"); // local choice retained
+    expect(theme.hlc).toEqual(peer); // NOT re-bumped → won't re-push and clobber the peer
+  });
+});

--- a/apps/extension/src/lib/sync/ext-sync-state-store.ts
+++ b/apps/extension/src/lib/sync/ext-sync-state-store.ts
@@ -1,0 +1,93 @@
+/**
+ * Extension {@link SyncStateStore} (#25, ADR 0033). The extension keeps its prefs
+ * under short `chrome.storage.sync` keys with native value types, while sync speaks
+ * the shared `ul.*` key names and serialized string values (the contract in
+ * `core/sync-keys.ts`). This store bridges the two: it maps only the keys the
+ * extension actually has that overlap the contract — `ul.theme` and
+ * `ul.hijriAdjust` — reading each as the same string the web app stores so the
+ * values merge across platforms, and writing a remote winner back into the
+ * extension's own storage. A presence-aware read reports a never-set pref as
+ * `null` (not its default) so a fresh install never pushes a value the user never
+ * chose, and never clobbers another device.
+ */
+import { MANAGED_KEYS, type SyncStateStore } from "@ummahlibrary/core";
+import { getPref, setPref } from "../storage";
+import { THEME_KEYS } from "../theme";
+import { writeThemeMirror } from "../theme-store";
+import { clockOf, loadMeta, reconcileMeta, saveMeta, setClockIn } from "./sync-meta";
+import { getNodeId } from "./sync-node";
+
+/** The project-wide Hijri adjustment domain (mirrors `apps/web/src/lib/hijri.ts`). */
+const clampHijriAdjust = (n: number): number => Math.max(-2, Math.min(2, Math.trunc(n)));
+
+/** A two-way bridge between one `ul.*` sync key and the extension's own storage. */
+interface KeyBridge {
+  /** The current value as the shared serialized string, or `null` if never set. */
+  read(): Promise<string | null>;
+  /** Apply a remote winner (or a deletion) into the extension's storage. */
+  write(value: string | null): Promise<void>;
+}
+
+const BRIDGES: Record<string, KeyBridge> = {
+  // Theme: web stores `ul.theme` as the raw ThemeKey string; the extension stores
+  // the same string under `theme`. Store raw on apply — the popup validates the
+  // key on read (unknown → default) and applies it pre-paint via the mirror.
+  "ul.theme": {
+    read: async () => (await getPref<string | undefined>("theme", undefined)) ?? null,
+    write: async (value) => {
+      if (value === null) return; // no "clear theme" affordance — leave the local choice
+      // Reject an unknown ThemeKey from a non-conforming/peer value rather than
+      // persisting and re-propagating garbage (the UI also validates on read).
+      if (!(THEME_KEYS as readonly string[]).includes(value)) return;
+      await setPref("theme", value);
+      writeThemeMirror(value);
+    },
+  },
+  // Hijri adjustment: web stores `ul.hijriAdjust` as `String(n)`; the extension
+  // stores the number under `hijriAdjust`, clamped to the same [-2, 2] domain every
+  // other consumer enforces (a non-conforming peer value would otherwise show a
+  // Hijri date off by that many days).
+  "ul.hijriAdjust": {
+    read: async () => {
+      const v = await getPref<number | undefined>("hijriAdjust", undefined);
+      return v === undefined ? null : String(v);
+    },
+    write: async (value) => {
+      if (value === null) return;
+      const n = Number(value);
+      if (Number.isFinite(n)) await setPref("hijriAdjust", clampHijriAdjust(n));
+    },
+  },
+};
+
+/** The `ul.*` keys this build syncs — a subset of the shared contract. */
+export const EXT_MANAGED: readonly string[] = Object.keys(BRIDGES).filter((k) =>
+  MANAGED_KEYS.includes(k),
+);
+
+export function createExtSyncStateStore(): SyncStateStore {
+  return {
+    all: async () => {
+      const node = await getNodeId();
+      const values = new Map<string, string | null>();
+      for (const key of EXT_MANAGED) values.set(key, await BRIDGES[key]!.read());
+      const meta = await loadMeta();
+      if (reconcileMeta(meta, EXT_MANAGED, values, new Date(), node)) await saveMeta(meta);
+      return EXT_MANAGED.map((key) => ({ key, value: values.get(key) ?? null, hlc: clockOf(meta, key, node) }));
+    },
+    apply: async (key, value, hlc) => {
+      const bridge = BRIDGES[key];
+      if (!bridge) return; // not a key this build manages
+      await bridge.write(value);
+      // Record the clock against what was ACTUALLY stored, not the incoming value:
+      // the bridge may have clamped it, rejected an unknown theme, or no-op'd a
+      // deletion (we keep the local choice). Hashing the incoming value instead
+      // would make the next `all()` see a mismatch and spuriously re-push the old
+      // value — resurrecting it and clobbering a peer under LWW.
+      const stored = await bridge.read();
+      const meta = await loadMeta();
+      setClockIn(meta, key, stored, hlc);
+      await saveMeta(meta);
+    },
+  };
+}

--- a/apps/extension/src/lib/sync/http-sync-backend.test.ts
+++ b/apps/extension/src/lib/sync/http-sync-backend.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Extension HTTP backend tests (#25, ADR 0033): posts ciphertext under a Bearer
+ * accountId to the deployed `${BASE_URL}/api/sync`, and drops reply entries with a
+ * malformed clock (the server is untrusted).
+ */
+import { describe, expect, it } from "vitest";
+import type { SyncEntry } from "@ummahlibrary/core";
+import { createHttpSyncBackend } from "./http-sync-backend";
+
+const good: SyncEntry = { id: "a", hlc: { millis: 5, counter: 0, node: "n1" }, ciphertext: "c", nonce: "i" };
+const resp = (body: unknown, ok = true, status = 200): Response =>
+  ({ ok, status, json: async () => body }) as unknown as Response;
+
+describe("createHttpSyncBackend (extension)", () => {
+  it("defaults to the apex /api/sync and sends a Bearer accountId", async () => {
+    let captured: { url: string; init: RequestInit } | null = null;
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      captured = { url, init };
+      return resp({ entries: [good] });
+    }) as unknown as typeof fetch;
+    const out = await createHttpSyncBackend({ fetchImpl }).exchange("acc", [good]);
+    expect(captured!.url).toBe("https://ummahlibrary.org/api/sync");
+    expect((captured!.init.headers as Record<string, string>).authorization).toBe("Bearer acc");
+    expect(out).toEqual([good]);
+  });
+
+  it("drops reply entries with a malformed clock", async () => {
+    const bad = [good, { id: "z", hlc: { millis: -1, counter: 0, node: "n" }, ciphertext: "c", nonce: "i" }, "x"];
+    const fetchImpl = (async () => resp({ entries: bad })) as unknown as typeof fetch;
+    expect(await createHttpSyncBackend({ fetchImpl }).exchange("a", [])).toEqual([good]);
+  });
+
+  it("throws on a non-OK response", async () => {
+    const fetchImpl = (async () => resp({}, false, 501)) as unknown as typeof fetch;
+    await expect(createHttpSyncBackend({ fetchImpl }).exchange("a", [])).rejects.toThrow(/501/);
+  });
+});

--- a/apps/extension/src/lib/sync/http-sync-backend.ts
+++ b/apps/extension/src/lib/sync/http-sync-backend.ts
@@ -1,0 +1,54 @@
+/**
+ * Extension implementation of the core {@link SyncBackend} port (#25, ADR 0033):
+ * one HTTPS round trip to the deployed `/api/sync` (the apex `BASE_URL` the popup
+ * already reads from). The `accountId` rides as a Bearer capability; only
+ * ciphertext travels in the body. The endpoint is cross-origin from the
+ * `chrome-extension://` popup, which is why the route answers a CORS preflight.
+ * `fetch` is injected so tests need no network. The server is untrusted, so each
+ * returned entry's shape and clock are re-validated before use.
+ */
+import type { SyncBackend, SyncEntry } from "@ummahlibrary/core";
+import { BASE_URL } from "../config";
+
+const isClockInt = (v: unknown): boolean =>
+  typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= Number.MAX_SAFE_INTEGER;
+
+function isValidEntry(e: unknown): e is SyncEntry {
+  if (typeof e !== "object" || e === null) return false;
+  const x = e as Record<string, unknown>;
+  if (typeof x.id !== "string" || x.id.length === 0) return false;
+  if (typeof x.nonce !== "string") return false;
+  if (x.ciphertext !== null && typeof x.ciphertext !== "string") return false;
+  const h = x.hlc as Record<string, unknown> | null;
+  if (typeof h !== "object" || h === null) return false;
+  return (
+    isClockInt(h.millis) &&
+    isClockInt(h.counter) &&
+    typeof h.node === "string" &&
+    h.node.length >= 1
+  );
+}
+
+export interface HttpSyncBackendOptions {
+  /** Endpoint to POST to; defaults to the deployed `${BASE_URL}/api/sync`. */
+  endpoint?: string;
+  /** Injected fetch — defaults to the global; tests pass a stub. */
+  fetchImpl?: typeof fetch;
+}
+
+export function createHttpSyncBackend(options: HttpSyncBackendOptions = {}): SyncBackend {
+  const endpoint = options.endpoint ?? `${BASE_URL}/api/sync`;
+  const doFetch = options.fetchImpl ?? fetch;
+  return {
+    exchange: async (accountId, entries) => {
+      const res = await doFetch(endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${accountId}` },
+        body: JSON.stringify({ entries }),
+      });
+      if (!res.ok) throw new Error(`sync failed (${res.status})`);
+      const data = (await res.json()) as { entries?: unknown };
+      return Array.isArray(data.entries) ? data.entries.filter(isValidEntry) : [];
+    },
+  };
+}

--- a/apps/extension/src/lib/sync/sync-controller.ts
+++ b/apps/extension/src/lib/sync/sync-controller.ts
@@ -1,0 +1,43 @@
+/**
+ * The extension sync controller (#25, ADR 0033): wires an unlocked {@link Cipher}
+ * to the HTTP transport and the extension state store, exposing one `syncNow()`
+ * that runs a full round via the pure core engine. The cipher is derived once from
+ * the recovery secret; nothing here generates clocks — that is the state store's job.
+ */
+import {
+  type Cipher,
+  type SyncBackend,
+  type SyncOutcome,
+  type SyncStateStore,
+  runSync,
+} from "@ummahlibrary/core";
+import { createHttpSyncBackend } from "./http-sync-backend";
+import { createExtSyncStateStore } from "./ext-sync-state-store";
+import { createWebCryptoCipher } from "./web-crypto-cipher";
+
+export interface SyncController {
+  syncNow(): Promise<SyncOutcome>;
+}
+
+export interface SyncControllerOptions {
+  backend?: SyncBackend;
+  state?: SyncStateStore;
+}
+
+export function createSyncController(
+  cipher: Cipher,
+  options: SyncControllerOptions = {},
+): SyncController {
+  const backend = options.backend ?? createHttpSyncBackend();
+  const state = options.state ?? createExtSyncStateStore();
+  return {
+    syncNow: () => runSync({ cipher, backend, state }),
+  };
+}
+
+export async function createSyncControllerFromSecret(
+  secret: string,
+  options: SyncControllerOptions = {},
+): Promise<SyncController> {
+  return createSyncController(await createWebCryptoCipher(secret), options);
+}

--- a/apps/extension/src/lib/sync/sync-e2e.test.ts
+++ b/apps/extension/src/lib/sync/sync-e2e.test.ts
@@ -1,0 +1,101 @@
+/**
+ * End-to-end extension sync (#25, ADR 0033). Drives the real stack — WebCrypto
+ * cipher, the chrome.storage state store, the clock sidecar, and the core engine —
+ * against an in-memory backend that merges like the server. Two "installs" are
+ * simulated by swapping the chrome.storage areas (a fresh install) while the server
+ * keeps its state. Proves a theme set in one install reaches the other and that a
+ * later change propagates back, and that a different phrase stays isolated.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { type SyncBackend, type SyncEntry, mergeEntries } from "@ummahlibrary/core";
+import { getPref, setPref } from "../storage";
+import { createExtSyncStateStore } from "./ext-sync-state-store";
+import { createSyncController } from "./sync-controller";
+import { createWebCryptoCipher } from "./web-crypto-cipher";
+
+function area() {
+  const store: Record<string, unknown> = {};
+  return {
+    store,
+    get: (key: string) => Promise.resolve(key in store ? { [key]: store[key] } : {}),
+    set: (obj: Record<string, unknown>) => {
+      Object.assign(store, obj);
+      return Promise.resolve();
+    },
+    remove: (key: string) => {
+      delete store[key];
+      return Promise.resolve();
+    },
+  };
+}
+/** Simulate a fresh install: brand-new chrome.storage areas. */
+function freshInstall(): void {
+  (globalThis as { chrome?: unknown }).chrome = { storage: { sync: area(), local: area() } };
+}
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+  localStorage.clear();
+});
+
+function inMemoryServer(): SyncBackend {
+  const store = new Map<string, SyncEntry[]>();
+  return {
+    exchange: async (accountId, entries) => {
+      const { merged } = mergeEntries(store.get(accountId) ?? [], entries);
+      store.set(accountId, merged);
+      return merged;
+    },
+  };
+}
+
+const PHRASE = "MBTQ7-K9XAR-2P4WD-NHJ58-VYZ36";
+
+describe("two-install extension sync round-trip", () => {
+  it("carries the theme to a second install and propagates a later change back", async () => {
+    const cipher = await createWebCryptoCipher(PHRASE);
+    const backend = inMemoryServer();
+    const run = () => createSyncController(cipher, { backend, state: createExtSyncStateStore() }).syncNow();
+
+    // Install A picks a theme and pushes it.
+    freshInstall();
+    await setPref("theme", "emerald");
+    const a1 = await run();
+    expect(a1.pushed).toBe(1);
+    expect(a1.applied).toBe(0);
+
+    // Install B (fresh) with the same phrase pulls and applies it.
+    freshInstall();
+    const b1 = await run();
+    expect(b1.applied).toBe(1);
+    expect(await getPref("theme", "x")).toBe("emerald");
+
+    // Install B changes the theme and syncs it up.
+    await setPref("theme", "midnight");
+    const b2 = await run();
+    expect(b2.pushed).toBe(1);
+
+    // Install A (fresh again) pulls the update.
+    freshInstall();
+    const a2 = await run();
+    expect(a2.applied).toBe(1);
+    expect(await getPref("theme", "x")).toBe("midnight");
+  });
+
+  it("keeps a different phrase on a separate account (isolation)", async () => {
+    const me = await createWebCryptoCipher(PHRASE);
+    const stranger = await createWebCryptoCipher("ZZZZZ-ZZZZZ-ZZZZZ-ZZZZZ-ZZZZZ");
+    const backend = inMemoryServer();
+
+    freshInstall();
+    await setPref("theme", "emerald");
+    await createSyncController(me, { backend, state: createExtSyncStateStore() }).syncNow();
+
+    freshInstall();
+    const out = await createSyncController(stranger, {
+      backend,
+      state: createExtSyncStateStore(),
+    }).syncNow();
+    expect(out.applied).toBe(0);
+    expect(await getPref("theme", "unset")).toBe("unset");
+  });
+});

--- a/apps/extension/src/lib/sync/sync-meta.test.ts
+++ b/apps/extension/src/lib/sync/sync-meta.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Extension sync-meta tests (#25, ADR 0033). Same diff-at-sync clock logic as
+ * web/mobile, over chrome.storage.local — including the never-tombstone-a-
+ * never-seen-key invariant and dropping a structurally-corrupt sidecar entry.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clockOf, loadMeta, reconcileMeta, saveMeta, setClockIn, type Meta } from "./sync-meta";
+
+function area() {
+  const store: Record<string, unknown> = {};
+  return {
+    store,
+    get: (key: string) => Promise.resolve(key in store ? { [key]: store[key] } : {}),
+    set: (obj: Record<string, unknown>) => {
+      Object.assign(store, obj);
+      return Promise.resolve();
+    },
+  };
+}
+let local: ReturnType<typeof area>;
+beforeEach(() => {
+  local = area();
+  (globalThis as { chrome?: unknown }).chrome = { storage: { sync: area(), local } };
+});
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+  localStorage.clear();
+});
+
+const NOW = new Date(1_700_000_000_000);
+
+describe("reconcileMeta", () => {
+  it("stamps a key that has a value but no prior meta", () => {
+    const meta: Meta = {};
+    expect(reconcileMeta(meta, ["ul.theme"], new Map([["ul.theme", "emerald"]]), NOW, "n1")).toBe(true);
+    expect(meta["ul.theme"]!.hlc).toEqual({ millis: NOW.getTime(), counter: 0, node: "n1" });
+  });
+
+  it("leaves a never-seen absent key untouched", () => {
+    const meta: Meta = {};
+    expect(reconcileMeta(meta, ["ul.theme"], new Map([["ul.theme", null]]), NOW, "n1")).toBe(false);
+    expect(meta["ul.theme"]).toBeUndefined();
+  });
+
+  it("tombstones a key that had a value and is now absent", () => {
+    const meta: Meta = { "ul.theme": { hlc: { millis: 1, counter: 0, node: "n1" }, hash: "abc" } };
+    expect(reconcileMeta(meta, ["ul.theme"], new Map([["ul.theme", null]]), NOW, "n1")).toBe(true);
+    expect(meta["ul.theme"]!.hash).toBe("_");
+  });
+});
+
+describe("loadMeta / saveMeta", () => {
+  it("round-trips a structural clock and reads it back", async () => {
+    const meta: Meta = { "ul.theme": { hlc: { millis: 5, counter: 2, node: "abc" }, hash: "h" } };
+    await saveMeta(meta);
+    expect(await loadMeta()).toEqual(meta);
+    expect(clockOf(await loadMeta(), "ul.theme", "n1")).toEqual({ millis: 5, counter: 2, node: "abc" });
+  });
+
+  it("drops a corrupt entry rather than trusting it", async () => {
+    const meta: Meta = {};
+    setClockIn(meta, "ok", "v", { millis: 1, counter: 0, node: "a" });
+    await saveMeta(meta);
+    // hand-corrupt the stored sidecar
+    local.store["sync.meta"] = { ...(local.store["sync.meta"] as object), bad: { hlc: { millis: "x" }, hash: "h" } };
+    expect(Object.keys(await loadMeta())).toEqual(["ok"]);
+  });
+});

--- a/apps/extension/src/lib/sync/sync-meta.ts
+++ b/apps/extension/src/lib/sync/sync-meta.ts
@@ -1,0 +1,103 @@
+/**
+ * The sync clock sidecar (#25, ADR 0033) for the extension: a `Meta` map from each
+ * managed key to its Hybrid Logical Clock + a hash of the value at that clock,
+ * stored device-locally (`chrome.storage.local` via `getCache`/`setCache`, key
+ * `sync.meta`). Mirrors the mobile adapter's logic — pure in-memory helpers plus
+ * async load/save — since `chrome.storage` is async. Never synced; never browser-
+ * mirrored. Same never-tombstone-a-never-seen-key invariant as web/mobile.
+ */
+import { type Hlc, hlcInit, hlcTick, parseHlc } from "@ummahlibrary/core";
+import { getCache, setCache } from "../storage";
+
+const META_KEY = "sync.meta";
+
+export interface MetaEntry {
+  hlc: Hlc;
+  hash: string;
+}
+export type Meta = Record<string, MetaEntry>;
+
+function isValidHlc(v: unknown): v is Hlc {
+  if (v === null || typeof v !== "object") return false;
+  const h = v as { millis?: unknown; counter?: unknown; node?: unknown };
+  return (
+    typeof h.millis === "number" &&
+    Number.isInteger(h.millis) &&
+    h.millis >= 0 &&
+    typeof h.counter === "number" &&
+    Number.isInteger(h.counter) &&
+    h.counter >= 0 &&
+    typeof h.node === "string" &&
+    h.node.length >= 1
+  );
+}
+
+/** Read the sidecar, dropping any structurally-corrupt entry rather than trusting it. */
+export async function loadMeta(): Promise<Meta> {
+  const raw = await getCache<unknown>(META_KEY, {});
+  if (raw === null || typeof raw !== "object") return {};
+  const meta: Meta = {};
+  for (const [key, entry] of Object.entries(raw as Record<string, unknown>)) {
+    if (entry === null || typeof entry !== "object") continue;
+    const e = entry as { hlc?: unknown; hash?: unknown };
+    const hlc = typeof e.hlc === "string" ? parseHlc(e.hlc) : e.hlc;
+    if (isValidHlc(hlc) && typeof e.hash === "string") meta[key] = { hlc, hash: e.hash };
+  }
+  return meta;
+}
+
+export async function saveMeta(meta: Meta): Promise<void> {
+  await setCache(META_KEY, meta);
+}
+
+/** FNV-1a — a tiny non-cryptographic hash, only used to detect a changed value. */
+function hashValue(value: string | null): string {
+  if (value === null) return "_";
+  let h = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16);
+}
+
+/**
+ * Bump the clock of every managed key whose value changed locally since the last
+ * sync, mutating `meta` in place and returning whether anything changed. An absent
+ * key with no prior meta is left untouched (no clock): "I don't have this key"
+ * means *unknown*, not *deleted*, so a fresh device can't wipe another's data via
+ * last-writer-wins. A tombstone is only minted when a key that *had* a value
+ * (prior meta) becomes null.
+ */
+export function reconcileMeta(
+  meta: Meta,
+  keys: readonly string[],
+  valuesByKey: Map<string, string | null>,
+  now: Date,
+  node: string,
+): boolean {
+  let changed = false;
+  for (const key of keys) {
+    const raw = valuesByKey.get(key) ?? null;
+    const prev = meta[key];
+    if (raw === null && !prev) continue;
+    const hash = hashValue(raw);
+    if (prev && prev.hash === hash) continue;
+    const base = prev ? prev.hlc : hlcInit(node);
+    const ticked = hlcTick(base, now);
+    meta[key] = { hlc: { ...ticked, node }, hash };
+    changed = true;
+  }
+  return changed;
+}
+
+/** The current clock for a key (a fresh clock if it has no meta yet). */
+export function clockOf(meta: Meta, key: string, node: string): Hlc {
+  const prev = meta[key];
+  return prev ? prev.hlc : hlcInit(node);
+}
+
+/** Record the clock and value-hash for a key after applying a remote winner (mutates `meta`). */
+export function setClockIn(meta: Meta, key: string, value: string | null, hlc: Hlc): void {
+  meta[key] = { hlc, hash: hashValue(value) };
+}

--- a/apps/extension/src/lib/sync/sync-node.ts
+++ b/apps/extension/src/lib/sync/sync-node.ts
@@ -1,0 +1,17 @@
+/**
+ * The stable per-device id (#25, ADR 0033) used as the HLC tiebreaker. One random
+ * id per extension install, kept device-locally (`chrome.storage.local`, key
+ * `sync.node`) so it isn't browser-mirrored across profiles — each install is its
+ * own sync node even when they share an account (one recovery phrase).
+ */
+import { getCache, setCache } from "../storage";
+
+const NODE_KEY = "sync.node";
+
+export async function getNodeId(): Promise<string> {
+  const existing = await getCache<string>(NODE_KEY, "");
+  if (existing) return existing;
+  const id = crypto.randomUUID();
+  await setCache(NODE_KEY, id);
+  return id;
+}

--- a/apps/extension/src/lib/sync/sync-runtime.ts
+++ b/apps/extension/src/lib/sync/sync-runtime.ts
@@ -1,0 +1,45 @@
+/**
+ * The extension's active sync controller (#25, ADR 0033). Derives the cipher once
+ * from the stored secret (PBKDF2 is deliberately slow) and caches it by secret, so
+ * the popup-open trigger and the "Sync now" button share one instance.
+ * `syncIfEnabled` is the single entry point — a no-op (resolves `null`) when sync
+ * is off — and coalesces concurrent calls; `resetSyncRuntime()` clears both the
+ * cached cipher and any in-flight round so a just-enabled sync starts fresh rather
+ * than being coalesced onto a round that sampled sync as OFF.
+ */
+import type { SyncOutcome } from "@ummahlibrary/core";
+import { type SyncController, createSyncControllerFromSecret } from "./sync-controller";
+import { isSyncEnabled, readSyncSecret } from "./sync-settings";
+
+let cached: { secret: string; controller: Promise<SyncController> } | null = null;
+let inFlight: Promise<SyncOutcome | null> | null = null;
+
+function controllerFor(secret: string): Promise<SyncController> {
+  if (cached?.secret !== secret) {
+    cached = { secret, controller: createSyncControllerFromSecret(secret) };
+  }
+  return cached.controller;
+}
+
+async function run(): Promise<SyncOutcome | null> {
+  if (!(await isSyncEnabled())) return null;
+  const secret = await readSyncSecret();
+  if (!secret) return null;
+  return (await controllerFor(secret)).syncNow();
+}
+
+/** Run one sync round if sync is enabled; resolves `null` when it's off. Coalesces concurrent calls. */
+export function syncIfEnabled(): Promise<SyncOutcome | null> {
+  if (inFlight) return inFlight;
+  const round = run().finally(() => {
+    if (inFlight === round) inFlight = null;
+  });
+  inFlight = round;
+  return round;
+}
+
+/** Drop the cached controller and any in-flight round — call after enabling/disabling/changing the secret. */
+export function resetSyncRuntime(): void {
+  cached = null;
+  inFlight = null;
+}

--- a/apps/extension/src/lib/sync/sync-settings.test.ts
+++ b/apps/extension/src/lib/sync/sync-settings.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Extension sync-settings tests (#25, ADR 0033): enablement + the recovery secret
+ * live device-locally; disabling truly forgets the secret (removeCache).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { disableSync, enableSync, isSyncEnabled, readSyncSecret } from "./sync-settings";
+
+function area() {
+  const store: Record<string, unknown> = {};
+  return {
+    store,
+    get: (key: string) => Promise.resolve(key in store ? { [key]: store[key] } : {}),
+    set: (obj: Record<string, unknown>) => {
+      Object.assign(store, obj);
+      return Promise.resolve();
+    },
+    remove: (key: string) => {
+      delete store[key];
+      return Promise.resolve();
+    },
+  };
+}
+let local: ReturnType<typeof area>;
+beforeEach(() => {
+  local = area();
+  (globalThis as { chrome?: unknown }).chrome = { storage: { sync: area(), local } };
+});
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+  localStorage.clear();
+});
+
+describe("sync-settings", () => {
+  it("is off and secret-less by default", async () => {
+    expect(await isSyncEnabled()).toBe(false);
+    expect(await readSyncSecret()).toBeNull();
+  });
+
+  it("enableSync stores the secret in local storage and turns sync on", async () => {
+    await enableSync("MBTQ7-K9XAR");
+    expect(await readSyncSecret()).toBe("MBTQ7-K9XAR");
+    expect(await isSyncEnabled()).toBe(true);
+    expect(local.store["sync.secret"]).toBe("MBTQ7-K9XAR"); // device-local, not the synced area
+  });
+
+  it("disableSync forgets the secret entirely", async () => {
+    await enableSync("x");
+    await disableSync();
+    expect(await readSyncSecret()).toBeNull();
+    expect(await isSyncEnabled()).toBe(false);
+    expect("sync.secret" in local.store).toBe(false);
+  });
+});

--- a/apps/extension/src/lib/sync/sync-settings.ts
+++ b/apps/extension/src/lib/sync/sync-settings.ts
@@ -1,0 +1,38 @@
+/**
+ * Sync enablement and the recovery secret (#25, ADR 0033), kept device-locally in
+ * `chrome.storage.local` (key `sync.secret`/`sync.enabled`) — NOT `chrome.storage.sync`,
+ * so the master key never rides the browser's own profile sync. The device is the
+ * trust boundary (the extension's prefs are plaintext on it); the E2EE protects
+ * data in transit and on the server.
+ */
+import { getCache, removeCache, setCache } from "../storage";
+
+const SECRET_KEY = "sync.secret";
+const ENABLED_KEY = "sync.enabled";
+
+/** The stored recovery secret on this device, or `null` if sync was never set up. */
+export async function readSyncSecret(): Promise<string | null> {
+  const s = await getCache<string>(SECRET_KEY, "");
+  return s ? s : null;
+}
+
+/** Whether sync is on AND a secret is present to drive it. */
+export async function isSyncEnabled(): Promise<boolean> {
+  const [enabled, secret] = await Promise.all([
+    getCache<boolean>(ENABLED_KEY, false),
+    getCache<string>(SECRET_KEY, ""),
+  ]);
+  return enabled === true && secret !== "";
+}
+
+/** Turn sync on with a recovery secret (kept on this device). */
+export async function enableSync(secret: string): Promise<void> {
+  await setCache(SECRET_KEY, secret);
+  await setCache(ENABLED_KEY, true);
+}
+
+/** Turn sync off and forget the secret on this device. */
+export async function disableSync(): Promise<void> {
+  await removeCache(SECRET_KEY);
+  await setCache(ENABLED_KEY, false);
+}

--- a/apps/extension/src/lib/sync/web-crypto-cipher.test.ts
+++ b/apps/extension/src/lib/sync/web-crypto-cipher.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Extension cipher tests (#25, ADR 0033). Same cross-platform interop vectors the
+ * web and mobile ciphers are pinned against: if the extension derives the same
+ * accountId/entryId and decrypts the web-produced ciphertext, a phrase set up on
+ * the web (or mobile) links to the same account and reads the same data in the
+ * extension. Runs under jsdom with Node's WebCrypto (`crypto.subtle`).
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Cipher } from "@ummahlibrary/core";
+import {
+  canonicalizeRecoverySecret,
+  createWebCryptoCipher,
+  generateRecoveryPhrase,
+} from "./web-crypto-cipher";
+
+const PHRASE = "MBTQ7-K9XAR-2P4WD-NHJ58-VYZ36";
+const KEY = "ul.lastRead";
+const PLAINTEXT = '{"surah":18,"ayah":10}';
+const ACCOUNT_ID = "2a18292b6de6a845428ce9ffbf5478993b4fd5f3f468cf647890c09efe49be8c";
+const ENTRY_ID = "47fb92d7ccf64b6ad6b530daeec67a4e77b9033de692008946f5b704443c057f";
+const NONCE_B64 = "CzBVep/E6Q4zWH2i";
+const CIPHERTEXT = "NMPO+7NqiblvNSnSsYMFsEFM5eWMZeJXeo5MimMBdmY6UVnUxqo=";
+
+describe("extension cipher — cross-platform interop", () => {
+  let cipher: Cipher;
+  beforeAll(async () => {
+    cipher = await createWebCryptoCipher(PHRASE);
+  });
+
+  it("derives the same accountId as web/mobile", async () => {
+    expect(await cipher.accountId()).toBe(ACCOUNT_ID);
+  });
+
+  it("derives the same entryId as web/mobile", async () => {
+    expect(await cipher.entryId(KEY)).toBe(ENTRY_ID);
+  });
+
+  it("decrypts ciphertext produced by the web cipher", async () => {
+    expect(await cipher.decrypt(CIPHERTEXT, NONCE_B64)).toBe(PLAINTEXT);
+  });
+
+  it("round-trips encrypt → decrypt with a fresh nonce each time", async () => {
+    const a = await cipher.encrypt("obsidian");
+    const b = await cipher.encrypt("obsidian");
+    expect(a.nonce).not.toBe(b.nonce);
+    expect(await cipher.decrypt(a.ciphertext, a.nonce)).toBe("obsidian");
+  });
+
+  it("returns null on tampered/foreign ciphertext", async () => {
+    expect(await cipher.decrypt("not-valid", NONCE_B64)).toBeNull();
+  });
+});
+
+describe("recovery secret helpers", () => {
+  it("canonicalizes to the same account regardless of case/spacing", async () => {
+    const a = await createWebCryptoCipher("mbtq7 k9xar 2p4wd nhj58 vyz36");
+    expect(await a.accountId()).toBe(ACCOUNT_ID);
+    expect(canonicalizeRecoverySecret("ab-cd ef")).toBe("ABCDEF");
+  });
+
+  it("generates five hyphen-separated groups of five from the safe alphabet", () => {
+    expect(generateRecoveryPhrase()).toMatch(
+      /^[ABCDEFGHJKMNPQRSTVWXYZ23456789]{5}(-[ABCDEFGHJKMNPQRSTVWXYZ23456789]{5}){4}$/,
+    );
+  });
+});

--- a/apps/extension/src/lib/sync/web-crypto-cipher.ts
+++ b/apps/extension/src/lib/sync/web-crypto-cipher.ts
@@ -1,0 +1,129 @@
+/**
+ * Extension implementation of the core {@link Cipher} port (#25, ADR 0033). The
+ * extension popup runs in a browser context with WebCrypto, so this is the same
+ * scheme as the web app's `web-crypto-cipher.ts` — PBKDF2 → HKDF → AES-256-GCM,
+ * with keyed-hash account/entry ids — kept identical so a recovery phrase set up on
+ * the web (or mobile) derives the same account here and the ciphertext interops.
+ * (Apps can't import each other, so the implementation is duplicated; the shared
+ * cross-platform interop vectors in the test pin it against the web/mobile output.)
+ * The `dataKey` never leaves the device.
+ */
+import type { Cipher } from "@ummahlibrary/core";
+
+const ENC = new TextEncoder();
+const DEC = new TextDecoder();
+
+const PBKDF2_SALT = ENC.encode("ummah-library/sync/v1");
+const PBKDF2_ITERATIONS = 210_000;
+
+const RECOVERY_ALPHABET = "ABCDEFGHJKMNPQRSTVWXYZ23456789";
+const RECOVERY_GROUPS = 5;
+const RECOVERY_GROUP_LEN = 5;
+
+function toBase64(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s);
+}
+
+function fromBase64(b64: string): Uint8Array<ArrayBuffer> {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function toHex(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += b.toString(16).padStart(2, "0");
+  return s;
+}
+
+/**
+ * Canonical form of a recovery secret used for key derivation: NFKC-normalized,
+ * upper-cased, with every non-alphanumeric stripped — so the same logical code
+ * typed with different case, spacing or hyphenation derives the SAME account.
+ */
+export function canonicalizeRecoverySecret(secret: string): string {
+  return secret.normalize("NFKC").toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
+
+/** A fresh, high-entropy recovery code (~120 bits), grouped for easy transcription. */
+export function generateRecoveryPhrase(): string {
+  const n = RECOVERY_GROUPS * RECOVERY_GROUP_LEN;
+  const rnd = crypto.getRandomValues(new Uint8Array(n));
+  let out = "";
+  for (let i = 0; i < n; i++) {
+    if (i > 0 && i % RECOVERY_GROUP_LEN === 0) out += "-";
+    out += RECOVERY_ALPHABET[rnd[i]! % RECOVERY_ALPHABET.length]!;
+  }
+  return out;
+}
+
+async function deriveRoot(secret: string): Promise<CryptoKey> {
+  const base = await crypto.subtle.importKey("raw", ENC.encode(secret), "PBKDF2", false, [
+    "deriveBits",
+  ]);
+  const rootBits = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", salt: PBKDF2_SALT, iterations: PBKDF2_ITERATIONS, hash: "SHA-256" },
+    base,
+    256,
+  );
+  return crypto.subtle.importKey("raw", rootBits, "HKDF", false, ["deriveBits", "deriveKey"]);
+}
+
+function hkdf(info: string): HkdfParams {
+  return { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: ENC.encode(info) };
+}
+
+/**
+ * Build an unlocked {@link Cipher} from a recovery secret. Derivation is the slow
+ * step (PBKDF2 by design); do it once when sync is enabled and reuse the instance.
+ */
+export async function createWebCryptoCipher(secret: string): Promise<Cipher> {
+  const root = await deriveRoot(canonicalizeRecoverySecret(secret));
+  const dataKey = await crypto.subtle.deriveKey(
+    hkdf("data-key"),
+    root,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+  const hmacKey = await crypto.subtle.deriveKey(
+    hkdf("entry-id"),
+    root,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const accountIdHex = toHex(
+    new Uint8Array(await crypto.subtle.deriveBits(hkdf("account-id"), root, 256)),
+  );
+
+  return {
+    accountId: async () => accountIdHex,
+    entryId: async (keyName) =>
+      toHex(new Uint8Array(await crypto.subtle.sign("HMAC", hmacKey, ENC.encode(keyName)))),
+    encrypt: async (plaintext) => {
+      const iv = crypto.getRandomValues(new Uint8Array(12));
+      const ct = await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv },
+        dataKey,
+        ENC.encode(plaintext),
+      );
+      return { ciphertext: toBase64(new Uint8Array(ct)), nonce: toBase64(iv) };
+    },
+    decrypt: async (ciphertext, nonce) => {
+      try {
+        const pt = await crypto.subtle.decrypt(
+          { name: "AES-GCM", iv: fromBase64(nonce) },
+          dataKey,
+          fromBase64(ciphertext),
+        );
+        return DEC.decode(pt);
+      } catch {
+        return null; // tampered, foreign, or wrong key — never surface as a throw
+      }
+    },
+  };
+}

--- a/apps/web/src/app/api/sync/route.test.ts
+++ b/apps/web/src/app/api/sync/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { POST } from "./route";
+import { OPTIONS, POST } from "./route";
 
 function post(body: unknown, auth?: string): Request {
   return new Request("http://localhost/api/sync", {
@@ -33,5 +33,18 @@ describe("POST /api/sync (dev fallback)", () => {
       body: "{nope",
     });
     expect((await POST(bad)).status).toBe(400);
+  });
+
+  it("sets open CORS on the POST response (extension calls it cross-origin)", async () => {
+    const res = await POST(post({ entries: [] }, AUTH));
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  it("answers the CORS preflight so the extension's authenticated POST can proceed", () => {
+    const res = OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(res.headers.get("access-control-allow-headers")).toContain("authorization");
   });
 });

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -6,12 +6,30 @@
  * a process-memory store so two local profiles can sync against `pnpm dev` with no
  * credentials. This route reads no datasets, so it needs no
  * `outputFileTracingIncludes` entry.
+ *
+ * CORS is open (like the public REST API): the browser extension calls this from a
+ * `chrome-extension://` origin, and its `Authorization` header makes the POST a
+ * non-simple request, so a preflight (`OPTIONS`) must be answered. `*` is safe here
+ * because the request carries no credentials (the `accountId` is a bearer token in
+ * the header, not a cookie), and the server only ever holds opaque ciphertext.
  */
 import { handleSync } from "./handler";
 import { InMemorySyncStore, type SyncStore, syncStoreFromEnv } from "./sync-store";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+const CORS_HEADERS: Record<string, string> = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "POST, OPTIONS",
+  "access-control-allow-headers": "authorization, content-type",
+  "access-control-max-age": "86400",
+};
+
+/** Answer the CORS preflight the extension's authenticated POST triggers. */
+export function OPTIONS(): Response {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
 
 // Reused across requests in one dev-server process so two profiles converge; never
 // constructed in production, where an unprovisioned endpoint stays 501.
@@ -26,7 +44,10 @@ function resolveStore(): SyncStore | null {
 }
 
 function json(body: unknown, status: number): Response {
-  return Response.json(body, { status, headers: { "cache-control": "no-store" } });
+  return Response.json(body, {
+    status,
+    headers: { "cache-control": "no-store", "access-control-allow-origin": "*" },
+  });
 }
 
 export async function POST(req: Request): Promise<Response> {

--- a/docs/adr/0033-account-sync.md
+++ b/docs/adr/0033-account-sync.md
@@ -112,9 +112,15 @@ non-extractable WebCrypto key in IndexedDB — is a later option.) The Settings 
   an AsyncStorage `SyncStateStore` + clock sidecar, and a "Sync across devices" Settings
   screen that syncs on launch and on foreground (`AppState`). The managed-key set now
   lives in `core` (`sync-keys.ts`) as the single shared contract across platforms.
-- **Deferred:** the extension cipher + CORS on `/api/sync`; Upstash provisioning +
-  deploy; a **live in-app/in-tab refresh** after a synced value is applied (today a
-  pulled change surfaces on the next read/navigation or app relaunch — the in-memory
-  React contexts re-read on mount, not on a sync event; true on web and mobile alike);
-  and the v2 refinements (element-level merge for set/map keys, atomic server merge
-  under concurrent push, an incremental pull cursor).
+  The **browser extension** also syncs now: it reuses the web WebCrypto `Cipher`
+  scheme, bridges the two prefs it shares with the contract (`ul.theme`,
+  `ul.hijriAdjust`) to its own `chrome.storage` layout + value formats, keeps the
+  recovery secret device-local in `chrome.storage.local`, and a compact popup panel
+  drives it; `/api/sync` answers a CORS preflight so the `chrome-extension://` popup's
+  authenticated POST can reach it.
+- **Deferred:** Upstash provisioning + deploy; a **live in-app/in-tab refresh** after a
+  synced value is applied (today a pulled change surfaces on the next read/navigation
+  or app relaunch — the in-memory React contexts re-read on mount, not on a sync event;
+  true on web, mobile, and the extension alike); and the v2 refinements (element-level
+  merge for set/map keys, atomic server merge under concurrent push, an incremental
+  pull cursor).


### PR DESCRIPTION
## D3 — extension cross-device sync + `/api/sync` CORS (#25)

Completes the D3 "one mechanism everywhere" goal: opt-in, end-to-end-encrypted sync ([ADR 0033](../blob/main/docs/adr/0033-account-sync.md)) for the browser extension, plus the CORS the cross-origin popup needs. The pure `core` engine is reused **unchanged**. **Off by default.**

> **Stacked on #169** (`feat/sync-mobile`) for the shared `core/sync-keys.ts` (`MANAGED_KEYS`). Base is `feat/sync-mobile`; re-target to `main` once #169 lands.

### CORS on `POST /api/sync`
The popup runs at a `chrome-extension://` origin and the extension has no `host_permissions`, so it relies on server CORS (like `/api/v1`). The POST carries an `Authorization` header → non-simple → triggers a preflight. Added an `OPTIONS` handler + `access-control-allow-origin: *` on responses. `*` is safe: the `accountId` is a bearer token (not a cookie), no credentials mode, and the server holds only opaque ciphertext.

### Extension sync client
- Reuses the **web WebCrypto `Cipher` scheme** (the popup is a browser context; pinned by the same cross-platform interop vectors as web/mobile).
- `http-sync-backend` → `${BASE_URL}/api/sync`; async `sync-meta`/`sync-node` over `chrome.storage.local`; the recovery **secret stays device-local** (`chrome.storage.local`, never the browser-synced area).
- `ext-sync-state-store` **bridges** the two prefs the extension shares with the contract — `ul.theme`, `ul.hijriAdjust` — to its own short `chrome.storage` keys + the web's serialized value formats, with **presence-aware reads** so a fresh install can't clobber another device. `EXT_MANAGED` is enforced as a subset of `MANAGED_KEYS`.
- `SyncPanel`: a compact, collapsible "Sync across devices" section in the popup; `syncIfEnabled()` on open, reflecting a pulled theme live.

### Scope note
The extension's whole syncable surface is **theme + Hijri offset** (its only contract-overlapping prefs); the high-value data (bookmarks, last-read, hifz) doesn't exist in the popup. This makes the extension consistent with the web/mobile theme/calendar settings — modest but completes the vision.

### Verification
- **63 extension tests** (cipher interop vectors, the value-bridge, presence/clobber + tombstone edges, secret handling, a **two-install e2e round-trip + isolation**) + 2 new web route tests (preflight/ACAO).
- `pnpm lint && typecheck && test && build` green; the extension also bundles under Vite.
- A focused 14-agent adversarial review **cleared CORS entirely** and confirmed 4 low findings — all fixed: clamp `hijriAdjust` to `[-2,2]` on apply, reject unknown `ThemeKey`s, stamp the sync clock from the actually-stored value (no spurious re-push), and guard `turnOn` against a wedging storage failure.

Draft until device-verified against a provisioned `/api/sync`.
