### PR TITLE
feat(sync): v2 element-level merge for collection keys (D5, #25)

### DIFF
--- a/apps/mobile/src/lib/sync/mobile-sync-state-store.test.ts
+++ b/apps/mobile/src/lib/sync/mobile-sync-state-store.test.ts
@@ -16,6 +16,7 @@ vi.mock("@react-native-async-storage/async-storage", () => ({
 }));
 vi.mock("./crypto-random", () => ({ randomBytes: () => new Uint8Array(0), randomId: () => "node-A" }));
 
+import { explodeKey } from "@ummahlibrary/core";
 import { createMobileSyncStateStore } from "./mobile-sync-state-store";
 
 beforeEach(() => mem.clear());
@@ -61,5 +62,39 @@ describe("createMobileSyncStateStore", () => {
     const theme = (await store.all()).find((r) => r.key === "ul.theme")!;
     expect(theme.value).toBeNull();
     expect(theme.hlc).toEqual(tombHlc);
+  });
+});
+
+describe("createMobileSyncStateStore — element-merge (v2) for a map key", () => {
+  const NOTES = "ul.ayahNotes";
+
+  it("flattens a map key into one self-describing record per element", async () => {
+    mem.set(NOTES, JSON.stringify({ "2:255": "kursi", "1:1": "fatiha" }));
+    const records = await createMobileSyncStateStore([NOTES]).all();
+    expect(records).toHaveLength(2);
+    expect(records.every((r) => r.key.startsWith(NOTES))).toBe(true);
+    const one = records.find((r) => r.key.endsWith("1:1"))!;
+    expect(JSON.parse(one.value!)).toEqual({ mk: NOTES, k: "1:1", v: '"fatiha"' });
+  });
+
+  it("apply() recomposes the owning map; a tombstone removes only that element", async () => {
+    mem.set(NOTES, JSON.stringify({ "1:1": "a", "2:2": "b" }));
+    const store = createMobileSyncStateStore([NOTES]);
+    await store.apply(explodeKey(NOTES, "3:3"), JSON.stringify({ mk: NOTES, k: "3:3", v: '"c"' }), {
+      millis: 9,
+      counter: 0,
+      node: "peer",
+    });
+    expect(JSON.parse(mem.get(NOTES)!)).toEqual({ "1:1": "a", "2:2": "b", "3:3": "c" });
+    await store.apply(explodeKey(NOTES, "1:1"), null, { millis: 10, counter: 0, node: "peer" });
+    expect(JSON.parse(mem.get(NOTES)!)).toEqual({ "2:2": "b", "3:3": "c" });
+  });
+
+  it("identify() resolves an element born on another device", async () => {
+    const store = createMobileSyncStateStore([NOTES]);
+    expect(store.identify!(JSON.stringify({ mk: NOTES, k: "5:5", v: '"x"' }))).toBe(
+      explodeKey(NOTES, "5:5"),
+    );
+    expect(store.identify!('"bare scalar"')).toBeNull();
   });
 });

--- a/apps/mobile/src/lib/sync/mobile-sync-state-store.ts
+++ b/apps/mobile/src/lib/sync/mobile-sync-state-store.ts
@@ -1,38 +1,100 @@
 /**
- * Mobile {@link SyncStateStore} (#25, ADR 0033) over the managed `ul.*`
- * AsyncStorage keys. `all()` reads every managed value in one `multiGet`,
- * reconciles each key's clock (diff-at-sync) against the sidecar, then returns
- * value+clock; `apply()` installs a winning remote value at its clock and records
- * it in the sidecar. This is a sync layer *beside* the existing stores — it never
- * changes how they read or write their own values, so sync staying off is a no-op
- * for every feature.
+ * Mobile {@link SyncStateStore} (#25, ADR 0033 + 0034) over the managed `ul.*`
+ * AsyncStorage keys. A **scalar** key syncs whole-value (v1); a **map** key
+ * (`sync-shapes.ts`) is flattened into one synced record per element under a
+ * synthetic key `mapKey + SEP + elementId`, so the engine merges per element and
+ * concurrent edits to different entries don't clobber. `all()` reads every managed
+ * value in one `multiGet`, explodes the maps, reconciles each (synthetic) key's
+ * clock, then returns value+clock; `apply()` installs a winning remote value —
+ * recomposing the owning map for a map element — and records it in the sidecar.
  *
  * Named `*-store.ts` (and routing raw access through `./storage`) so the ADR-0028
  * persistence lint is satisfied without a single disable.
  */
-import { MANAGED_KEYS, type SyncStateStore } from "@ummahlibrary/core";
-import { multiGet, removeItem, setItem } from "./storage";
+import {
+  MANAGED_KEYS,
+  type SyncRecord,
+  type SyncStateStore,
+  explodeKey,
+  parseElementKey,
+  shapeOf,
+  unwrapElement,
+  wrapElement,
+} from "@ummahlibrary/core";
+import { getItem, multiGet, removeItem, setItem } from "./storage";
 import { clockOf, loadMeta, reconcileMeta, saveMeta, setClockIn } from "./sync-meta";
 import { getNodeId } from "./sync-node";
+
+function parseJson(raw: string | null): unknown {
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
 
 /** Build a state store over the given managed keys (defaults to {@link MANAGED_KEYS}). */
 export function createMobileSyncStateStore(
   keys: readonly string[] = MANAGED_KEYS,
 ): SyncStateStore {
+  const keySet = new Set(keys);
   return {
     all: async () => {
       const node = await getNodeId();
-      const values = await multiGet(keys);
+      const stored = await multiGet(keys); // base key -> whole value
+      // Synthetic/scalar key -> value (the self-describing envelope for map elements).
+      const values = new Map<string, string | null>();
+      for (const key of keys) {
+        const shape = shapeOf(key);
+        if (shape.kind === "scalar") {
+          values.set(key, stored.get(key) ?? null);
+          continue;
+        }
+        for (const [id, v] of shape.explode(parseJson(stored.get(key) ?? null))) {
+          values.set(explodeKey(key, id), wrapElement(key, id, v));
+        }
+      }
       const meta = await loadMeta();
-      if (reconcileMeta(meta, keys, values, new Date(), node)) await saveMeta(meta);
-      return keys.map((key) => ({ key, value: values.get(key) ?? null, hlc: clockOf(meta, key, node) }));
+      // An element that previously had meta but is gone locally → tombstone it.
+      for (const metaKey of Object.keys(meta)) {
+        const parsed = parseElementKey(metaKey);
+        if (parsed && keySet.has(parsed.mapKey) && !values.has(metaKey)) values.set(metaKey, null);
+      }
+      const syntheticKeys = [...values.keys()];
+      if (reconcileMeta(meta, syntheticKeys, values, new Date(), node)) await saveMeta(meta);
+      const records: SyncRecord[] = [];
+      for (const [key, value] of values) records.push({ key, value, hlc: clockOf(meta, key, node) });
+      return records;
     },
     apply: async (key, value, hlc) => {
-      if (value === null) await removeItem(key);
-      else await setItem(key, value);
+      const parsed = parseElementKey(key);
+      if (parsed === null) {
+        // scalar key — whole-value as in v1
+        if (value === null) await removeItem(key);
+        else await setItem(key, value);
+        const meta = await loadMeta();
+        setClockIn(meta, key, value, hlc);
+        await saveMeta(meta);
+        return;
+      }
+      // map element — recompose the owning map around the winning element
+      const shape = shapeOf(parsed.mapKey);
+      if (shape.kind !== "map") return; // not a map this build manages
+      const elements = shape.explode(parseJson(await getItem(parsed.mapKey)));
+      if (value === null) elements.delete(parsed.id);
+      else elements.set(parsed.id, unwrapElement(value)?.v ?? value);
+      const rebuilt = elements.size === 0 ? null : shape.rebuild(elements);
+      if (rebuilt === null) await removeItem(parsed.mapKey);
+      else await setItem(parsed.mapKey, rebuilt);
       const meta = await loadMeta();
       setClockIn(meta, key, value, hlc);
       await saveMeta(meta);
+    },
+    identify: (plaintext) => {
+      const env = unwrapElement(plaintext);
+      if (!env || !keySet.has(env.mk) || shapeOf(env.mk).kind !== "map") return null;
+      return explodeKey(env.mk, env.k);
     },
   };
 }

--- a/apps/web/src/app/api/sync/handler.test.ts
+++ b/apps/web/src/app/api/sync/handler.test.ts
@@ -40,7 +40,7 @@ describe("handleSync", () => {
   });
 
   it("rejects too many entries with 413", async () => {
-    const entries = Array.from({ length: 501 }, (_, i) => entry(`id${i}`, 1));
+    const entries = Array.from({ length: 2001 }, (_, i) => entry(`id${i}`, 1));
     const r = await handleSync({ authorization: auth, body: { entries } }, new InMemorySyncStore());
     expect(r.status).toBe(413);
   });

--- a/apps/web/src/app/api/sync/handler.ts
+++ b/apps/web/src/app/api/sync/handler.ts
@@ -9,7 +9,11 @@
 import { type SyncEntry, mergeEntries } from "@ummahlibrary/core";
 import type { SyncStore } from "./sync-store";
 
-const MAX_ENTRIES = 500;
+// Element-level merge (ADR 0034) flattens each map key into one entry per element,
+// so an account holds hundreds of entries (Phase 1) instead of ~16. Headroom for
+// that; per-entry size (below) + per-account/IP rate limiting stay the real abuse
+// guards. The unbounded key (`ul.hifz`) is gated on the incremental-pull cursor.
+const MAX_ENTRIES = 2000;
 const MAX_CIPHERTEXT = 64 * 1024;
 const MAX_NONCE = 256;
 const MAX_NODE = 128;

--- a/apps/web/src/lib/sync/managed-keys.test.ts
+++ b/apps/web/src/lib/sync/managed-keys.test.ts
@@ -21,19 +21,20 @@ describe("MANAGED_KEYS", () => {
     expect(MANAGED_KEYS).not.toContain("ul.sync.node");
   });
 
-  it("excludes collection/log/counter keys that need element-level merge (v2)", () => {
+  it("manages the Phase-1 element-merged collection/set keys (v2, ADR 0034)", () => {
+    for (const key of ["ul.ayahNotes", "ul.collections", "ul.qada", "ul.haid", "ul.badges"]) {
+      expect(MANAGED_KEYS).toContain(key);
+    }
+  });
+
+  it("still excludes counters and the Phase-2/3 keys (hifz, date logs)", () => {
     for (const key of [
-      "ul.collections",
-      "ul.ayahNotes",
-      "ul.hifz",
-      "ul.hifz.streak",
-      "ul.prayerLog",
-      "ul.qada",
-      "ul.haid",
-      "ul.tasbih2",
-      "ul.searchHistory",
-      "ul.badges",
-      "ul.readingLog",
+      "ul.hifz", // Phase 3 — gated on the incremental-pull cursor
+      "ul.hifz.streak", // counter
+      "ul.tasbih", // counter
+      "ul.prayerLog", // Phase 2 — date log
+      "ul.readingLog", // Phase 2 — date log
+      "ul.searchHistory", // weak identity, low value
     ]) {
       expect(MANAGED_KEYS).not.toContain(key);
     }

--- a/apps/web/src/lib/sync/sync-meta.ts
+++ b/apps/web/src/lib/sync/sync-meta.ts
@@ -95,12 +95,28 @@ function hashValue(value: string | null): string {
  * when a key that *did* have a value (prior meta) becomes null — a real deletion.
  */
 export function reconcile(keys: readonly string[], now: Date, node: string): void {
+  const values = new Map<string, string | null>();
+  for (const key of keys) values.set(key, getItem(key));
+  reconcileValues(values, now, node);
+}
+
+/**
+ * Like {@link reconcile}, but over already-computed `key → value` pairs. The
+ * element-merge store (ADR 0034) flattens a map key into synthetic element keys
+ * that have no storage entry of their own, so it supplies the values directly.
+ * Same diff-at-sync semantics and the same never-tombstone-a-never-seen-key
+ * invariant — applied per element.
+ */
+export function reconcileValues(
+  valuesByKey: ReadonlyMap<string, string | null>,
+  now: Date,
+  node: string,
+): void {
   const meta = readMeta();
   let changed = false;
-  for (const key of keys) {
-    const raw = getItem(key);
+  for (const [key, raw] of valuesByKey) {
     const prev = meta[key];
-    if (raw === null && !prev) continue; // never-seen absent key — not a deletion
+    if (raw === null && !prev) continue; // never-seen absent key/element — not a deletion
     const hash = hashValue(raw);
     if (prev && prev.hash === hash) continue;
     const base = prev ? prev.hlc : hlcInit(node);
@@ -109,6 +125,11 @@ export function reconcile(keys: readonly string[], now: Date, node: string): voi
     changed = true;
   }
   if (changed) writeMeta(meta);
+}
+
+/** Every key currently tracked in the sidecar — lets the store tombstone a locally-removed element. */
+export function metaKeys(): string[] {
+  return Object.keys(readMeta());
 }
 
 /** The current clock for a key (a fresh clock if it has no meta yet). */

--- a/apps/web/src/lib/sync/sync-runtime.test.ts
+++ b/apps/web/src/lib/sync/sync-runtime.test.ts
@@ -46,4 +46,31 @@ describe("syncIfEnabled", () => {
     await syncIfEnabled();
     expect(create).toHaveBeenCalledTimes(2);
   });
+
+  it("coalesces concurrent calls into a single in-flight round", async () => {
+    enableSync("phrase-a");
+    let release!: (v: { pushed: number; pulled: number; applied: number }) => void;
+    syncNow.mockImplementationOnce(() => new Promise((r) => (release = r)));
+    const p1 = syncIfEnabled();
+    const p2 = syncIfEnabled();
+    expect(p1).toBe(p2); // same in-flight promise (focus + visibilitychange double-fire)
+    await vi.waitFor(() => expect(syncNow).toHaveBeenCalledTimes(1));
+    release({ pushed: 0, pulled: 0, applied: 0 });
+    await Promise.all([p1, p2]);
+    expect(syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("resetSyncRuntime clears the in-flight round so the next call starts fresh", async () => {
+    enableSync("phrase-a");
+    let release!: (v: { pushed: number; pulled: number; applied: number }) => void;
+    syncNow.mockImplementationOnce(() => new Promise((r) => (release = r)));
+    const p1 = syncIfEnabled();
+    await vi.waitFor(() => expect(syncNow).toHaveBeenCalledTimes(1));
+    resetSyncRuntime();
+    const p2 = syncIfEnabled();
+    expect(p2).not.toBe(p1);
+    release({ pushed: 0, pulled: 0, applied: 0 });
+    await Promise.all([p1, p2]);
+    expect(syncNow).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/src/lib/sync/sync-runtime.ts
+++ b/apps/web/src/lib/sync/sync-runtime.ts
@@ -2,14 +2,21 @@
  * The app's active sync controller (#25, ADR 0033). Derives the cipher once from
  * the stored secret (PBKDF2 is deliberately slow) and caches it by secret, so the
  * {@link SyncBootstrap} auto-triggers and the Settings "Sync now" button share one
- * instance. `syncIfEnabled` is the single entry point both call — it is a no-op
+ * instance. `syncIfEnabled` is the single entry point both call — a no-op
  * (resolves `null`) whenever sync is off, so callers never need to check first.
+ *
+ * Concurrent calls are **coalesced** (matching the mobile runtime): `SyncBootstrap`
+ * wires both `visibilitychange` and window `focus`, which both fire on a single tab
+ * refocus, and "Sync now" can overlap a background round. Two overlapping rounds
+ * would interleave at every `await` and could transiently regress the shared
+ * `ul.sync.meta` clock sidecar, so while a round is in flight, extra calls return it.
  */
 import type { SyncOutcome } from "@ummahlibrary/core";
 import { type SyncController, createSyncControllerFromSecret } from "./sync-controller";
 import { isSyncEnabled, readSyncSecret } from "./sync-settings";
 
 let cached: { secret: string; controller: Promise<SyncController> } | null = null;
+let inFlight: Promise<SyncOutcome | null> | null = null;
 
 function controllerFor(secret: string): Promise<SyncController> {
   if (cached?.secret !== secret) {
@@ -18,15 +25,25 @@ function controllerFor(secret: string): Promise<SyncController> {
   return cached.controller;
 }
 
-/** Run one sync round if sync is enabled; resolves `null` when it's off. */
-export async function syncIfEnabled(): Promise<SyncOutcome | null> {
+async function run(): Promise<SyncOutcome | null> {
   if (!isSyncEnabled()) return null;
   const secret = readSyncSecret();
   if (!secret) return null;
   return (await controllerFor(secret)).syncNow();
 }
 
-/** Drop the cached controller — call after disabling sync or changing the secret. */
+/** Run one sync round if sync is enabled; resolves `null` when it's off. Coalesces concurrent calls. */
+export function syncIfEnabled(): Promise<SyncOutcome | null> {
+  if (inFlight) return inFlight;
+  const round = run().finally(() => {
+    if (inFlight === round) inFlight = null;
+  });
+  inFlight = round;
+  return round;
+}
+
+/** Drop the cached controller and any in-flight round — call after enabling/disabling/changing the secret. */
 export function resetSyncRuntime(): void {
   cached = null;
+  inFlight = null;
 }

--- a/apps/web/src/lib/sync/web-sync-state-store.test.ts
+++ b/apps/web/src/lib/sync/web-sync-state-store.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { explodeKey } from "@ummahlibrary/core";
 import { SYNC_CHANGE_EVENT, createWebSyncStateStore } from "./web-sync-state-store";
 
 beforeEach(() => localStorage.clear());
@@ -42,5 +43,54 @@ describe("createWebSyncStateStore", () => {
   it("defaults to the managed keys when none are passed", async () => {
     const records = await createWebSyncStateStore().all();
     expect(records.some((r) => r.key === KEY)).toBe(true);
+  });
+
+  describe("element-merge (v2) for a map key", () => {
+    const NOTES = "ul.ayahNotes";
+
+    it("all() flattens a map key into one record per element, self-describing", async () => {
+      localStorage.setItem(NOTES, JSON.stringify({ "2:255": "ayat al-kursi", "1:1": "fatiha" }));
+      const records = await createWebSyncStateStore([NOTES]).all();
+      const keys = records.map((r) => r.key).sort();
+      // synthetic keys: `ul.ayahNotes<SEP>1:1` etc. (one per element, no bare map-key record)
+      expect(keys).toHaveLength(2);
+      expect(keys.every((k) => k.startsWith(NOTES))).toBe(true);
+      const one = records.find((r) => r.key.endsWith("1:1"))!;
+      expect(JSON.parse(one.value!)).toEqual({ mk: NOTES, k: "1:1", v: '"fatiha"' });
+    });
+
+    it("never-set map key emits no records", async () => {
+      expect(await createWebSyncStateStore([NOTES]).all()).toEqual([]);
+    });
+
+    it("apply() recomposes the owning map around the winning element", async () => {
+      localStorage.setItem(NOTES, JSON.stringify({ "1:1": "old" }));
+      const store = createWebSyncStateStore([NOTES]);
+      const recs = await store.all();
+      // simulate a remote element arriving for a DIFFERENT ayah
+      await store.apply(explodeKey(NOTES, "2:255"), JSON.stringify({ mk: NOTES, k: "2:255", v: '"new"' }), {
+        millis: 9,
+        counter: 0,
+        node: "peer",
+      });
+      expect(JSON.parse(localStorage.getItem(NOTES)!)).toEqual({ "1:1": "old", "2:255": "new" });
+      // the original element is untouched (no clobber)
+      expect(recs.length).toBe(1);
+    });
+
+    it("apply() of a tombstone removes only that element", async () => {
+      localStorage.setItem(NOTES, JSON.stringify({ "1:1": "a", "2:2": "b" }));
+      const store = createWebSyncStateStore([NOTES]);
+      await store.apply(explodeKey(NOTES, "1:1"), null, { millis: 9, counter: 0, node: "peer" });
+      expect(JSON.parse(localStorage.getItem(NOTES)!)).toEqual({ "2:2": "b" });
+    });
+
+    it("identify() resolves an element born on another device from its payload", async () => {
+      const store = createWebSyncStateStore([NOTES]);
+      const synthetic = store.identify!(JSON.stringify({ mk: NOTES, k: "3:3", v: '"x"' }));
+      expect(synthetic).toBe(explodeKey(NOTES, "3:3"));
+      expect(store.identify!('"a bare scalar value"')).toBeNull();
+      expect(store.identify!(JSON.stringify({ mk: "ul.notManaged", k: "1", v: "1" }))).toBeNull();
+    });
   });
 });

--- a/apps/web/src/lib/sync/web-sync-state-store.ts
+++ b/apps/web/src/lib/sync/web-sync-state-store.ts
@@ -1,18 +1,28 @@
 /**
- * Web {@link SyncStateStore} (#25, ADR 0033) over the managed `ul.*` localStorage
- * keys. `all()` reconciles each key's clock (diff-at-sync) then reads value+clock;
- * `apply()` installs a winning remote value at its clock and announces the change
- * so an open tab can re-read. This is a sync layer *beside* the existing stores —
- * it never changes how they read or write their own values, so sync staying off
- * is a no-op for every feature.
+ * Web {@link SyncStateStore} (#25, ADR 0033 + 0034) over the managed `ul.*`
+ * localStorage keys. A **scalar** key syncs whole-value (v1); a **map** key
+ * (`sync-shapes.ts`) is flattened into one synced record per element under a
+ * synthetic key `mapKey + SEP + elementId`, so the engine merges per element and
+ * concurrent edits to different entries don't clobber. `all()` reconciles each
+ * (synthetic) key's clock then reads value+clock; `apply()` installs a winning
+ * remote value — recomposing the owning map for a map element — and announces the
+ * change so an open tab can re-read. A sync layer *beside* the existing stores.
  */
-import type { SyncStateStore } from "@ummahlibrary/core";
-import { MANAGED_KEYS } from "./managed-keys";
-import { clockFor, reconcile, setClock } from "./sync-meta";
+import {
+  MANAGED_KEYS,
+  type SyncRecord,
+  type SyncStateStore,
+  explodeKey,
+  parseElementKey,
+  shapeOf,
+  unwrapElement,
+  wrapElement,
+} from "@ummahlibrary/core";
+import { clockFor, metaKeys, reconcileValues, setClock } from "./sync-meta";
 import { getItem, removeItem, setItem } from "./storage";
 import { getNodeId } from "./sync-node";
 
-/** Fired (per key) after a remote value is applied, so open UI can re-read. */
+/** Fired (per top-level key) after a remote value is applied, so open UI can re-read. */
 export const SYNC_CHANGE_EVENT = "ul:sync:change";
 
 function putItem(key: string, value: string | null): void {
@@ -25,18 +35,66 @@ function announce(key: string): void {
   window.dispatchEvent(new CustomEvent(SYNC_CHANGE_EVENT, { detail: { key } }));
 }
 
+function parseJson(raw: string | null): unknown {
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
 /** Build a state store over the given managed keys (defaults to {@link MANAGED_KEYS}). */
 export function createWebSyncStateStore(keys: readonly string[] = MANAGED_KEYS): SyncStateStore {
+  const keySet = new Set(keys);
   return {
     all: async () => {
       const node = getNodeId();
-      reconcile(keys, new Date(), node);
-      return keys.map((key) => ({ key, value: getItem(key), hlc: clockFor(key, node) }));
+      // Synthetic/scalar key -> value (the self-describing envelope for map elements).
+      const values = new Map<string, string | null>();
+      for (const key of keys) {
+        const shape = shapeOf(key);
+        if (shape.kind === "scalar") {
+          values.set(key, getItem(key));
+          continue;
+        }
+        for (const [id, v] of shape.explode(parseJson(getItem(key)))) {
+          values.set(explodeKey(key, id), wrapElement(key, id, v));
+        }
+      }
+      // An element that previously had meta but is gone locally → tombstone it.
+      for (const metaKey of metaKeys()) {
+        const parsed = parseElementKey(metaKey);
+        if (parsed && keySet.has(parsed.mapKey) && !values.has(metaKey)) values.set(metaKey, null);
+      }
+      reconcileValues(values, new Date(), node);
+      const records: SyncRecord[] = [];
+      for (const [key, value] of values) records.push({ key, value, hlc: clockFor(key, node) });
+      return records;
     },
     apply: async (key, value, hlc) => {
-      putItem(key, value);
+      const parsed = parseElementKey(key);
+      if (parsed === null) {
+        // scalar key — whole-value as in v1
+        putItem(key, value);
+        setClock(key, value, hlc);
+        announce(key);
+        return;
+      }
+      // map element — recompose the owning map around the winning element
+      const shape = shapeOf(parsed.mapKey);
+      if (shape.kind !== "map") return; // not a map this build manages
+      const elements = shape.explode(parseJson(getItem(parsed.mapKey)));
+      if (value === null) elements.delete(parsed.id);
+      else elements.set(parsed.id, unwrapElement(value)?.v ?? value);
+      putItem(parsed.mapKey, elements.size === 0 ? null : shape.rebuild(elements));
       setClock(key, value, hlc);
-      announce(key);
+      announce(parsed.mapKey);
+    },
+    identify: (plaintext) => {
+      const env = unwrapElement(plaintext);
+      if (!env || !keySet.has(env.mk) || shapeOf(env.mk).kind !== "map") return null;
+      return explodeKey(env.mk, env.k);
     },
   };
 }

--- a/docs/adr/0034-sync-element-merge.md
+++ b/docs/adr/0034-sync-element-merge.md
@@ -1,0 +1,161 @@
+# ADR 0034 — Cross-device sync v2: element-level merge
+
+- **Status:** Accepted
+- **Date:** 2026-06-24
+- **Amends:** [ADR 0033](0033-account-sync.md)
+
+## Context
+
+[ADR 0033](0033-account-sync.md) shipped opt-in, end-to-end-encrypted, zero-PII
+sync with **whole-value last-writer-wins (LWW)** per `ul.*` key. That is correct
+only for **scalar** keys — a single setting, the last-read position, a theme — where
+"the most recent write on any device wins" is what the user wants.
+
+It is wrong for **collection** keys. `ul.hifz`, `ul.ayahNotes`, the prayer/qaḍāʾ/
+ḥayḍ logs, bookmark collections, the reading logs — these are maps and sets of many
+independent entries. Whole-value LWW would let a device that edited *one* entry
+overwrite *every* entry another device changed. So 0033 deliberately **excluded**
+those keys ("element-level merge … is a later refinement") and v1 syncs only scalars.
+
+This ADR settles how those collection keys sync without clobbering: **v2
+element-level merge**. It does not change v1's scalar path.
+
+## What the excluded keys actually are
+
+A survey of every excluded key found one dominant shape — **a map keyed by a stable
+id** — plus a few sets and a few counters:
+
+| Shape | Keys | Element identity |
+| --- | --- | --- |
+| Map `Record<id, V>` | `ul.hifz` (ayah→SM-2 card), `ul.ayahNotes` (ayah→text), `ul.prayerLog` (date→statuses), `ul.readingLog` (date→pages), `ul.qada` (prayer→count), `ul.ramadanFasts`/`ul.ramadanWorship`, `ul.asmaLearned` | the record key |
+| Array keyed by a field | `ul.collections` (`{id,name,ayahs}[]`, by `id`), `ul.haid` (`{start,end?}[]`, by `start`) | the keyed field |
+| Set (`string[]` / `Record<id,true>`) | `ul.badges`, `ul.readingActive`, `ul.bookmarks` | the member |
+| Counter / structured scalar | `ul.tasbih`, `ul.hifz.streak`, `ul.adhkar`, `ul.readingGoal`, `ul.readingPlan`, `ul.readingPages` | — none — |
+
+## Decision
+
+**Sync each element of a collection key as its own entry, reusing the existing pure
+HLC/LWW engine unchanged. Merge then happens per element automatically.**
+
+### 1. Element-flattening with synthetic keys
+
+A managed key declares a **sync shape** (pure `core` knowledge): `scalar` (v1) or
+`map`. For a map key the state store **explodes** the value into one logical record
+per element, under a **synthetic key** `mapKey + NUL + elementId`. The cipher's
+`entryId(syntheticKey) = HMAC(dataKey, syntheticKey)` keys it on the wire, so the
+**same element on two devices gets the same opaque id and merges**, while the server
+still sees only `{ id, hlc, ciphertext, nonce }`. A deleted element is a tombstone
+(null at a non-zero clock), exactly as in v1. Recompose on apply.
+
+`mergeEntries`, `hlcCompare`, the wire format, and the server are **unchanged** — the
+merge is per-element purely because each element is its own id. The new logic is a
+shared shape registry in `core` plus the explode/recompose in each platform's state
+store; the per-key clock sidecar already keys on arbitrary strings, so synthetic
+element keys flow through it with no structural change.
+
+### 2. Self-describing element payloads + a one-round discovery hook
+
+The one place flattening breaks: an element **born on another device** has an opaque
+`entryId` this device never generated, so it isn't in the local `id → key` map and
+can't be resolved. Two ways were considered: a separate per-map "directory" record
+(needs its own union-merge — circular) and self-describing payloads. We chose the
+latter.
+
+Each **map element's plaintext is `{ mk: mapKey, k: elementId, v: value }`** — the
+element carries its own identity *inside the ciphertext* (the server still can't read
+it). The engine gains one small, **optional, additive** hook: on an `id → key` miss
+it decrypts the entry and asks `state.identify(plaintext)` for the synthetic key,
+which the store returns iff `mk` is a managed map. Discovery is **one round** and
+deterministic. Scalar entries keep their bare-value payload, so v1 and v2 clients
+interoperate. (The entry id remains the HMAC of the synthetic key — deterministic
+across devices — so identity drives *merge*; the payload only drives *first-contact
+resolution*.)
+
+### 3. Counters stay scalar — no CRDT counters
+
+`ul.tasbih`, `ul.hifz.streak`, and `ul.adhkar`'s tallies are counters; LWW loses
+concurrent increments. A convergent counter (PN-counter with per-node sub-counts)
+needs a *second* merge algorithm and per-node state, which would break the
+"engine-unchanged" property that makes this design cheap. The conflict is rare
+(single user, rarely concurrent) and the loss is cosmetic (a streak off by one).
+So counters are **not** element-merged: they stay excluded, or become plain
+scalar-LWW. The same goes for the structured scalars (`readingGoal`/`Plan`/`Pages`)
+— a single coherent value, correctly handled by whole-value LWW.
+
+### 4. Collections merge at the collection level first
+
+A `Collection` is one element (id = its UUID, value = the whole collection incl. its
+`ayahs`). Concurrent edits to **different** collections merge cleanly; concurrent
+edits to the **same** collection still LWW-clobber (one device's ayah list wins) —
+an accepted residual, mirroring v1's accepted bookmark-add loss. True nested
+(collection × ayah) merge is a later refinement.
+
+### 5. Phasing (element-flattening multiplies entry count)
+
+Flattening turns ~16 entries into one per element across all map keys, against the
+server's `MAX_ENTRIES` cap and an "every round resends all elements" cost. So roll
+out by cardinality:
+
+- **Phase 1 (this change): bounded keys** — `ul.ayahNotes`, `ul.collections`,
+  `ul.qada`, `ul.haid`, `ul.badges`, `ul.readingActive`, `ul.asmaLearned`,
+  `ul.ramadanFasts`. Combined worst case is a few hundred entries for years of use.
+  Raise `MAX_ENTRIES` (500 → 2000) as headroom; per-entry size + rate-limiting stay
+  the real abuse guards.
+- **Phase 2: slow-growing date logs** — `ul.prayerLog`, `ul.readingLog`,
+  `ul.ramadanWorship` (≈1 element/day; fine under the raised cap for years).
+- **Phase 3: `ul.hifz`** — the only key that can be thousands of elements at once.
+  Gated on the **incremental-pull cursor** (deferred in 0033) so a round is
+  O(changed), not O(total), plus an **atomic server merge** under concurrent push.
+
+Existing v1 scalar keys (notably `ul.bookmarks`) are **not** re-represented in this
+change: every Phase-1 key is a *previously-excluded* key, so each is a pure addition
+of brand-new ids — a v1 client simply never sees them (the engine skips ids it
+doesn't manage), so mixed-version devices can't corrupt each other.
+
+## Consequences
+
+- **Good:** the high-value collection data (notes, collections, qaḍāʾ, ḥayḍ, …) now
+  syncs without clobbering, with **no change to the engine's merge, the wire, or the
+  server** — the same property that made 0033 cheap. Backward-compatible: a v1 client
+  ignores element ids it doesn't manage.
+- **Cost — metadata footprint grows.** The server now holds hundreds (Phase 1) and
+  eventually thousands (hifz) of opaque entries per account instead of ~16. It still
+  cannot read key names, element ids, or plaintext (ids are HMACs; identity rides
+  *inside* the ciphertext). But the **entry count and per-entry sizes/timestamps** —
+  already accepted as residual metadata in 0033 — now also weakly fingerprint usage
+  intensity (e.g. a large hifz set implies a heavy memorizer). This is a conscious
+  acceptance, consistent with 0033 (never content or identity); ciphertext-size
+  bucketing/padding is a possible future mitigation, out of scope here.
+- **Sidecar grows.** `ul.sync.meta` gains a clock+hash per element (~100 bytes each)
+  — single-digit KB for Phase-1 bounded keys; tens–hundreds of KB once hifz lands
+  (tombstone pruning becomes worthwhile then, alongside the cursor).
+- **Determinism.** Array shapes (`collections`, `haid`, sets) must `rebuild` with a
+  deterministic order (sorted) so the recomposed value is stable.
+- **Known Phase-1 limitations (resolved by the Phase-3 cursor).** These follow from
+  flattening + the v1 server's all-or-nothing batch and are accepted for now:
+  - **Tombstones are never pruned.** A deleted element keeps its meta entry and is
+    re-pushed every round, so the client entry count is `live + ever-deleted`,
+    growing monotonically. The `MAX_ENTRIES` cap (now 2000) gives years of headroom
+    for the bounded Phase-1 keys, but pruning provably-converged tombstones is a
+    Phase-3 task (it pairs naturally with the cursor).
+  - **The cap is a hard cliff.** Exceeding `MAX_ENTRIES` makes the server reject the
+    *whole* round (413), and a single element over `MAX_CIPHERTEXT` rejects the whole
+    push (400) — so one fat/excess element can stall sync of everything else
+    (including scalar settings). This all-or-nothing behavior is inherited from v1;
+    flattening makes it more reachable. The fix (graceful per-key/partial-push +
+    prioritising scalar keys, or filtering rather than rejecting) ships with the cursor.
+- **Future hardening — LWW-on-apply guard.** The runtimes now coalesce concurrent
+  rounds (web matched to mobile), which removes the only first-party way two rounds
+  interleave. As defense-in-depth against any future caller that bypasses the
+  runtime, `apply()` could additionally skip a write whose clock is not newer than
+  the stored one (`hlcCompare(incoming, stored) <= 0`), making it idempotent under
+  reordering. Deferred (it interacts with the diff-at-sync clock stamping and is
+  unnecessary given coalescing).
+
+## References
+
+- [ADR 0033](0033-account-sync.md) — the v1 sync decision this refines (its "element-
+  level merge is a later refinement" clause is settled here).
+- Engine/ports: `packages/core/src/sync.ts`, `sync-engine.ts`, `ports.ts`; the shared
+  key contract `packages/core/src/sync-keys.ts`; the new registry
+  `packages/core/src/sync-shapes.ts`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export * from "./backup";
 export * from "./sync";
 export * from "./sync-engine";
 export * from "./sync-keys";
+export * from "./sync-shapes";
 export * from "./collections";
 export * from "./tasbih";
 export * from "./audio";

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -545,4 +545,13 @@ export interface SyncBackend {
 export interface SyncStateStore {
   all(): Promise<readonly SyncRecord[]>;
   apply(key: string, value: string | null, hlc: Hlc): Promise<void>;
+  /**
+   * Optional (v2 element-level merge, ADR 0034): resolve an incoming entry whose
+   * opaque id this device never generated — a collection element first created on
+   * another device. Given the decrypted plaintext (a self-describing element
+   * envelope), return the synthetic key to `apply` it under, or `null` if it isn't
+   * an element this build manages. Lets the engine discover new elements in one
+   * round without learning any value shapes; stores with only scalar keys omit it.
+   */
+  identify?(plaintext: string): string | null;
 }

--- a/packages/core/src/sync-engine.test.ts
+++ b/packages/core/src/sync-engine.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Cipher, SyncBackend, SyncStateStore } from "./ports";
 import { type Hlc, type SyncEntry, hlcInit, mergeEntries } from "./sync";
 import { runSync } from "./sync-engine";
+import { explodeKey, isMapKey, parseElementKey, unwrapElement, wrapElement } from "./sync-shapes";
 
 const at = (millis: number, counter = 0, node = "a"): Hlc => ({ millis, counter, node });
 
@@ -49,6 +50,46 @@ class FakeState implements SyncStateStore {
   }
   async apply(key: string, value: string | null, hlc: Hlc): Promise<void> {
     this.data.set(key, { value, hlc });
+  }
+}
+
+/**
+ * An element-merged state over one real map key (`ul.ayahNotes`), using the actual
+ * `sync-shapes` helpers. Each element is flattened to a synthetic key and carries a
+ * self-describing payload; `identify` resolves an element first seen on another
+ * device. Exercises the v2 engine path end to end.
+ */
+class FakeElementState implements SyncStateStore {
+  private readonly map = new Map<string, string>(); // elementId -> element-JSON value
+  private readonly clocks = new Map<string, Hlc>(); // synthetic key -> hlc
+  private readonly mapKey = "ul.ayahNotes";
+  setEl(id: string, value: string, hlc: Hlc): void {
+    this.map.set(id, value);
+    this.clocks.set(explodeKey(this.mapKey, id), hlc);
+  }
+  getEl(id: string): string | null {
+    return this.map.get(id) ?? null;
+  }
+  async all() {
+    return [...this.map.entries()].map(([id, value]) => {
+      const synthetic = explodeKey(this.mapKey, id);
+      return {
+        key: synthetic,
+        value: wrapElement(this.mapKey, id, value),
+        hlc: this.clocks.get(synthetic) ?? hlcInit("node"),
+      };
+    });
+  }
+  async apply(key: string, value: string | null, hlc: Hlc): Promise<void> {
+    const p = parseElementKey(key);
+    if (!p) return;
+    if (value === null) this.map.delete(p.id);
+    else this.map.set(p.id, unwrapElement(value)?.v ?? value);
+    this.clocks.set(key, hlc);
+  }
+  identify(plaintext: string): string | null {
+    const env = unwrapElement(plaintext);
+    return env && isMapKey(env.mk) ? explodeKey(env.mk, env.k) : null;
   }
 }
 
@@ -136,6 +177,36 @@ describe("runSync", () => {
     const out = await runSync({ cipher, backend, state: a });
     expect(out.pushed).toBe(1);
     expect(backend.store.get("acct-1")).toHaveLength(1);
+  });
+
+  it("discovers an element first created on another device via the identify hook (v2)", async () => {
+    const backend = new FakeBackend();
+    const a = new FakeElementState();
+    a.setEl("2:255", '"my note"', at(10));
+    const b = new FakeElementState(); // has never seen 2:255 — its id isn't in b's keyById
+
+    await runSync({ cipher, backend, state: a }); // A pushes the element
+    const out = await runSync({ cipher, backend, state: b }); // B must DISCOVER it
+
+    expect(b.getEl("2:255")).toBe('"my note"');
+    expect(out.applied).toBe(1);
+  });
+
+  it("merges different elements from two devices without clobbering (the v2 win)", async () => {
+    const backend = new FakeBackend();
+    const a = new FakeElementState();
+    a.setEl("1:1", '"alpha"', at(10, 0, "a"));
+    const b = new FakeElementState();
+    b.setEl("2:2", '"beta"', at(10, 0, "b"));
+
+    await runSync({ cipher, backend, state: a }); // server: {1:1}
+    await runSync({ cipher, backend, state: b }); // server: {1:1, 2:2}; b discovers 1:1
+    await runSync({ cipher, backend, state: a }); // a discovers 2:2
+
+    for (const dev of [a, b]) {
+      expect(dev.getEl("1:1")).toBe('"alpha"');
+      expect(dev.getEl("2:2")).toBe('"beta"'); // neither write clobbered the other
+    }
   });
 
   it("ignores server entries for keys this build does not manage", async () => {

--- a/packages/core/src/sync-engine.ts
+++ b/packages/core/src/sync-engine.ts
@@ -64,15 +64,25 @@ export async function runSync(deps: SyncDeps): Promise<SyncOutcome> {
 
   let applied = 0;
   for (const entry of incoming) {
-    const key = keyById.get(entry.id);
-    if (key === undefined) continue; // a key this build doesn't manage
+    let key = keyById.get(entry.id);
     if (entry.ciphertext === null) {
+      // A tombstone. Only meaningful for a key we already track; an unknown id with
+      // no ciphertext can't be identified (nothing to decrypt) and names something
+      // this device never had — so there is nothing to delete.
+      if (key === undefined) continue;
       await state.apply(key, null, entry.hlc);
       applied++;
       continue;
     }
     const plaintext = await cipher.decrypt(entry.ciphertext, entry.nonce);
     if (plaintext === null) continue; // foreign or corrupt — never clobber local
+    if (key === undefined) {
+      // An element first created on another device: its opaque id isn't in our map,
+      // but its decrypted payload is self-describing (ADR 0034) — let the store
+      // resolve it to a synthetic key, so discovery completes in this one round.
+      key = state.identify?.(plaintext) ?? undefined;
+      if (key === undefined) continue; // not an element this build manages
+    }
     await state.apply(key, plaintext, entry.hlc);
     applied++;
   }

--- a/packages/core/src/sync-keys.ts
+++ b/packages/core/src/sync-keys.ts
@@ -53,4 +53,16 @@ export const MANAGED_KEYS: readonly string[] = [
   "ul.prayerMadhab",
   "ul.prayerHighLat",
   "ul.prayerCoords",
+  // Element-merged collection/set keys (v2, ADR 0034 — Phase 1, bounded cardinality).
+  // Each syncs per element via `sync-shapes.ts`, so concurrent edits to different
+  // entries don't clobber. The date-keyed logs (prayer/reading/ramadan worship) are
+  // Phase 2 and `ul.hifz` is Phase 3 (gated on the incremental-pull cursor).
+  "ul.ayahNotes",
+  "ul.collections",
+  "ul.qada",
+  "ul.haid",
+  "ul.asmaLearned",
+  "ul.ramadanFasts",
+  "ul.badges",
+  "ul.readingActive",
 ];

--- a/packages/core/src/sync-shapes.test.ts
+++ b/packages/core/src/sync-shapes.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Sync shape registry tests (#25, ADR 0034). The load-bearing properties: explode∘
+ * rebuild round-trips, rebuild is deterministically ordered (so a recomposed value
+ * is identical across devices), the element envelope is self-describing, and the
+ * synthetic-key separator can't collide with any managed key or element id.
+ */
+import { describe, expect, it } from "vitest";
+import { MANAGED_KEYS } from "./sync-keys";
+import {
+  ELEMENT_SEP,
+  SYNC_SHAPES,
+  arrayKeyedShape,
+  explodeKey,
+  isMapKey,
+  parseElementKey,
+  recordShape,
+  setShape,
+  shapeOf,
+  unwrapElement,
+  wrapElement,
+} from "./sync-shapes";
+
+describe("recordShape", () => {
+  const s = recordShape();
+  it("explodes a Record into per-element JSON and rebuilds it (sorted, lossless)", () => {
+    const els = s.explode({ b: "x", a: 2 });
+    expect(els.get("a")).toBe("2");
+    expect(els.get("b")).toBe('"x"');
+    expect(s.rebuild(els)).toBe('{"a":2,"b":"x"}'); // deterministic key order
+  });
+  it("tolerates a wrong-shaped value", () => {
+    expect(s.explode(null).size).toBe(0);
+    expect(s.explode([1, 2]).size).toBe(0);
+    expect(s.explode(42).size).toBe(0);
+  });
+});
+
+describe("arrayKeyedShape", () => {
+  const s = arrayKeyedShape((c) => c.id);
+  it("keys array items by a stable field and rebuilds a sorted array", () => {
+    const els = s.explode([
+      { id: "c2", name: "B" },
+      { id: "c1", name: "A" },
+    ]);
+    expect([...els.keys()].sort()).toEqual(["c1", "c2"]);
+    expect(s.rebuild(els)).toBe('[{"id":"c1","name":"A"},{"id":"c2","name":"B"}]');
+  });
+  it("skips items missing the key field", () => {
+    expect(arrayKeyedShape((c) => c.id).explode([{ name: "no id" }]).size).toBe(0);
+  });
+});
+
+describe("setShape", () => {
+  const s = setShape();
+  it("treats each member as an element and rebuilds a sorted array", () => {
+    const els = s.explode(["rose", "mint"]);
+    expect(els.get("mint")).toBe("1");
+    expect(s.rebuild(els)).toBe('["mint","rose"]');
+  });
+  it("drops non-string members", () => {
+    expect(setShape().explode(["a", 3, null]).size).toBe(1);
+  });
+});
+
+describe("element envelope (self-describing payload)", () => {
+  it("wraps and unwraps round-trip", () => {
+    const wrapped = wrapElement("ul.ayahNotes", "2:255", '"my note"');
+    expect(unwrapElement(wrapped)).toEqual({ mk: "ul.ayahNotes", k: "2:255", v: '"my note"' });
+  });
+  it("returns null for a bare/foreign value (a scalar payload)", () => {
+    expect(unwrapElement('"obsidian"')).toBeNull();
+    expect(unwrapElement("not json")).toBeNull();
+    expect(unwrapElement(JSON.stringify({ mk: 1, k: "x", v: "y" }))).toBeNull();
+  });
+});
+
+describe("synthetic keys", () => {
+  it("explode/parse round-trip", () => {
+    const syn = explodeKey("ul.ayahNotes", "2:255");
+    expect(parseElementKey(syn)).toEqual({ mapKey: "ul.ayahNotes", id: "2:255" });
+  });
+  it("returns null for a plain scalar key (no separator)", () => {
+    expect(parseElementKey("ul.theme")).toBeNull();
+  });
+  it("splits on the FIRST separator so element ids may contain colons/dashes", () => {
+    expect(parseElementKey(explodeKey("ul.haid", "2026-06-24"))).toEqual({
+      mapKey: "ul.haid",
+      id: "2026-06-24",
+    });
+  });
+});
+
+describe("registry invariants", () => {
+  it("the separator is a single control char that can't appear in keys or ids", () => {
+    expect(ELEMENT_SEP).toHaveLength(1);
+    expect(ELEMENT_SEP.charCodeAt(0)).toBe(0); // NUL
+    for (const key of Object.keys(SYNC_SHAPES)) expect(key).not.toContain(ELEMENT_SEP);
+    for (const key of MANAGED_KEYS) expect(key).not.toContain(ELEMENT_SEP);
+  });
+  it("every map key is also a managed key (so it actually syncs)", () => {
+    for (const key of Object.keys(SYNC_SHAPES)) expect(MANAGED_KEYS).toContain(key);
+  });
+  it("classifies known keys", () => {
+    expect(isMapKey("ul.ayahNotes")).toBe(true);
+    expect(isMapKey("ul.collections")).toBe(true);
+    expect(shapeOf("ul.theme").kind).toBe("scalar");
+    expect(shapeOf("ul.hifz").kind).toBe("scalar"); // Phase 3 — not yet a map
+  });
+});

--- a/packages/core/src/sync-shapes.ts
+++ b/packages/core/src/sync-shapes.ts
@@ -1,0 +1,171 @@
+/**
+ * Sync shape registry (#25, ADR 0034) — the pure, platform-neutral description of
+ * how each managed key merges. A key is either `scalar` (v1 whole-value
+ * last-writer-wins) or `map` (v2 element-level merge). For a map key, the shape
+ * knows how to **explode** the parsed whole-value into per-element values and
+ * **rebuild** the whole-value from surviving elements.
+ *
+ * The state stores use this to flatten a map key into one synced entry per element
+ * (under a synthetic key `mapKey + SEP + elementId`), so the existing pure
+ * `mergeEntries`/HLC engine merges per element with no change. Nothing here touches
+ * storage, crypto, or the network — same discipline as `sync.ts`/`sync-keys.ts`.
+ */
+
+export type ElementId = string;
+
+export interface ScalarShape {
+  kind: "scalar";
+}
+
+export interface MapShape {
+  kind: "map";
+  /** Explode a parsed whole-value into `elementId → element-JSON`. Tolerates a wrong-shaped value (→ empty). */
+  explode(whole: unknown): Map<ElementId, string>;
+  /** Rebuild the whole-value JSON string from surviving elements, in a deterministic order. */
+  rebuild(elements: Map<ElementId, string>): string;
+}
+
+export type SyncShape = ScalarShape | MapShape;
+
+const SCALAR: ScalarShape = { kind: "scalar" };
+
+/**
+ * Separator between a map key and an element id in a synthetic key. NUL never
+ * appears in a `ul.*` key or in any element id we produce (ayah `s:a`, ISO dates,
+ * prayer-name enums, UUIDs, badge ids, integer indices), so it can't collide.
+ */
+export const ELEMENT_SEP = String.fromCharCode(0);
+
+/** `mapKey` + the element id → the synthetic key that gets hashed into a wire entry id. */
+export function explodeKey(mapKey: string, id: ElementId): string {
+  return mapKey + ELEMENT_SEP + id;
+}
+
+/** Split a synthetic key back into `(mapKey, id)`, or `null` if it's a plain scalar key. */
+export function parseElementKey(synthetic: string): { mapKey: string; id: ElementId } | null {
+  const i = synthetic.indexOf(ELEMENT_SEP);
+  if (i < 0) return null;
+  return { mapKey: synthetic.slice(0, i), id: synthetic.slice(i + 1) };
+}
+
+/**
+ * The decrypted plaintext of a map element carries its own identity (#25, ADR 0034
+ * §2) so a device can resolve an element born on another device in one round —
+ * without the server (which only sees ciphertext) learning the key name or element
+ * id. Scalar entries keep their bare-value payload, so v1 clients interoperate.
+ */
+export interface ElementEnvelope {
+  /** The map key, e.g. `ul.ayahNotes`. */
+  mk: string;
+  /** The element id within that map. */
+  k: ElementId;
+  /** The element's value, as a JSON string. */
+  v: string;
+}
+
+/** Wrap a map element's value into its self-describing payload. */
+export function wrapElement(mapKey: string, id: ElementId, value: string): string {
+  const env: ElementEnvelope = { mk: mapKey, k: id, v: value };
+  return JSON.stringify(env);
+}
+
+/** Parse a self-describing element payload, or `null` if it isn't one (a scalar/foreign value). */
+export function unwrapElement(plaintext: string): ElementEnvelope | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(plaintext);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object") return null;
+  const o = parsed as Record<string, unknown>;
+  if (typeof o.mk === "string" && typeof o.k === "string" && typeof o.v === "string") {
+    return { mk: o.mk, k: o.k, v: o.v };
+  }
+  return null;
+}
+
+const byKeyAsc = (a: [string, string], b: [string, string]): number =>
+  a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+
+/** A map stored as `Record<id, V>` (e.g. `ul.ayahNotes`, `ul.qada`, `ul.asmaLearned`, `ul.ramadanFasts`). */
+export function recordShape(): MapShape {
+  return {
+    kind: "map",
+    explode: (whole) => {
+      const out = new Map<ElementId, string>();
+      if (whole !== null && typeof whole === "object" && !Array.isArray(whole)) {
+        for (const [k, v] of Object.entries(whole as Record<string, unknown>)) {
+          out.set(k, JSON.stringify(v));
+        }
+      }
+      return out;
+    },
+    rebuild: (elements) => {
+      const obj: Record<string, unknown> = {};
+      for (const [k, v] of [...elements.entries()].sort(byKeyAsc)) obj[k] = JSON.parse(v) as unknown;
+      return JSON.stringify(obj);
+    },
+  };
+}
+
+/** A map stored as an array of objects keyed by one stable field (e.g. `ul.collections` by `id`, `ul.haid` by `start`). */
+export function arrayKeyedShape(keyOf: (item: Record<string, unknown>) => unknown): MapShape {
+  return {
+    kind: "map",
+    explode: (whole) => {
+      const out = new Map<ElementId, string>();
+      if (Array.isArray(whole)) {
+        for (const item of whole) {
+          if (item !== null && typeof item === "object") {
+            const id = keyOf(item as Record<string, unknown>);
+            if (typeof id === "string" && id.length > 0) out.set(id, JSON.stringify(item));
+          }
+        }
+      }
+      return out;
+    },
+    rebuild: (elements) =>
+      JSON.stringify([...elements.entries()].sort(byKeyAsc).map(([, v]) => JSON.parse(v) as unknown)),
+  };
+}
+
+/** A set stored as `string[]` (e.g. `ul.badges`, `ul.readingActive`); presence is the element, deletion a tombstone. */
+export function setShape(): MapShape {
+  return {
+    kind: "map",
+    explode: (whole) => {
+      const out = new Map<ElementId, string>();
+      if (Array.isArray(whole)) for (const s of whole) if (typeof s === "string") out.set(s, "1");
+      return out;
+    },
+    rebuild: (elements) => JSON.stringify([...elements.keys()].sort()),
+  };
+}
+
+/**
+ * The shape of every map key (Phase 1, ADR 0034 §5 — bounded keys). Any key NOT
+ * listed here is a scalar (v1 whole-value LWW). Phase 2 adds the date-keyed logs
+ * (`ul.prayerLog`, `ul.readingLog`, `ul.ramadanWorship`); Phase 3 adds `ul.hifz`,
+ * gated on the incremental-pull cursor.
+ */
+export const SYNC_SHAPES: Record<string, SyncShape> = {
+  "ul.ayahNotes": recordShape(),
+  "ul.qada": recordShape(),
+  "ul.asmaLearned": recordShape(),
+  "ul.ramadanFasts": recordShape(),
+  "ul.collections": arrayKeyedShape((c) => c.id),
+  "ul.haid": arrayKeyedShape((p) => p.start),
+  "ul.badges": setShape(),
+  "ul.readingActive": setShape(),
+};
+
+/** The merge shape of a key — scalar unless registered as a map. */
+export function shapeOf(key: string): SyncShape {
+  return SYNC_SHAPES[key] ?? SCALAR;
+}
+
+/** Whether a key is element-merged (a map) rather than whole-value LWW (a scalar). */
+export function isMapKey(key: string): boolean {
+  return shapeOf(key).kind === "map";
+}


### PR DESCRIPTION
## v2 element-level merge (#25, ADR 0034)

Lets the **collection keys** sync — the ones v1 deliberately excluded because whole-value LWW would clobber concurrent edits on different sub-entries (notes, collections, qaḍāʾ, ḥayḍ, badges, asmaLearned, ramadanFasts, readingActive). New [ADR 0034](../blob/feat/sync-mobile/docs/adr/0034-sync-element-merge.md). **Off by default.**

> **Stacked on #169** (`feat/sync-mobile`) for the shared `core/sync-keys.ts`. Base is `feat/sync-mobile`; re-target to `main` once #169 lands. Parallel to the extension PR #170.

### The keystone: element-flattening (engine unchanged)
Each element of a map key becomes its **own `SyncEntry`**, keyed by `HMAC(dataKey, mapKey + NUL + elementId)`. The same element on two devices gets the same opaque id, so the **existing** `mergeEntries`/HLC engine merges per element — `mergeEntries`, the wire format, and the server are **untouched** (the server stays a dumb ciphertext box; the key name + element id ride *inside* the AES-GCM ciphertext, never on the wire).

- **`core/sync-shapes.ts`** (new) — the shape registry: `scalar` (v1) vs `map`, with `recordShape`/`arrayKeyedShape`/`setShape`, `explodeKey`/`parseElementKey`, and the self-describing `{mk,k,v}` envelope.
- **One-round discovery** — an element first created on another device has an id this device never generated; the engine resolves it via an **additive, optional** `state.identify(plaintext)` hook on a `keyById` miss. Scalars keep their bare payload, so v1 clients interoperate (they ignore element ids they don't manage).
- **Web + mobile state stores** flatten/recompose map keys and tombstone removed elements; web `sync-meta` gains `reconcileValues`/`metaKeys`.
- **Server** `MAX_ENTRIES` 500 → 2000 (flattening multiplies entry count).

### Scope & phasing (ADR 0034 §5)
- **Phase 1 (this PR):** bounded keys only — combined worst case is a few hundred entries for years.
- **Phase 2:** slow-growing date logs (prayerLog/readingLog/ramadanWorship).
- **Phase 3:** `ul.hifz` (can be thousands at once), gated on the deferred incremental-pull cursor; tombstone pruning + graceful overflow ship there too.
- `ul.bookmarks` stays **scalar** (not re-represented) — every Phase-1 key is a pure addition, safe for mixed v1/v2 devices.

### Verification
- **Core**: 23 sync tests incl. **one-round discovery** via `identify` and a **two-device no-clobber** case (different elements both survive); 14 shape round-trip/envelope/separator tests.
- **Web/mobile**: element flatten/recompose/tombstone/identify tests; web coalescer tests.
- `pnpm lint && typecheck && test && build` all green.
- A 14-agent adversarial review **refuted** the deep convergence/idempotence/tombstone/no-clobber and NUL-safety concerns (core merge sound) and confirmed 4 findings: **fixed** the one medium (ported mobile's in-flight coalescer to the web runtime — the only first-party way two rounds could interleave and transiently regress the clock sidecar); **documented** 3 low items (tombstone pruning, the hard `MAX_ENTRIES` cliff, oversized-element batch rejection) as Phase-3 work in the ADR.

Draft until provisioned `/api/sync` + device verification.
