### PR TITLE
feat(sync): Phase 2 — date-keyed log element-merge (#25)

### DIFF
--- a/apps/web/src/lib/sync/managed-keys.test.ts
+++ b/apps/web/src/lib/sync/managed-keys.test.ts
@@ -21,19 +21,28 @@ describe("MANAGED_KEYS", () => {
     expect(MANAGED_KEYS).not.toContain("ul.sync.node");
   });
 
-  it("manages the Phase-1 element-merged collection/set keys (v2, ADR 0034)", () => {
-    for (const key of ["ul.ayahNotes", "ul.collections", "ul.qada", "ul.haid", "ul.badges"]) {
+  it("manages the element-merged collection/set/log keys (v2, ADR 0034 Phase 1+2)", () => {
+    for (const key of [
+      // Phase 1
+      "ul.ayahNotes",
+      "ul.collections",
+      "ul.qada",
+      "ul.haid",
+      "ul.badges",
+      // Phase 2 — date logs
+      "ul.readingLog",
+      "ul.prayerLog",
+      "ul.ramadanWorship",
+    ]) {
       expect(MANAGED_KEYS).toContain(key);
     }
   });
 
-  it("still excludes counters and the Phase-2/3 keys (hifz, date logs)", () => {
+  it("still excludes counters and Phase-3 hifz", () => {
     for (const key of [
       "ul.hifz", // Phase 3 — gated on the incremental-pull cursor
       "ul.hifz.streak", // counter
       "ul.tasbih", // counter
-      "ul.prayerLog", // Phase 2 — date log
-      "ul.readingLog", // Phase 2 — date log
       "ul.searchHistory", // weak identity, low value
     ]) {
       expect(MANAGED_KEYS).not.toContain(key);

--- a/packages/core/src/sync-keys.ts
+++ b/packages/core/src/sync-keys.ts
@@ -65,4 +65,9 @@ export const MANAGED_KEYS: readonly string[] = [
   "ul.ramadanFasts",
   "ul.badges",
   "ul.readingActive",
+  // Phase 2 — date-keyed logs. prayerLog/ramadanWorship merge per (date, item) via
+  // the nested shape, so marking different prayers/items on the same day converges.
+  "ul.readingLog",
+  "ul.prayerLog",
+  "ul.ramadanWorship",
 ];

--- a/packages/core/src/sync-shapes.test.ts
+++ b/packages/core/src/sync-shapes.test.ts
@@ -8,10 +8,12 @@ import { describe, expect, it } from "vitest";
 import { MANAGED_KEYS } from "./sync-keys";
 import {
   ELEMENT_SEP,
+  INNER_SEP,
   SYNC_SHAPES,
   arrayKeyedShape,
   explodeKey,
   isMapKey,
+  nestedRecordShape,
   parseElementKey,
   recordShape,
   setShape,
@@ -59,6 +61,32 @@ describe("setShape", () => {
   });
   it("drops non-string members", () => {
     expect(setShape().explode(["a", 3, null]).size).toBe(1);
+  });
+});
+
+describe("nestedRecordShape", () => {
+  const s = nestedRecordShape();
+  it("explodes Record<outer, Record<inner, V>> into one element per (outer, inner) pair", () => {
+    const els = s.explode({ "2026-06-24": { Fajr: "ontime", Dhuhr: "late" }, "2026-06-25": { Fajr: "none" } });
+    expect(els.size).toBe(3);
+    expect(els.get(`2026-06-24${INNER_SEP}Fajr`)).toBe('"ontime"');
+    expect(els.get(`2026-06-25${INNER_SEP}Fajr`)).toBe('"none"');
+  });
+  it("rebuilds the nested record (round-trip)", () => {
+    const whole = { "2026-06-24": { Fajr: "ontime" }, "2026-06-25": { Fajr: "none", Isha: "late" } };
+    expect(JSON.parse(s.rebuild(s.explode(whole)))).toEqual(whole);
+  });
+  it("merging different (date, prayer) elements yields both — the Phase-2 win", () => {
+    // device A marked Fajr, device B marked Dhuhr, same day → union, no clobber
+    const merged = new Map([
+      ...s.explode({ "2026-06-24": { Fajr: "ontime" } }),
+      ...s.explode({ "2026-06-24": { Dhuhr: "late" } }),
+    ]);
+    expect(JSON.parse(s.rebuild(merged))).toEqual({ "2026-06-24": { Dhuhr: "late", Fajr: "ontime" } });
+  });
+  it("tolerates a wrong-shaped value or non-object inner", () => {
+    expect(s.explode(null).size).toBe(0);
+    expect(s.explode({ "2026-06-24": "not an object" }).size).toBe(0);
   });
 });
 

--- a/packages/core/src/sync-shapes.ts
+++ b/packages/core/src/sync-shapes.ts
@@ -36,6 +36,14 @@ const SCALAR: ScalarShape = { kind: "scalar" };
  */
 export const ELEMENT_SEP = String.fromCharCode(0);
 
+/**
+ * Separator WITHIN an element id for a two-level map (`nestedRecordShape`) — joins
+ * the outer and inner keys (e.g. `date<US>prayer`). A distinct control char (US,
+ * 0x1f) so it can't be confused with {@link ELEMENT_SEP} (NUL) and never appears in
+ * an ISO date, prayer-name enum, or worship-item id.
+ */
+export const INNER_SEP = String.fromCharCode(31);
+
 /** `mapKey` + the element id → the synthetic key that gets hashed into a wire entry id. */
 export function explodeKey(mapKey: string, id: ElementId): string {
   return mapKey + ELEMENT_SEP + id;
@@ -130,6 +138,41 @@ export function arrayKeyedShape(keyOf: (item: Record<string, unknown>) => unknow
   };
 }
 
+/**
+ * A two-level map `Record<outerId, Record<innerId, V>>` (e.g. `ul.prayerLog`
+ * date→prayer→status, `ul.ramadanWorship` date→item→done). Each (outer, inner) pair
+ * is its OWN element keyed by `outerId + INNER_SEP + innerId`, so marking different
+ * prayers/items on the same day from two devices merges instead of one day's whole
+ * record clobbering the other.
+ */
+export function nestedRecordShape(): MapShape {
+  return {
+    kind: "map",
+    explode: (whole) => {
+      const out = new Map<ElementId, string>();
+      if (whole !== null && typeof whole === "object" && !Array.isArray(whole)) {
+        for (const [outer, inner] of Object.entries(whole as Record<string, unknown>)) {
+          if (inner !== null && typeof inner === "object" && !Array.isArray(inner)) {
+            for (const [innerKey, v] of Object.entries(inner as Record<string, unknown>)) {
+              out.set(outer + INNER_SEP + innerKey, JSON.stringify(v));
+            }
+          }
+        }
+      }
+      return out;
+    },
+    rebuild: (elements) => {
+      const obj: Record<string, Record<string, unknown>> = {};
+      for (const [id, v] of [...elements.entries()].sort(byKeyAsc)) {
+        const i = id.indexOf(INNER_SEP);
+        if (i < 0) continue; // malformed compound id — skip
+        (obj[id.slice(0, i)] ??= {})[id.slice(i + 1)] = JSON.parse(v) as unknown;
+      }
+      return JSON.stringify(obj);
+    },
+  };
+}
+
 /** A set stored as `string[]` (e.g. `ul.badges`, `ul.readingActive`); presence is the element, deletion a tombstone. */
 export function setShape(): MapShape {
   return {
@@ -144,12 +187,12 @@ export function setShape(): MapShape {
 }
 
 /**
- * The shape of every map key (Phase 1, ADR 0034 §5 — bounded keys). Any key NOT
- * listed here is a scalar (v1 whole-value LWW). Phase 2 adds the date-keyed logs
- * (`ul.prayerLog`, `ul.readingLog`, `ul.ramadanWorship`); Phase 3 adds `ul.hifz`,
- * gated on the incremental-pull cursor.
+ * The shape of every map key. Any key NOT listed here is a scalar (v1 whole-value
+ * LWW). Phase 1 (ADR 0034 §5) = bounded keys; Phase 2 = the date-keyed logs below;
+ * Phase 3 adds `ul.hifz`, gated on the incremental-pull cursor.
  */
 export const SYNC_SHAPES: Record<string, SyncShape> = {
+  // Phase 1 — bounded keys
   "ul.ayahNotes": recordShape(),
   "ul.qada": recordShape(),
   "ul.asmaLearned": recordShape(),
@@ -158,6 +201,10 @@ export const SYNC_SHAPES: Record<string, SyncShape> = {
   "ul.haid": arrayKeyedShape((p) => p.start),
   "ul.badges": setShape(),
   "ul.readingActive": setShape(),
+  // Phase 2 — date-keyed logs (≈1 element/day; the nested ones merge per date+item)
+  "ul.readingLog": recordShape(),
+  "ul.prayerLog": nestedRecordShape(),
+  "ul.ramadanWorship": nestedRecordShape(),
 };
 
 /** The merge shape of a key — scalar unless registered as a map. */


### PR DESCRIPTION
## Phase 2 — element-merge the date-keyed logs (#25, ADR 0034)

Brings the date-keyed tracking logs into element-level sync, reusing the Phase-1 machinery (no engine/wire/server change). **Off by default.**

> **Stacked on #171** (`feat/sync-element-merge`), which is itself on #169. Re-target up the chain as each lands.

### New `nestedRecordShape` for two-level maps
`ul.prayerLog` (date→prayer→status) and `ul.ramadanWorship` (date→item→done) are `Record<date, Record<item, V>>`. The nested shape makes **each (date, item) its own element** (keyed `date<US>item`), so marking *different* prayers on the **same day** from two devices converges — instead of one day's whole record clobbering the other (which flat per-date LWW would do). `ul.readingLog` (date→pages) uses the flat `recordShape`.

- Added to `MANAGED_KEYS`; the state stores are unchanged (they treat the compound element id opaquely and delegate to the shape's explode/rebuild).
- These grow ≈1 element/day → comfortably under the 2000 cap for years. `ul.hifz` (unbounded) stays Phase 3, gated on the incremental-pull cursor.

### Verification
- Core 27 sync tests, incl. nested explode/rebuild round-trip and a **per-(date,prayer) no-clobber** case.
- `pnpm lint && typecheck && test && build` green.
