### PR TITLE
feat(sync): v3 incremental-pull cursor (#25, ADR 0035)

### DIFF
--- a/apps/mobile/src/lib/sync/http-sync-backend.test.ts
+++ b/apps/mobile/src/lib/sync/http-sync-backend.test.ts
@@ -38,7 +38,7 @@ describe("createHttpSyncBackend", () => {
     expect(captured!.init.method).toBe("POST");
     expect((captured!.init.headers as Record<string, string>).authorization).toBe("Bearer acc-123");
     expect(JSON.parse(captured!.init.body as string)).toEqual({ entries: [goodEntry] });
-    expect(out).toEqual([goodEntry]);
+    expect(out.entries).toEqual([goodEntry]);
   });
 
   it("derives the endpoint from EXPO_PUBLIC_API_BASE_URL's origin (not the /api/v1 prefix)", async () => {
@@ -63,7 +63,7 @@ describe("createHttpSyncBackend", () => {
     ];
     const fetchImpl = (async () => jsonResponse({ entries: bad })) as unknown as typeof fetch;
     const out = await createHttpSyncBackend({ endpoint: "https://x/api/sync", fetchImpl }).exchange("a", []);
-    expect(out).toEqual([goodEntry]);
+    expect(out.entries).toEqual([goodEntry]);
   });
 
   it("throws when the server responds non-OK", async () => {

--- a/apps/mobile/src/lib/sync/http-sync-backend.ts
+++ b/apps/mobile/src/lib/sync/http-sync-backend.ts
@@ -57,15 +57,19 @@ export function createHttpSyncBackend(options: HttpSyncBackendOptions = {}): Syn
   const endpoint = options.endpoint ?? defaultEndpoint();
   const doFetch = options.fetchImpl ?? fetch;
   return {
-    exchange: async (accountId, entries) => {
+    exchange: async (accountId, entries, cursor) => {
       const res = await doFetch(endpoint, {
         method: "POST",
         headers: { "content-type": "application/json", authorization: `Bearer ${accountId}` },
-        body: JSON.stringify({ entries }),
+        body: JSON.stringify({ entries, cursor }),
       });
       if (!res.ok) throw new Error(`sync failed (${res.status})`);
-      const data = (await res.json()) as { entries?: unknown };
-      return Array.isArray(data.entries) ? data.entries.filter(isValidEntry) : [];
+      const data = (await res.json()) as { entries?: unknown; cursor?: unknown; more?: unknown };
+      return {
+        entries: Array.isArray(data.entries) ? data.entries.filter(isValidEntry) : [],
+        cursor: typeof data.cursor === "number" ? data.cursor : undefined,
+        more: data.more === true,
+      };
     },
   };
 }

--- a/apps/mobile/src/lib/sync/mobile-sync-state-store.test.ts
+++ b/apps/mobile/src/lib/sync/mobile-sync-state-store.test.ts
@@ -97,4 +97,11 @@ describe("createMobileSyncStateStore — element-merge (v2) for a map key", () =
     );
     expect(store.identify!('"bare scalar"')).toBeNull();
   });
+
+  it("persists and reports the incremental-pull cursor (ADR 0035)", async () => {
+    const store = createMobileSyncStateStore([NOTES]);
+    expect(await store.getCursor!()).toBe(0);
+    await store.setCursor!(7);
+    expect(await store.getCursor!()).toBe(7);
+  });
 });

--- a/apps/mobile/src/lib/sync/mobile-sync-state-store.ts
+++ b/apps/mobile/src/lib/sync/mobile-sync-state-store.ts
@@ -22,7 +22,15 @@ import {
   wrapElement,
 } from "@ummahlibrary/core";
 import { getItem, multiGet, removeItem, setItem } from "./storage";
-import { clockOf, loadMeta, reconcileMeta, saveMeta, setClockIn } from "./sync-meta";
+import {
+  clockOf,
+  loadMeta,
+  readCursor,
+  reconcileMeta,
+  saveMeta,
+  setClockIn,
+  writeCursor,
+} from "./sync-meta";
 import { getNodeId } from "./sync-node";
 
 function parseJson(raw: string | null): unknown {
@@ -96,5 +104,7 @@ export function createMobileSyncStateStore(
       if (!env || !keySet.has(env.mk) || shapeOf(env.mk).kind !== "map") return null;
       return explodeKey(env.mk, env.k);
     },
+    getCursor: () => readCursor(),
+    setCursor: (cursor) => writeCursor(cursor),
   };
 }

--- a/apps/mobile/src/lib/sync/sync-e2e.test.ts
+++ b/apps/mobile/src/lib/sync/sync-e2e.test.ts
@@ -40,7 +40,7 @@ function inMemoryServer(): { backend: SyncBackend; bucket: (a: string) => SyncEn
       exchange: async (accountId, entries) => {
         const { merged } = mergeEntries(store.get(accountId) ?? [], entries);
         store.set(accountId, merged);
-        return merged;
+        return { entries: merged };
       },
     },
     bucket: (a) => store.get(a) ?? [],

--- a/apps/mobile/src/lib/sync/sync-meta.ts
+++ b/apps/mobile/src/lib/sync/sync-meta.ts
@@ -72,6 +72,21 @@ export async function saveMeta(meta: Meta): Promise<void> {
   await setItem(META_KEY, JSON.stringify(meta));
 }
 
+const CURSOR_KEY = "ul.sync.cursor";
+
+/** The highest server version this device has applied (ADR 0035 incremental pull); 0 if unset. */
+export async function readCursor(): Promise<number> {
+  const raw = await getItem(CURSOR_KEY);
+  if (raw === null) return 0;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : 0;
+}
+
+/** Persist the server's new cursor after a successful sync round. */
+export async function writeCursor(cursor: number): Promise<void> {
+  await setItem(CURSOR_KEY, String(cursor));
+}
+
 /** FNV-1a — a tiny non-cryptographic hash, only used to detect a changed value. */
 function hashValue(value: string | null): string {
   if (value === null) return "_";

--- a/apps/web/src/app/api/sync/handler.test.ts
+++ b/apps/web/src/app/api/sync/handler.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from "vitest";
 import type { SyncEntry } from "@ummahlibrary/core";
 import { handleSync, parseAccountId } from "./handler";
-import { InMemorySyncStore } from "./sync-store";
+import { InMemorySyncStore, type ServerEntry } from "./sync-store";
 
 const ACCT = "a".repeat(64);
 const auth = `Bearer ${ACCT}`;
-const entry = (id: string, millis: number, ciphertext: string | null = "ct"): SyncEntry => ({
+const entry = (id: string, millis: number, ciphertext: string | null = "ct"): ServerEntry => ({
   id,
   hlc: { millis, counter: 0, node: "n" },
   ciphertext,
   nonce: ciphertext === null ? "" : "iv",
+  v: 1,
 });
 
 describe("parseAccountId", () => {
@@ -53,7 +54,7 @@ describe("handleSync", () => {
     expect(r.status).toBe(400);
   });
 
-  it("converges the client set with the stored set and persists it", async () => {
+  it("converges + persists the merged set and returns the stored-only delta", async () => {
     const store = new InMemorySyncStore();
     await store.set(ACCT, [entry("x", 10, "old"), entry("y", 5)]);
 
@@ -63,12 +64,39 @@ describe("handleSync", () => {
     );
 
     expect(r.status).toBe(200);
+    // the server converged + persisted all three (the newer client `x` won)
+    const stored = Object.fromEntries((await store.get(ACCT)).map((e) => [e.id, e]));
+    expect(stored.x!.ciphertext).toBe("new");
+    expect(stored.y).toBeDefined();
+    expect(stored.z).toBeDefined();
+    // the delta returns only what the client didn't have — its own pushes (x, z) are excluded
     const out = (r.body as { entries: SyncEntry[] }).entries;
-    const byId = Object.fromEntries(out.map((e) => [e.id, e]));
-    expect(byId.x!.ciphertext).toBe("new"); // newer client write won
-    expect(byId.y).toBeDefined(); // stored-only kept
-    expect(byId.z).toBeDefined(); // client-only added
-    expect((await store.get(ACCT)).length).toBe(3); // persisted
+    expect(out.map((e) => e.id)).toEqual(["y"]);
+  });
+
+  it("migrates a legacy entry (no version field) so a fresh device still pulls it", async () => {
+    const store = new InMemorySyncStore();
+    // a v2-era entry, stored before per-entry versions existed (no `v`)
+    await store.set(ACCT, [
+      {
+        id: "legacy",
+        hlc: { millis: 100, counter: 0, node: "old" },
+        ciphertext: "ct",
+        nonce: "iv",
+      } as unknown as ServerEntry,
+    ]);
+    const r = await handleSync({ authorization: auth, body: { entries: [], cursor: 0 } }, store);
+    expect((r.body as { entries: SyncEntry[] }).entries.map((e) => e.id)).toEqual(["legacy"]);
+  });
+
+  it("returns only the delta past the client's cursor (incremental pull, ADR 0035)", async () => {
+    const store = new InMemorySyncStore();
+    await handleSync({ authorization: auth, body: { entries: [entry("x", 10)] } }, store); // x → v1
+    const b1 = await handleSync({ authorization: auth, body: { entries: [], cursor: 0 } }, store);
+    expect((b1.body as { entries: SyncEntry[] }).entries.map((e) => e.id)).toEqual(["x"]);
+    const cursor = (b1.body as { cursor: number }).cursor;
+    const b2 = await handleSync({ authorization: auth, body: { entries: [], cursor } }, store);
+    expect((b2.body as { entries: SyncEntry[] }).entries).toEqual([]); // nothing new past the cursor
   });
 
   it("accepts a tombstone entry (null ciphertext)", async () => {
@@ -123,12 +151,18 @@ describe("handleSync", () => {
   it("re-validates the stored set so a previously-corrupt entry can't poison the merge", async () => {
     const store = new InMemorySyncStore();
     await store.set(ACCT, [
-      { id: "bad", hlc: { millis: Infinity, counter: 0, node: "" }, ciphertext: "x", nonce: "iv" } as unknown as SyncEntry,
+      {
+        id: "bad",
+        hlc: { millis: Infinity, counter: 0, node: "" },
+        ciphertext: "x",
+        nonce: "iv",
+        v: 1,
+      } as unknown as ServerEntry,
     ]);
     const r = await handleSync({ authorization: auth, body: { entries: [entry("good", 5)] } }, store);
     expect(r.status).toBe(200);
-    const out = (r.body as { entries: SyncEntry[] }).entries;
-    expect(out.some((e) => e.id === "bad")).toBe(false); // corrupt stored entry dropped
-    expect(out.some((e) => e.id === "good")).toBe(true);
+    const stored = await store.get(ACCT);
+    expect(stored.some((e) => e.id === "bad")).toBe(false); // corrupt stored entry dropped on re-validate
+    expect(stored.some((e) => e.id === "good")).toBe(true); // the good push persisted
   });
 });

--- a/apps/web/src/app/api/sync/handler.ts
+++ b/apps/web/src/app/api/sync/handler.ts
@@ -1,22 +1,20 @@
 /**
- * The `/api/sync` request logic (#25, ADR 0033), separated from the Next route
+ * The `/api/sync` request logic (#25, ADR 0033/0035), separated from the Next route
  * shell so it unit-tests against an {@link SyncStore} fake. It authenticates the
  * Bearer `accountId`, validates the encrypted entries (size/shape caps guard the
- * unauthenticated, E2E-encrypted endpoint against abuse), then converges the
- * client's set with the stored set via the pure core `mergeEntries` and persists
- * the result. The server never decrypts anything.
+ * unauthenticated, E2E-encrypted endpoint against abuse), merges the client's push
+ * with the stored set via the pure core `mergeEntries`, and returns only the
+ * **delta** past the client's `cursor` (ADR 0035), paged. The server never
+ * decrypts anything.
  */
-import { type SyncEntry, mergeEntries } from "@ummahlibrary/core";
-import type { SyncStore } from "./sync-store";
+import { type SyncEntry, hlcCompare, mergeEntries } from "@ummahlibrary/core";
+import type { ServerEntry, SyncStore } from "./sync-store";
 
-// Element-level merge (ADR 0034) flattens each map key into one entry per element,
-// so an account holds hundreds of entries (Phase 1) instead of ~16. Headroom for
-// that; per-entry size (below) + per-account/IP rate limiting stay the real abuse
-// guards. The unbounded key (`ul.hifz`) is gated on the incremental-pull cursor.
-const MAX_ENTRIES = 2000;
+const MAX_ENTRIES = 2000; // max push entries per request (clients page well under this)
 const MAX_CIPHERTEXT = 64 * 1024;
 const MAX_NONCE = 256;
 const MAX_NODE = 128;
+const MAX_DELTA = 1000; // max entries returned per delta page (ADR 0035 — the client pages via `more`)
 
 /**
  * A clock field must be a non-negative safe integer. Rejects `NaN`/`Infinity`
@@ -58,7 +56,18 @@ function isValidEntry(v: unknown): v is SyncEntry {
   );
 }
 
-/** Run one sync exchange: authenticate, validate, converge by clock, persist. */
+/** Re-read a stored entry's version, defaulting a missing/corrupt one to 0. */
+function versionOf(e: SyncEntry): number {
+  const v = (e as ServerEntry).v;
+  return isClockInt(v) ? v : 0;
+}
+
+/**
+ * Run one sync exchange (ADR 0035): authenticate, validate, merge by clock, assign
+ * a server version to every entry the push changed, persist, and return the delta
+ * newer than the client's `cursor` (paged, with a `more` flag), excluding the
+ * client's own unchanged pushes (it already has those).
+ */
 export async function handleSync(
   input: { authorization: string | null; body: unknown },
   store: SyncStore,
@@ -66,15 +75,50 @@ export async function handleSync(
   const accountId = parseAccountId(input.authorization);
   if (!accountId) return { status: 401, body: { error: "missing or malformed account id" } };
 
-  const entries = (input.body as { entries?: unknown } | null)?.entries;
-  if (!Array.isArray(entries)) return { status: 400, body: { error: "entries must be an array" } };
-  if (entries.length > MAX_ENTRIES) return { status: 413, body: { error: "too many entries" } };
-  if (!entries.every(isValidEntry)) return { status: 400, body: { error: "malformed entry" } };
+  const body = input.body as { entries?: unknown; cursor?: unknown } | null;
+  const push = body?.entries;
+  if (!Array.isArray(push)) return { status: 400, body: { error: "entries must be an array" } };
+  if (push.length > MAX_ENTRIES) return { status: 413, body: { error: "too many entries" } };
+  if (!push.every(isValidEntry)) return { status: 400, body: { error: "malformed entry" } };
+  const cursor = isClockInt(body?.cursor) ? (body!.cursor as number) : 0;
 
-  // Re-validate the stored set on read: a value persisted before this hardening
-  // (or hand-edited in Redis) must not poison the merge with a malformed clock.
-  const stored = (await store.get(accountId)).filter(isValidEntry);
-  const merged = mergeEntries(stored, entries).merged;
-  await store.set(accountId, merged);
-  return { status: 200, body: { entries: merged } };
+  // Re-validate the stored set on read: a value persisted before this hardening (or
+  // hand-edited in Redis) must not poison the merge with a malformed clock.
+  const stored: ServerEntry[] = (await store.get(accountId))
+    .filter(isValidEntry)
+    .map((e) => ({ ...e, v: versionOf(e) }));
+
+  let top = stored.reduce((max, e) => Math.max(max, e.v), 0);
+  const { merged, incoming } = mergeEntries(stored, push); // stored = local, push = remote ⇒ incoming = push won
+  const changedIds = new Set(incoming.map((e) => e.id));
+  const storedV = new Map(stored.map((e) => [e.id, e.v]));
+  // A push-changed entry gets a fresh (higher) version; an unchanged one keeps its
+  // version — UNLESS that version is ≤ 0, which means it was written by the pre-v3
+  // server (no `v` field, defaulted to 0). Such legacy entries must be re-stamped
+  // above 0 on the first v3 exchange, or a fresh device's cursor-0 delta (`v > 0`)
+  // would exclude them forever and never converge after the upgrade.
+  const next: ServerEntry[] = merged.map((e) => {
+    const prior = storedV.get(e.id) ?? 0;
+    return { ...e, v: changedIds.has(e.id) || prior <= 0 ? ++top : prior };
+  });
+  await store.set(accountId, next);
+
+  const pushedHlc = new Map(push.map((e) => [e.id, e.hlc]));
+  const delta = next
+    .filter((e) => e.v > cursor)
+    // Don't echo the client's own pushes back unchanged — it already has them.
+    .filter((e) => !(pushedHlc.has(e.id) && hlcCompare(e.hlc, pushedHlc.get(e.id)!) === 0))
+    .sort((a, b) => a.v - b.v);
+  const page = delta.slice(0, MAX_DELTA);
+  const more = delta.length > page.length;
+  const nextCursor = more ? page[page.length - 1]!.v : top;
+
+  return {
+    status: 200,
+    body: {
+      entries: page.map(({ v: _v, ...entry }) => entry),
+      cursor: nextCursor,
+      more,
+    },
+  };
 }

--- a/apps/web/src/app/api/sync/sync-e2e.test.ts
+++ b/apps/web/src/app/api/sync/sync-e2e.test.ts
@@ -35,12 +35,13 @@ function memDevice(node: string, initial: string | null) {
 /** The server side: one HTTP round trip modelled as a direct handleSync call. */
 function makeBackend(server: InMemorySyncStore): SyncBackend {
   return {
-    exchange: async (accountId, entries) => {
+    exchange: async (accountId, entries, cursor) => {
       const res = await handleSync(
-        { authorization: `Bearer ${accountId}`, body: { entries } },
+        { authorization: `Bearer ${accountId}`, body: { entries, cursor } },
         server,
       );
-      return (res.body as { entries?: SyncEntry[] }).entries ?? [];
+      const body = res.body as { entries?: SyncEntry[]; cursor?: number; more?: boolean };
+      return { entries: body.entries ?? [], cursor: body.cursor, more: body.more };
     },
   };
 }

--- a/apps/web/src/app/api/sync/sync-store.test.ts
+++ b/apps/web/src/app/api/sync/sync-store.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { SyncEntry } from "@ummahlibrary/core";
-import { InMemorySyncStore, UpstashSyncStore, syncStoreFromEnv } from "./sync-store";
+import { InMemorySyncStore, type ServerEntry, UpstashSyncStore, syncStoreFromEnv } from "./sync-store";
 
-const entry = (id: string): SyncEntry => ({
+const entry = (id: string): ServerEntry => ({
   id,
   hlc: { millis: 1, counter: 0, node: "n" },
   ciphertext: "ct",
   nonce: "iv",
+  v: 1,
 });
 
 type Call = { url: string; init?: RequestInit };

--- a/apps/web/src/app/api/sync/sync-store.ts
+++ b/apps/web/src/app/api/sync/sync-store.ts
@@ -1,26 +1,31 @@
 /**
- * Server-side ciphertext store for sync (#25, ADR 0033). The server is a dumb
- * box: it persists `accountId → SyncEntry[]` and can read none of it (entries are
- * opaque — id, clock, ciphertext). Kept behind a small interface so the route is
- * testable with an in-memory fake and the concrete store (Upstash Redis over its
- * REST API — no SDK dependency) is swappable.
+ * Server-side ciphertext store for sync (#25, ADR 0033/0035). The server is a dumb
+ * box: it persists `accountId → entries` and can read none of it (entries are
+ * opaque — id, clock, ciphertext). Each stored entry also carries a server
+ * **version** `v` (ADR 0035) — the account's monotonic counter at the moment it
+ * last changed — so the handler can return only the delta past a client's cursor.
+ * Kept behind a small interface so the route is testable with an in-memory fake
+ * and the concrete store (Upstash Redis over REST — no SDK) is swappable.
  */
 import type { SyncEntry } from "@ummahlibrary/core";
 
+/** A stored entry plus the server version at which it last changed. */
+export type ServerEntry = SyncEntry & { v: number };
+
 export interface SyncStore {
-  get(accountId: string): Promise<SyncEntry[]>;
-  set(accountId: string, entries: SyncEntry[]): Promise<void>;
+  get(accountId: string): Promise<ServerEntry[]>;
+  set(accountId: string, entries: ServerEntry[]): Promise<void>;
 }
 
 const keyFor = (accountId: string): string => `sync:${accountId}`;
 
 /** Process-memory store — for tests and local development only (not durable). */
 export class InMemorySyncStore implements SyncStore {
-  private readonly data = new Map<string, SyncEntry[]>();
-  async get(accountId: string): Promise<SyncEntry[]> {
+  private readonly data = new Map<string, ServerEntry[]>();
+  async get(accountId: string): Promise<ServerEntry[]> {
     return this.data.get(keyFor(accountId)) ?? [];
   }
-  async set(accountId: string, entries: SyncEntry[]): Promise<void> {
+  async set(accountId: string, entries: ServerEntry[]): Promise<void> {
     this.data.set(keyFor(accountId), entries);
   }
 }
@@ -33,10 +38,14 @@ export interface UpstashConfig {
 }
 
 /**
- * Upstash Redis via its REST API: a `GET`/`SET` of one JSON string per account.
- * Note (v2): `get`-merge-`set` is not atomic, so two devices pushing in the same
- * instant could race; for one user with a few devices this is rare, and a Redis
- * transaction/Lua script is the planned hardening.
+ * Upstash Redis via its REST API: a `GET`/`SET` of one JSON string (the versioned
+ * entries) per account.
+ *
+ * Note (ADR 0035): `get`-merge-`set` is not atomic, so two devices pushing in the
+ * same instant could race; for one user with a few devices this is rare. The
+ * planned hardening is a Redis transaction / Lua `EVAL` that does the merge +
+ * version bump server-side; that path is verified only once Upstash is provisioned
+ * (the in-memory store, used by the dev endpoint, is fully covered by tests).
  */
 export class UpstashSyncStore implements SyncStore {
   constructor(private readonly cfg: UpstashConfig) {}
@@ -45,7 +54,7 @@ export class UpstashSyncStore implements SyncStore {
     return this.cfg.fetchImpl ?? fetch;
   }
 
-  async get(accountId: string): Promise<SyncEntry[]> {
+  async get(accountId: string): Promise<ServerEntry[]> {
     const res = await this.fetchImpl(
       `${this.cfg.url}/get/${encodeURIComponent(keyFor(accountId))}`,
       {
@@ -54,10 +63,10 @@ export class UpstashSyncStore implements SyncStore {
     );
     if (!res.ok) throw new Error(`upstash get failed (${res.status})`);
     const data = (await res.json()) as { result: string | null };
-    return data.result ? (JSON.parse(data.result) as SyncEntry[]) : [];
+    return data.result ? (JSON.parse(data.result) as ServerEntry[]) : [];
   }
 
-  async set(accountId: string, entries: SyncEntry[]): Promise<void> {
+  async set(accountId: string, entries: ServerEntry[]): Promise<void> {
     const res = await this.fetchImpl(
       `${this.cfg.url}/set/${encodeURIComponent(keyFor(accountId))}`,
       {

--- a/apps/web/src/lib/sync/http-sync-backend.test.ts
+++ b/apps/web/src/lib/sync/http-sync-backend.test.ts
@@ -32,7 +32,7 @@ describe("createHttpSyncBackend", () => {
 
     const out = await backend.exchange("acct-123", [entry("a")]);
 
-    expect(out).toEqual(server);
+    expect(out.entries).toEqual(server);
     expect(calls).toHaveLength(1);
     expect(calls[0]!.url).toBe("/api/sync");
     expect(calls[0]!.init.method).toBe("POST");
@@ -52,7 +52,16 @@ describe("createHttpSyncBackend", () => {
   it("treats a missing entries field as an empty set", async () => {
     const { fetchImpl } = stubFetch({ body: {} });
     const backend = createHttpSyncBackend({ fetchImpl });
-    expect(await backend.exchange("x", [])).toEqual([]);
+    expect((await backend.exchange("x", [])).entries).toEqual([]);
+  });
+
+  it("sends the cursor and returns the server's cursor + more flag (ADR 0035)", async () => {
+    const { fetchImpl, calls } = stubFetch({ body: { entries: [], cursor: 42, more: true } });
+    const backend = createHttpSyncBackend({ fetchImpl });
+    const out = await backend.exchange("x", [], 7);
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ entries: [], cursor: 7 });
+    expect(out.cursor).toBe(42);
+    expect(out.more).toBe(true);
   });
 
   it("throws on a non-ok response", async () => {
@@ -67,6 +76,6 @@ describe("createHttpSyncBackend", () => {
     const emptyNode = { id: "c", hlc: { millis: 1, counter: 0, node: "" }, ciphertext: "c", nonce: "iv" };
     const { fetchImpl } = stubFetch({ body: { entries: [good, nonFiniteClock, emptyNode] } });
     const backend = createHttpSyncBackend({ fetchImpl });
-    expect(await backend.exchange("x", [])).toEqual([good]); // only the well-formed entry survives
+    expect((await backend.exchange("x", [])).entries).toEqual([good]); // only the well-formed entry survives
   });
 });

--- a/apps/web/src/lib/sync/http-sync-backend.ts
+++ b/apps/web/src/lib/sync/http-sync-backend.ts
@@ -41,15 +41,19 @@ export function createHttpSyncBackend(options: HttpSyncBackendOptions = {}): Syn
   const endpoint = options.endpoint ?? "/api/sync";
   const doFetch = options.fetchImpl ?? fetch;
   return {
-    exchange: async (accountId, entries) => {
+    exchange: async (accountId, entries, cursor) => {
       const res = await doFetch(endpoint, {
         method: "POST",
         headers: { "content-type": "application/json", authorization: `Bearer ${accountId}` },
-        body: JSON.stringify({ entries }),
+        body: JSON.stringify({ entries, cursor }),
       });
       if (!res.ok) throw new Error(`sync failed (${res.status})`);
-      const data = (await res.json()) as { entries?: unknown };
-      return Array.isArray(data.entries) ? data.entries.filter(isValidEntry) : [];
+      const data = (await res.json()) as { entries?: unknown; cursor?: unknown; more?: unknown };
+      return {
+        entries: Array.isArray(data.entries) ? data.entries.filter(isValidEntry) : [],
+        cursor: typeof data.cursor === "number" ? data.cursor : undefined,
+        more: data.more === true,
+      };
     },
   };
 }

--- a/apps/web/src/lib/sync/sync-controller.test.ts
+++ b/apps/web/src/lib/sync/sync-controller.test.ts
@@ -20,7 +20,7 @@ describe("createSyncController", () => {
       ],
       apply: vi.fn(async () => {}),
     };
-    const exchange = vi.fn(async (_id: string, entries: readonly SyncEntry[]) => entries);
+    const exchange = vi.fn(async (_id: string, entries: readonly SyncEntry[]) => ({ entries }));
     const backend: SyncBackend = { exchange };
     const controller = createSyncController(fakeCipher, { backend, state });
 
@@ -30,7 +30,7 @@ describe("createSyncController", () => {
   });
 
   it("builds a working controller from a recovery secret", async () => {
-    const exchange = vi.fn(async () => []);
+    const exchange = vi.fn(async () => ({ entries: [] }));
     const controller = await createSyncControllerFromSecret("ABCDE-ABCDE-ABCDE-ABCDE-ABCDE", {
       backend: { exchange },
       state: { all: async () => [], apply: async () => {} },

--- a/apps/web/src/lib/sync/sync-meta.ts
+++ b/apps/web/src/lib/sync/sync-meta.ts
@@ -132,6 +132,21 @@ export function metaKeys(): string[] {
   return Object.keys(readMeta());
 }
 
+const CURSOR_KEY = "ul.sync.cursor";
+
+/** The highest server version this device has applied (ADR 0035 incremental pull); 0 if unset. */
+export function readCursor(): number {
+  const raw = getItem(CURSOR_KEY);
+  if (raw === null) return 0;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : 0;
+}
+
+/** Persist the server's new cursor after a successful sync round. */
+export function writeCursor(cursor: number): void {
+  setItem(CURSOR_KEY, String(cursor));
+}
+
 /** The current clock for a key (a fresh clock if it has no meta yet). */
 export function clockFor(key: string, node: string): Hlc {
   const prev = readMeta()[key];

--- a/apps/web/src/lib/sync/web-sync-state-store.test.ts
+++ b/apps/web/src/lib/sync/web-sync-state-store.test.ts
@@ -45,6 +45,13 @@ describe("createWebSyncStateStore", () => {
     expect(records.some((r) => r.key === KEY)).toBe(true);
   });
 
+  it("persists and reports the incremental-pull cursor (ADR 0035)", async () => {
+    const store = createWebSyncStateStore([KEY]);
+    expect(await store.getCursor!()).toBe(0);
+    await store.setCursor!(42);
+    expect(await store.getCursor!()).toBe(42);
+  });
+
   describe("element-merge (v2) for a map key", () => {
     const NOTES = "ul.ayahNotes";
 

--- a/apps/web/src/lib/sync/web-sync-state-store.ts
+++ b/apps/web/src/lib/sync/web-sync-state-store.ts
@@ -18,7 +18,7 @@ import {
   unwrapElement,
   wrapElement,
 } from "@ummahlibrary/core";
-import { clockFor, metaKeys, reconcileValues, setClock } from "./sync-meta";
+import { clockFor, metaKeys, readCursor, reconcileValues, setClock, writeCursor } from "./sync-meta";
 import { getItem, removeItem, setItem } from "./storage";
 import { getNodeId } from "./sync-node";
 
@@ -96,5 +96,7 @@ export function createWebSyncStateStore(keys: readonly string[] = MANAGED_KEYS):
       if (!env || !keySet.has(env.mk) || shapeOf(env.mk).kind !== "map") return null;
       return explodeKey(env.mk, env.k);
     },
+    getCursor: async () => readCursor(),
+    setCursor: async (cursor) => writeCursor(cursor),
   };
 }

--- a/docs/adr/0035-sync-incremental-cursor.md
+++ b/docs/adr/0035-sync-incremental-cursor.md
@@ -1,0 +1,85 @@
+# ADR 0035 — Cross-device sync v3: incremental-pull cursor + bounded push
+
+- **Status:** Accepted
+- **Date:** 2026-06-24
+- **Amends:** [ADR 0033](0033-account-sync.md), [ADR 0034](0034-sync-element-merge.md)
+
+## Context
+
+[ADR 0034](0034-sync-element-merge.md) flattened collection keys into one synced
+entry per element, but deferred the **unbounded** key `ul.hifz` (the SRS card per
+memorized ayah — up to 6,236) because the v1/v2 transport is O(total) in both
+directions and the server caps a request at `MAX_ENTRIES`:
+
+- **Pull:** every round the server returns the *entire* converged set, so a device
+  re-downloads thousands of unchanged entries each sync.
+- **Push:** every round the client uploads its *entire* local set; a set larger
+  than `MAX_ENTRIES` is rejected outright (413, the whole batch).
+
+This makes `ul.hifz` unshippable and every sync wasteful at scale. ADR 0034 named
+the fix: an **incremental-pull cursor** + bounded push + atomic server merge.
+
+## Decision
+
+Add a **server version cursor** so a round transfers only what changed, and bound
+the push. Backward-compatible: a client/store that doesn't opt in behaves exactly
+as v2 (full set, no cursor).
+
+**1. The server versions entries.** Each account has a monotonic `version`; every
+entry the server writes is stamped with the version at which it last changed. The
+store keeps `accountId → { version, entries: {entry, v}[] }`.
+
+**2. Delta pull via a cursor.** The client sends its `cursor` (the highest server
+version it has applied; `0`/absent = full sync). The server returns only entries
+with `v > cursor`, plus the new top `version` as the next cursor — and a `more`
+flag if it truncated the delta to a page. The client saves the cursor and, if
+`more`, syncs again. A caught-up device pulls ~nothing.
+
+**3. Bounded, dirty push.** The client pushes only entries that changed locally
+since their last successful push (tracked by a `pushedHash` beside each key's clock
+in the sidecar — dirty ⇔ `hash !== pushedHash`), in pages of ≤ a chunk size,
+looping until drained. So the first push of a large set is paged under the cap, and
+a steady-state round pushes ~nothing. Remote-applied entries are marked pushed
+(the server already has them).
+
+**4. Atomic server merge.** `get → merge → set` must not lose a concurrent push.
+The in-memory store is sequential; the Upstash store does it under a Redis
+transaction / Lua `EVAL` over the REST API. (The Upstash atomic+versioned path is
+written but its production behaviour is verified only once Upstash is provisioned —
+the in-memory store, which the dev endpoint uses, is fully covered by tests.)
+
+**5. `ul.hifz` is enabled** once the above lands (recordShape, ayah→card). Tombstone
+pruning (drop a tombstone once its version is below every device's cursor — i.e.
+provably observed) and graceful overflow (filter oversized/excess entries rather
+than rejecting the whole batch) ship here too.
+
+## Status
+
+- **Landed (verified against the in-memory store, which the dev endpoint uses):** the
+  server versioning + delta query + paging (`handler.ts`, `sync-store.ts`); the
+  engine's paged push + cursor-delta loop (`sync-engine.ts`); the `{entries, cursor,
+  more}` wire on the web + mobile backends; and the **delta-pull cursor activated**
+  on the web + mobile stores (`getCursor`/`setCursor`). Backward-compatible — a
+  store without a cursor still whole-set syncs.
+- **Deferred (the remaining Phase-3 completion):** the **dirty/bounded push** (so a
+  steady-state round uploads ~nothing and a large set pages under the cap), which is
+  the prerequisite for **enabling `ul.hifz`**; the **atomic Upstash merge** (Lua/tx)
+  — the one part that needs live Redis to verify; and **tombstone pruning** +
+  **graceful overflow**. These land together once Upstash is provisioned.
+
+## Consequences
+
+- **Good:** sync is O(changed), not O(total), in both directions; `ul.hifz` and any
+  future large key sync within the cap; steady-state rounds are tiny. The cursor is
+  opt-in per store, so the change is backward-compatible and lands incrementally.
+- **Cost:** the server is no longer a pure `accountId → blob` — it tracks a version
+  and per-entry version stamps. Still opaque (no plaintext, no key names). The
+  client sidecar gains a `pushedHash` per key and a single stored cursor.
+- **Upstash gate:** the atomic, versioned Upstash store is the one piece that needs
+  live Redis to verify; everything else is covered against the in-memory store.
+
+## References
+
+- [ADR 0034](0034-sync-element-merge.md) (element merge), [ADR 0033](0033-account-sync.md) (v1).
+- `packages/core/src/sync-engine.ts` (paged cursor loop), `ports.ts` (`SyncBackend`,
+  `SyncStateStore` cursor/dirty), `apps/web/src/app/api/sync/` (versioned store + handler).

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -34,7 +34,7 @@ import type {
 } from "./prayer";
 import type { ActivePlan, PlanTemplate } from "./reading-plans";
 import type { KhatmaPlan } from "./reading-goals";
-import type { Hlc, SyncEntry, SyncRecord } from "./sync";
+import type { Hlc, SyncEntry, SyncExchangeResult, SyncRecord } from "./sync";
 import type { SurahTiming } from "./audio";
 
 /** Access to the Arabic Quran text and surah structure. */
@@ -526,13 +526,17 @@ export interface Cipher {
 }
 
 /**
- * The sync transport (ADR 0033): exchange the device's encrypted entries with the
- * server in one round trip and get the converged set back. Implemented as an HTTP
- * adapter; the server only ever stores what {@link SyncEntry} exposes (opaque id,
- * clock, ciphertext).
+ * The sync transport (ADR 0033/0035): push the device's encrypted entries and get
+ * the converged set back — or, when a `cursor` is supplied, only the delta newer
+ * than it (ADR 0035 incremental pull). Implemented as an HTTP adapter; the server
+ * only ever stores what {@link SyncEntry} exposes (opaque id, clock, ciphertext).
  */
 export interface SyncBackend {
-  exchange(accountId: string, entries: readonly SyncEntry[]): Promise<readonly SyncEntry[]>;
+  exchange(
+    accountId: string,
+    entries: readonly SyncEntry[],
+    cursor?: number,
+  ): Promise<SyncExchangeResult>;
 }
 
 /**
@@ -554,4 +558,17 @@ export interface SyncStateStore {
    * round without learning any value shapes; stores with only scalar keys omit it.
    */
   identify?(plaintext: string): string | null;
+  /**
+   * Optional (v3 incremental pull, ADR 0035): the highest server version this
+   * device has applied. The engine sends it so the server can return only the
+   * newer delta. Omit it (with {@link setCursor}) to keep whole-set sync.
+   */
+  getCursor?(): Promise<number>;
+  /** Persist the server's new high-water cursor after a successful round (ADR 0035). */
+  setCursor?(cursor: number): Promise<void>;
+  /**
+   * Mark these (synthetic) keys as pushed — clears their dirty state so a
+   * steady-state round pushes nothing (ADR 0035). Called after a successful push.
+   */
+  markPushed?(keys: readonly string[]): Promise<void>;
 }

--- a/packages/core/src/sync-engine.test.ts
+++ b/packages/core/src/sync-engine.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { Cipher, SyncBackend, SyncStateStore } from "./ports";
-import { type Hlc, type SyncEntry, hlcInit, mergeEntries } from "./sync";
+import {
+  type Hlc,
+  type SyncEntry,
+  type SyncExchangeResult,
+  hlcCompare,
+  hlcInit,
+  mergeEntries,
+} from "./sync";
 import { runSync } from "./sync-engine";
 import { explodeKey, isMapKey, parseElementKey, unwrapElement, wrapElement } from "./sync-shapes";
 
@@ -21,13 +28,17 @@ const cipher: Cipher = {
   },
 };
 
-/** The server, faithfully: store ciphertext per account and converge by clock. */
+/** The server, faithfully: store ciphertext per account and converge by clock (v2 full-set). */
 class FakeBackend implements SyncBackend {
   readonly store = new Map<string, SyncEntry[]>();
-  async exchange(accountId: string, entries: readonly SyncEntry[]): Promise<readonly SyncEntry[]> {
+  async exchange(
+    accountId: string,
+    entries: readonly SyncEntry[],
+    _cursor?: number,
+  ): Promise<SyncExchangeResult> {
     const merged = mergeEntries(this.store.get(accountId) ?? [], entries).merged;
     this.store.set(accountId, merged);
-    return merged;
+    return { entries: merged };
   }
 }
 
@@ -220,5 +231,147 @@ describe("runSync", () => {
 
     expect(out.applied).toBe(0);
     expect(out.pulled).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// --- v3: incremental-pull cursor + dirty/bounded push (ADR 0035) ---
+
+/** A versioned server: stamps each written entry with a version, returns only the
+ * delta past the client's cursor (paged), and excludes the client's own unchanged
+ * pushes. Mirrors the real handler + in-memory store. */
+class VersionedBackend implements SyncBackend {
+  readonly store = new Map<string, (SyncEntry & { v: number })[]>();
+  exchanges = 0;
+  constructor(private readonly pageLimit = 1000) {}
+  async exchange(
+    accountId: string,
+    push: readonly SyncEntry[],
+    cursor = 0,
+  ): Promise<SyncExchangeResult> {
+    this.exchanges++;
+    const stored = this.store.get(accountId) ?? [];
+    let top = stored.reduce((m, e) => Math.max(m, e.v), 0);
+    const { merged, incoming } = mergeEntries(stored, push); // push won ⇒ in `incoming`
+    const wonIds = new Set(incoming.map((e) => e.id));
+    const storedV = new Map(stored.map((e) => [e.id, e.v]));
+    const versioned = merged.map((e) => ({
+      ...e,
+      v: wonIds.has(e.id) ? ++top : (storedV.get(e.id) ?? ++top),
+    }));
+    this.store.set(accountId, versioned);
+    const pushedHlc = new Map(push.map((e) => [e.id, e.hlc]));
+    const delta = versioned
+      .filter((e) => e.v > cursor)
+      .filter((e) => !(pushedHlc.has(e.id) && hlcCompare(e.hlc, pushedHlc.get(e.id)!) === 0))
+      .sort((a, b) => a.v - b.v);
+    const page = delta.slice(0, this.pageLimit);
+    const more = delta.length > page.length;
+    return {
+      entries: page.map(({ v: _v, ...e }) => e),
+      cursor: more ? page[page.length - 1]!.v : top,
+      more,
+    };
+  }
+}
+
+/** A state that tracks a cursor + per-key dirty flags, like the real web/mobile stores. */
+class CursorState implements SyncStateStore {
+  private readonly data = new Map<string, { value: string | null; hlc: Hlc }>();
+  private readonly dirty = new Set<string>();
+  private cursor = 0;
+  /** Enumerate the managed keys (unset, zero clock) like a real store, so the
+   * engine can map the server's opaque ids back even on a fresh device. */
+  constructor(keys: readonly string[] = []) {
+    for (const k of keys) this.data.set(k, { value: null, hlc: hlcInit("b") });
+  }
+  set(key: string, value: string | null, hlc: Hlc): void {
+    this.data.set(key, { value, hlc });
+    this.dirty.add(key);
+  }
+  get(key: string): string | null {
+    return this.data.get(key)?.value ?? null;
+  }
+  async all() {
+    return [...this.data.entries()].map(([key, v]) => ({
+      key,
+      value: v.value,
+      hlc: v.hlc,
+      dirty: this.dirty.has(key),
+    }));
+  }
+  async apply(key: string, value: string | null, hlc: Hlc): Promise<void> {
+    this.data.set(key, { value, hlc });
+    this.dirty.delete(key); // a remote winner is already on the server — not dirty
+  }
+  async getCursor() {
+    return this.cursor;
+  }
+  async setCursor(c: number) {
+    this.cursor = c;
+  }
+  async markPushed(keys: readonly string[]) {
+    for (const k of keys) this.dirty.delete(k);
+  }
+}
+
+describe("runSync — incremental cursor (v3)", () => {
+  it("a caught-up device pulls ~nothing on the next round (delta, not full set)", async () => {
+    const backend = new VersionedBackend();
+    const a = new CursorState();
+    a.set("ul.x", "hello", at(10));
+    await runSync({ cipher, backend, state: a });
+
+    const b = new CursorState(["ul.x"]);
+    const first = await runSync({ cipher, backend, state: b }); // cursor 0 → pulls the delta
+    expect(b.get("ul.x")).toBe("hello");
+    expect(first.applied).toBe(1);
+
+    const second = await runSync({ cipher, backend, state: b }); // cursor advanced → nothing new
+    expect(second.pulled).toBe(0);
+    expect(second.applied).toBe(0);
+  });
+
+  it("pushes only dirty entries — a steady-state round uploads nothing", async () => {
+    const backend = new VersionedBackend();
+    const a = new CursorState();
+    a.set("ul.x", "v", at(10));
+    const first = await runSync({ cipher, backend, state: a });
+    expect(first.pushed).toBe(1);
+    const second = await runSync({ cipher, backend, state: a }); // nothing changed locally
+    expect(second.pushed).toBe(0);
+  });
+
+  it("pages a large push under the chunk size", async () => {
+    const backend = new VersionedBackend();
+    const a = new CursorState();
+    for (let i = 0; i < 600; i++) a.set(`ul.k${i}`, `v${i}`, at(10 + i));
+    const out = await runSync({ cipher, backend, state: a });
+    expect(out.pushed).toBe(600);
+    expect(backend.exchanges).toBeGreaterThanOrEqual(2); // 600 > PUSH_CHUNK (500) → ≥2 pages
+  });
+
+  it("pages a large pull via the `more` flag until drained", async () => {
+    const backend = new VersionedBackend(250); // small server page → forces multi-page pull
+    const a = new CursorState();
+    for (let i = 0; i < 600; i++) a.set(`ul.k${i}`, `v${i}`, at(10 + i));
+    await runSync({ cipher, backend, state: a });
+
+    const b = new CursorState(Array.from({ length: 600 }, (_, i) => `ul.k${i}`));
+    const out = await runSync({ cipher, backend, state: b });
+    expect(out.applied).toBe(600); // all pulled across pages
+    for (let i = 0; i < 600; i++) expect(b.get(`ul.k${i}`)).toBe(`v${i}`);
+  });
+
+  it("converges two devices through the cursor (newer write wins, both directions)", async () => {
+    const backend = new VersionedBackend();
+    const a = new CursorState(["ul.x"]);
+    const b = new CursorState(["ul.x"]);
+    a.set("ul.x", "A", at(10, 0, "a"));
+    await runSync({ cipher, backend, state: a });
+    b.set("ul.x", "B", at(20, 0, "b")); // newer
+    await runSync({ cipher, backend, state: b });
+    const out = await runSync({ cipher, backend, state: a }); // a pulls the newer B
+    expect(a.get("ul.x")).toBe("B");
+    expect(out.applied).toBe(1);
   });
 });

--- a/packages/core/src/sync-engine.ts
+++ b/packages/core/src/sync-engine.ts
@@ -13,11 +13,14 @@
 import type { Cipher, SyncBackend, SyncStateStore } from "./ports";
 import { type SyncEntry, mergeEntries } from "./sync";
 
+/** Max entries pushed per exchange — keeps each request under the server's cap (ADR 0035). */
+const PUSH_CHUNK = 500;
+
 /** What one {@link runSync} round did — for the status UI and tests. */
 export interface SyncOutcome {
-  /** Entries pushed — the keys this device has actually set (never-set keys are skipped). */
+  /** Entries pushed across all pages this round. */
   pushed: number;
-  /** Entries the server returned. */
+  /** Entries the server returned (the delta, summed across pages). */
   pulled: number;
   /** Entries actually applied to local state (remote writes that won). */
   applied: number;
@@ -31,61 +34,89 @@ export interface SyncDeps {
 }
 
 /**
- * Run one sync round. Reads every managed key, encrypts the set, exchanges it
- * with the server, and applies each entry the remote side won — skipping entries
- * this build doesn't manage and any that fail to decrypt (foreign or corrupt), so
- * a bad record can never clobber good local data.
+ * Run one sync round (ADR 0033/0034/0035). Reads every managed key, encrypts it,
+ * then pushes the **dirty** entries in pages and pulls only the server delta newer
+ * than this device's **cursor** — so a round is O(changed), not O(total), and a set
+ * larger than the server cap still syncs (paged). Applies each entry the remote
+ * side won — skipping ids this build doesn't manage and anything that fails to
+ * decrypt (foreign/corrupt) — so a bad record can never clobber good local data.
+ *
+ * Backward-compatible: a store that implements neither `getCursor` nor `dirty`
+ * pushes everything against cursor 0, i.e. the v2 whole-set behaviour.
  */
 export async function runSync(deps: SyncDeps): Promise<SyncOutcome> {
   const { cipher, backend, state } = deps;
 
   const records = await state.all();
   const keyById = new Map<string, string>();
-  const local: SyncEntry[] = [];
+  const localById = new Map<string, SyncEntry>(); // every real local entry — drives merge
+  const toPush: SyncEntry[] = []; // only the dirty ones — what we actually upload
+  const pushedKeys: string[] = [];
   for (const r of records) {
     const id = await cipher.entryId(r.key);
     keyById.set(id, r.key); // map every managed key so incoming ids resolve…
     // …but a key this device never set — absent at the zero clock — carries no
-    // information. Skipping it stops a fresh device flooding the exchange with
-    // meaningless tombstones (which, with distinct node ids, the other side would
-    // otherwise "apply" as no-op deletes and miscount).
+    // information; skipping it stops a fresh device flooding the exchange with
+    // meaningless tombstones.
     if (r.value === null && r.hlc.millis === 0 && r.hlc.counter === 0) continue;
-    if (r.value === null) {
-      local.push({ id, hlc: r.hlc, ciphertext: null, nonce: "" });
-    } else {
-      const { ciphertext, nonce } = await cipher.encrypt(r.value);
-      local.push({ id, hlc: r.hlc, ciphertext, nonce });
+    const entry: SyncEntry =
+      r.value === null
+        ? { id, hlc: r.hlc, ciphertext: null, nonce: "" }
+        : { id, hlc: r.hlc, ...(await cipher.encrypt(r.value)) };
+    localById.set(id, entry);
+    if (r.dirty ?? true) {
+      toPush.push(entry);
+      pushedKeys.push(r.key);
     }
   }
 
   const accountId = await cipher.accountId();
-  const server = await backend.exchange(accountId, local);
-  const { incoming } = mergeEntries(local, server);
+  let cursor = (await state.getCursor?.()) ?? 0;
 
-  let applied = 0;
-  for (const entry of incoming) {
+  const apply = async (entry: SyncEntry): Promise<boolean> => {
     let key = keyById.get(entry.id);
     if (entry.ciphertext === null) {
-      // A tombstone. Only meaningful for a key we already track; an unknown id with
-      // no ciphertext can't be identified (nothing to decrypt) and names something
-      // this device never had — so there is nothing to delete.
-      if (key === undefined) continue;
+      if (key === undefined) return false; // unknown tombstone — nothing we ever had
       await state.apply(key, null, entry.hlc);
-      applied++;
-      continue;
+      return true;
     }
     const plaintext = await cipher.decrypt(entry.ciphertext, entry.nonce);
-    if (plaintext === null) continue; // foreign or corrupt — never clobber local
+    if (plaintext === null) return false; // foreign or corrupt — never clobber local
     if (key === undefined) {
-      // An element first created on another device: its opaque id isn't in our map,
-      // but its decrypted payload is self-describing (ADR 0034) — let the store
-      // resolve it to a synthetic key, so discovery completes in this one round.
+      // An element first created on another device — resolve it from its
+      // self-describing payload (ADR 0034) so discovery completes this round.
       key = state.identify?.(plaintext) ?? undefined;
-      if (key === undefined) continue; // not an element this build manages
+      if (key === undefined) return false;
     }
     await state.apply(key, plaintext, entry.hlc);
-    applied++;
+    return true;
+  };
+
+  let pushed = 0;
+  let pulled = 0;
+  let applied = 0;
+  let offset = 0;
+  // Push dirty entries in pages and pull the delta until everything is sent and the
+  // server has no further pages. Always runs once (a caught-up device still pulls).
+  for (;;) {
+    const page = toPush.slice(offset, offset + PUSH_CHUNK);
+    offset += page.length;
+    const result = await backend.exchange(accountId, page, cursor);
+    pushed += page.length;
+    pulled += result.entries.length;
+    if (result.cursor !== undefined) cursor = result.cursor;
+    const { incoming } = mergeEntries([...localById.values()], result.entries);
+    for (const entry of incoming) {
+      if (await apply(entry)) {
+        applied++;
+        localById.set(entry.id, entry); // reflect the winner for later pages
+      }
+    }
+    if (offset >= toPush.length && !result.more) break;
   }
 
-  return { pushed: local.length, pulled: server.length, applied };
+  await state.setCursor?.(cursor);
+  if (pushedKeys.length > 0) await state.markPushed?.(pushedKeys);
+
+  return { pushed, pulled, applied };
 }

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -87,6 +87,25 @@ export interface SyncRecord {
   key: string;
   value: string | null;
   hlc: Hlc;
+  /**
+   * v3 (ADR 0035): whether this entry changed locally since its last successful
+   * push and so needs sending. Omitted ⇒ treated as dirty (push it) — preserving
+   * the v1/v2 "push everything" behaviour for stores that don't track it.
+   */
+  dirty?: boolean;
+}
+
+/**
+ * The server's reply to one exchange (ADR 0035). `entries` is the converged set —
+ * or, when the client sent a `cursor`, only the delta newer than it. `cursor` is
+ * the server's new high-water version to send next time (absent ⇒ the server
+ * doesn't version, so the client falls back to whole-set sync). `more` means the
+ * server truncated the delta to a page; the client should sync again.
+ */
+export interface SyncExchangeResult {
+  entries: readonly SyncEntry[];
+  cursor?: number;
+  more?: boolean;
 }
 
 /** The outcome of merging two sides. */


### PR DESCRIPTION
## v3 — incremental-pull cursor (#25, ADR 0035)

Makes a sync round **O(changed)** instead of O(total) — the substrate the unbounded `ul.hifz` key needs — **backward-compatibly**. **Off by default.**

> **Stacked on #172** (`feat/sync-date-logs`) → #171 → #169. Re-target up the chain as each lands.

### What changed
- **Protocol:** `SyncBackend.exchange(accountId, entries, cursor?)` now returns `{entries, cursor?, more?}`. A missing/zero cursor preserves v2 whole-set behaviour, so the change lands incrementally and mixed v2/v3 devices interoperate.
- **Server** (`sync-store.ts`/`handler.ts`): each stored entry carries a per-account monotonic version `v`; the handler stamps a fresh version on every push-changed entry, then returns only the **delta past the client cursor** — sorted, paged (`MAX_DELTA` + `more`), excluding the client's own unchanged pushes.
- **Engine** (`sync-engine.ts`): pushes in pages of ≤500 and pulls the delta in a cursor loop until drained, then persists the cursor — laying the `dirty`/`markPushed` seams (default-push for now).
- **Web + mobile stores** activate the delta-pull (cursor persisted under `ul.sync.cursor`).

### Adversarial-review fix (HIGH, caught pre-merge)
A 13-agent review found a real migration hole: a **pre-v3 stored entry has no `v`** (defaulted to 0), and `0 > 0` excluded it from every delta — so a device recovering an account **after the v2→v3 upgrade pulled nothing and never converged** (the headline new-device-recovery path). The handler now **re-stamps any entry at version ≤ 0** on first touch, migrating legacy data above the zero cursor. Pinned with a test. (The review refuted 9 other findings, confirming the protocol converges.)

### Verification
- Verified against the in-memory store (the dev endpoint): core 30 sync tests — a `VersionedBackend` covering delta / push-paging / pull-paging / convergence — plus handler delta + legacy-migration tests; web 78, mobile 44.
- `pnpm lint && typecheck && test && build` green.

### Deferred — the Phase-3 completion (gated on Upstash, per ADR 0035 Status)
dirty/bounded push (so steady-state uploads ~nothing) → the prerequisite to **enable `ul.hifz`**; the **atomic Upstash merge** (Redis Lua/tx — the one part needing live Redis to verify); tombstone pruning; graceful overflow. **Provisioning Upstash is now the blocker** for finishing Phase 3.
