### PR TITLE
feat(sync): live in-app refresh after a synced value is applied (#25)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -27,6 +27,7 @@ import { syncPrayerReminders } from "./src/prayer-reminders";
 import { syncSunnahFastReminder } from "./src/sunnah-fast-reminders";
 import { syncIslamicEventReminders } from "./src/islamic-event-reminders";
 import { syncIfEnabled } from "./src/lib/sync/sync-runtime";
+import { emitSyncApplied } from "./src/lib/sync/sync-events";
 import type { RootStackParamList } from "./src/navigation/types";
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
@@ -160,7 +161,12 @@ export default function App() {
       void syncPrayerReminders();
       void syncSunnahFastReminder();
       void syncIslamicEventReminders();
-      void syncIfEnabled().catch(() => {});
+      void syncIfEnabled()
+        .then((outcome) => {
+          // A pulled value landed — re-hydrate the contexts so it shows without a relaunch.
+          if (outcome && outcome.applied > 0) emitSyncApplied();
+        })
+        .catch(() => {});
     };
     void initNotifier().then(syncAll);
     const sub = AppState.addEventListener("change", (s) => {

--- a/apps/mobile/src/lib/sync/sync-events.ts
+++ b/apps/mobile/src/lib/sync/sync-events.ts
@@ -1,0 +1,21 @@
+/**
+ * In-app refresh signal for mobile sync (#25, ADR 0033/0034). The sync engine writes
+ * AsyncStorage directly, bypassing the feature write-paths, so the React contexts
+ * don't learn that a pulled value landed. After a sync round applies remote changes,
+ * `App` emits this and the providers re-hydrate — the mobile counterpart of the web
+ * `SYNC_CHANGE_EVENT` wiring. Uses `DeviceEventEmitter` (RN has no window events).
+ */
+import { DeviceEventEmitter } from "react-native";
+
+const SYNC_APPLIED = "ul:sync:applied";
+
+/** Announce that a sync round applied remote changes, so contexts re-hydrate live. */
+export function emitSyncApplied(): void {
+  DeviceEventEmitter.emit(SYNC_APPLIED);
+}
+
+/** Re-hydrate on a sync-applied signal; returns an unsubscribe. */
+export function onSyncApplied(handler: () => void): () => void {
+  const sub = DeviceEventEmitter.addListener(SYNC_APPLIED, handler);
+  return () => sub.remove();
+}

--- a/apps/mobile/src/state/LibraryContext.tsx
+++ b/apps/mobile/src/state/LibraryContext.tsx
@@ -24,6 +24,7 @@ import {
 } from "@ummahlibrary/core";
 import { KEYS, getJSON, isObjectRecord, setJSON } from "../storage";
 import { mobileLibraryStore as library } from "./library-store";
+import { onSyncApplied } from "../lib/sync/sync-events";
 import { EMPTY_STREAK, advanceStreak, type StreakData } from "../hifz";
 
 export interface HifzRecord {
@@ -83,34 +84,38 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
   const [notes, setNotes] = useState<Record<string, string>>({});
   const [ready, setReady] = useState(false);
 
-  useEffect(() => {
-    void (async () => {
-      const [bm, lr, hz, st, log, cols, nts] = await Promise.all([
-        library.readBookmarks(),
-        getJSON<{ surah: number } | null>(KEYS.lastRead, null, isObjectRecord),
-        getJSON<HifzStore>(KEYS.hifz, {}, isObjectRecord),
-        getJSON<StreakData>(
-          KEYS.hifzStreak,
-          EMPTY_STREAK,
-          (v) =>
-            isObjectRecord(v) &&
-            typeof (v as StreakData).count === "number" &&
-            typeof (v as StreakData).lastDate === "string",
-        ),
-        getJSON<HifzActivityLog>(KEYS.hifzReviewLog, {}, isObjectRecord),
-        library.readCollections(),
-        library.readNotes(),
-      ]);
-      setBookmarks(bm);
-      setLastReadState(lr?.surah ?? null);
-      setHifz(hz);
-      setStreak(st);
-      setReviewLog(log);
-      setCollections(cols);
-      setNotes(nts);
-      setReady(true);
-    })();
+  const load = useCallback(async () => {
+    const [bm, lr, hz, st, log, cols, nts] = await Promise.all([
+      library.readBookmarks(),
+      getJSON<{ surah: number } | null>(KEYS.lastRead, null, isObjectRecord),
+      getJSON<HifzStore>(KEYS.hifz, {}, isObjectRecord),
+      getJSON<StreakData>(
+        KEYS.hifzStreak,
+        EMPTY_STREAK,
+        (v) =>
+          isObjectRecord(v) &&
+          typeof (v as StreakData).count === "number" &&
+          typeof (v as StreakData).lastDate === "string",
+      ),
+      getJSON<HifzActivityLog>(KEYS.hifzReviewLog, {}, isObjectRecord),
+      library.readCollections(),
+      library.readNotes(),
+    ]);
+    setBookmarks(bm);
+    setLastReadState(lr?.surah ?? null);
+    setHifz(hz);
+    setStreak(st);
+    setReviewLog(log);
+    setCollections(cols);
+    setNotes(nts);
+    setReady(true);
   }, []);
+
+  // Load on mount, and re-hydrate when a sync round pulls in remote changes.
+  useEffect(() => {
+    void load();
+    return onSyncApplied(() => void load());
+  }, [load]);
 
   const updateCollections = useCallback((next: Collection[]) => {
     setCollections(next);

--- a/apps/mobile/src/state/SettingsContext.tsx
+++ b/apps/mobile/src/state/SettingsContext.tsx
@@ -17,6 +17,7 @@ import type { QuranScript, Translation } from "@ummahlibrary/core";
 import { api, type TafsirMeta } from "../api";
 import { mobileSettingsStore as store } from "./settings-store";
 import { readTafsirCompare, writeTafsirCompare } from "../tafsir-compare-store";
+import { onSyncApplied } from "../lib/sync/sync-events";
 import { RECITER, TAFSIRS } from "../plugins";
 import { defaultEditions, MAX_SCALE, MIN_SCALE, type ReadingMode } from "../types";
 
@@ -71,24 +72,23 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [catalogue, setCatalogue] = useState<Translation[]>([]);
   const [tafsirs, setTafsirs] = useState<TafsirMeta[]>([]);
 
+  const loadPrefs = useCallback(async () => {
+    const s = await store.read();
+    if (s.editions && s.editions.length > 0) setEditionsState(s.editions);
+    if (s.readingMode === "translation" || s.readingMode === "reading" || s.readingMode === "reading-tr")
+      setReadingModeState(s.readingMode);
+    if (s.readingTranslation) setReadingTranslationState(s.readingTranslation);
+    if (s.reciter) setReciterIdState(s.reciter);
+    if (s.tafsir) setTafsirIdState(s.tafsir);
+    if (s.scale != null) setScaleState(clampScale(s.scale));
+    if (s.transliteration != null) setTransliterationState(s.transliteration);
+    if (s.wordTransliteration != null) setWordTransliterationState(s.wordTransliteration);
+    if (s.tapToHear != null) setTapToHearState(s.tapToHear);
+    if (s.script === "uthmani" || s.script === "indopak") setScriptState(s.script);
+  }, []);
+
   useEffect(() => {
-    void store.read().then((s) => {
-      if (s.editions && s.editions.length > 0) setEditionsState(s.editions);
-      if (
-        s.readingMode === "translation" ||
-        s.readingMode === "reading" ||
-        s.readingMode === "reading-tr"
-      )
-        setReadingModeState(s.readingMode);
-      if (s.readingTranslation) setReadingTranslationState(s.readingTranslation);
-      if (s.reciter) setReciterIdState(s.reciter);
-      if (s.tafsir) setTafsirIdState(s.tafsir);
-      if (s.scale != null) setScaleState(clampScale(s.scale));
-      if (s.transliteration != null) setTransliterationState(s.transliteration);
-      if (s.wordTransliteration != null) setWordTransliterationState(s.wordTransliteration);
-      if (s.tapToHear != null) setTapToHearState(s.tapToHear);
-      if (s.script === "uthmani" || s.script === "indopak") setScriptState(s.script);
-    });
+    void loadPrefs();
     void readTafsirCompare().then(setTafsirCompareState);
     void api
       .listTranslationCatalog()
@@ -98,7 +98,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       .listTafsirs()
       .then(setTafsirs)
       .catch(() => setTafsirs([]));
-  }, []);
+    // Re-read prefs when a sync round pulls in a remote change (the catalogue is static).
+    return onSyncApplied(() => void loadPrefs());
+  }, [loadPrefs]);
 
   const setEditions = useCallback((ids: string[]) => {
     const next = ids.length > 0 ? ids : defaultEditions();

--- a/apps/mobile/src/theme.tsx
+++ b/apps/mobile/src/theme.tsx
@@ -9,6 +9,7 @@
  */
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -23,6 +24,7 @@ import {
   type ThemeKey,
 } from "@ummahlibrary/ui";
 import { KEYS, getString, setString } from "./storage";
+import { onSyncApplied } from "./lib/sync/sync-events";
 
 export type { Palette, ThemeKey };
 
@@ -61,13 +63,18 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     Appearance.getColorScheme() === "light" ? "ivory" : "obsidian",
   );
 
-  useEffect(() => {
-    void getString(KEYS.theme).then((saved) => {
-      if (!saved) return;
-      const key = VALID.has(saved) ? (saved as ThemeKey) : LEGACY[saved];
-      if (key) setThemeKey(key);
-    });
+  const loadTheme = useCallback(async () => {
+    const saved = await getString(KEYS.theme);
+    if (!saved) return;
+    const key = VALID.has(saved) ? (saved as ThemeKey) : LEGACY[saved];
+    if (key) setThemeKey(key);
   }, []);
+
+  // Load on mount, and re-apply when a sync round pulls a theme from another device.
+  useEffect(() => {
+    void loadTheme();
+    return onSyncApplied(() => void loadTheme());
+  }, [loadTheme]);
 
   const setTheme = (key: ThemeKey) => {
     setThemeKey(key);

--- a/apps/web/src/components/SyncBootstrap.tsx
+++ b/apps/web/src/components/SyncBootstrap.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { syncIfEnabled } from "../lib/sync/sync-runtime";
+import { wireSyncRefresh } from "../lib/sync/sync-refresh";
 
 /**
  * App-wide sync trigger (#25, ADR 0033): runs one sync round on load and whenever
@@ -9,9 +10,13 @@ import { syncIfEnabled } from "../lib/sync/sync-runtime";
  * is a no-op otherwise. Invisible; mounted in the root layout beside the reminder
  * schedulers so sync keeps up no matter which page is open. Failures are swallowed
  * (offline, server unprovisioned) — the local-first app carries on regardless.
+ *
+ * Also wires {@link wireSyncRefresh} so a value pulled from another device shows
+ * without a reload (re-reads the affected feature; re-applies a synced theme).
  */
 export function SyncBootstrap() {
   useEffect(() => {
+    const unwireRefresh = wireSyncRefresh();
     const run = () => void syncIfEnabled().catch(() => {});
     run();
     const onVisible = () => {
@@ -20,6 +25,7 @@ export function SyncBootstrap() {
     document.addEventListener("visibilitychange", onVisible);
     window.addEventListener("focus", run);
     return () => {
+      unwireRefresh();
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("focus", run);
     };

--- a/apps/web/src/lib/sync/sync-refresh.test.ts
+++ b/apps/web/src/lib/sync/sync-refresh.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MANAGED_KEYS } from "@ummahlibrary/core";
+import { REFRESH_EVENTS, refreshForKey, wireSyncRefresh } from "./sync-refresh";
+import { SYNC_CHANGE_EVENT } from "./web-sync-state-store";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("REFRESH_EVENTS", () => {
+  it("maps every managed key, so adding a key forces a refresh decision", () => {
+    for (const key of MANAGED_KEYS) expect(Object.hasOwn(REFRESH_EVENTS, key)).toBe(true);
+  });
+});
+
+describe("refreshForKey", () => {
+  it("dispatches the feature re-read event for a synced tracker key (name differs from the key)", () => {
+    const onTracker = vi.fn();
+    window.addEventListener("ul.prayerTracker", onTracker);
+    refreshForKey("ul.prayerLog");
+    expect(onTracker).toHaveBeenCalledOnce();
+    window.removeEventListener("ul.prayerTracker", onTracker);
+  });
+
+  it("re-applies a synced theme to the document live", () => {
+    localStorage.setItem("ul.theme", "emerald");
+    refreshForKey("ul.theme");
+    expect(document.documentElement.dataset.theme).toBe("emerald");
+  });
+
+  it("is a no-op (no throw) for a key with no live listener", () => {
+    expect(() => refreshForKey("ul.bookmarks")).not.toThrow();
+  });
+});
+
+describe("wireSyncRefresh", () => {
+  it("re-reads the affected feature when a sync change is announced", () => {
+    const unwire = wireSyncRefresh();
+    const onReading = vi.fn();
+    window.addEventListener("ul.reading", onReading);
+    window.dispatchEvent(new CustomEvent(SYNC_CHANGE_EVENT, { detail: { key: "ul.readingLog" } }));
+    expect(onReading).toHaveBeenCalledOnce();
+    window.removeEventListener("ul.reading", onReading);
+    unwire();
+  });
+
+  it("stops listening after the returned unsubscribe runs", () => {
+    wireSyncRefresh()();
+    const onTracker = vi.fn();
+    window.addEventListener("ul.prayerTracker", onTracker);
+    window.dispatchEvent(new CustomEvent(SYNC_CHANGE_EVENT, { detail: { key: "ul.prayerLog" } }));
+    expect(onTracker).not.toHaveBeenCalled();
+    window.removeEventListener("ul.prayerTracker", onTracker);
+  });
+});

--- a/apps/web/src/lib/sync/sync-refresh.ts
+++ b/apps/web/src/lib/sync/sync-refresh.ts
@@ -1,0 +1,81 @@
+/**
+ * Live in-app refresh after a sync round applies a remote value (#25, ADR 0033/0034).
+ *
+ * The sync state store writes `localStorage` and fires {@link SYNC_CHANGE_EVENT}
+ * with the changed key — but feature components don't listen to *that*; they listen
+ * to their own bespoke change events (which their write-paths fire, and which sync
+ * bypasses by writing storage directly). This module is the single place that
+ * translates a synced key into the event(s) those components already re-read on, so
+ * a pulled change shows without a reload.
+ *
+ * Theme is special-cased: there's no theme "event", so we re-apply it directly.
+ * Keys with no live listener today (bookmarks, notes, prayer settings, …) map to
+ * `[]` — they reflect on the next read/navigation, exactly as before. A test guards
+ * that every managed key has an entry here, so adding one forces a conscious choice.
+ */
+import { applyTheme, normalizeTheme } from "../themes";
+import { getItem } from "./storage";
+import { SYNC_CHANGE_EVENT } from "./web-sync-state-store";
+
+/** Managed key → the feature event(s) whose listeners re-read it. `[]` ⇒ reflects on next navigation. */
+export const REFRESH_EVENTS: Record<string, readonly string[]> = {
+  // Trackers / collections — note several feature event names differ from the key.
+  "ul.collections": ["ul.collections"],
+  "ul.qada": ["ul.qada"],
+  "ul.haid": ["ul.haid"],
+  "ul.prayerLog": ["ul.prayerTracker"],
+  "ul.readingLog": ["ul.reading"],
+  "ul.readingActive": ["ul.reading"],
+  "ul.ramadanFasts": ["ul.ramadan"],
+  "ul.ramadanWorship": ["ul.ramadan"],
+  // Reader preferences.
+  "ul.editions": ["ul.editions"],
+  "ul.tafsir": ["ul.tafsir"],
+  "ul.readingTranslation": ["ul.readingTranslation"],
+  "ul.reciter": ["ul.reciter"],
+  "ul.wbw": ["ul.wbw"],
+  "ul.transliteration": ["ul.transliteration"],
+  "ul.wbwTranslit": ["ul.wbwTranslit"],
+  "ul.tapToHear": ["ul.tapToHear"],
+  "ul.script": ["ul.script"],
+  // Calendar.
+  "ul.hijriAdjust": ["ul.hijriAdjust"],
+  // Theme — re-applied directly in refreshForKey (no event exists), so [] here.
+  "ul.theme": [],
+  // No live listener today → reflects on the next read/navigation:
+  "ul.bookmarks": [],
+  "ul.ayahNotes": [],
+  "ul.asmaLearned": [],
+  "ul.badges": [],
+  "ul.lastRead": [],
+  "ul.scale": [],
+  "ul.readingMode": [],
+  "ul.loop": [],
+  "ul.prayerMethod": [],
+  "ul.prayerMadhab": [],
+  "ul.prayerHighLat": [],
+  "ul.prayerCoords": [],
+};
+
+/** Apply the in-app effect of a synced key changing: re-apply the theme, or fire the feature re-read events. */
+export function refreshForKey(key: string): void {
+  if (typeof window === "undefined") return;
+  if (key === "ul.theme") {
+    applyTheme(normalizeTheme(getItem("ul.theme")));
+    return;
+  }
+  for (const event of REFRESH_EVENTS[key] ?? []) {
+    window.dispatchEvent(new CustomEvent(event));
+  }
+}
+
+/** Listen for sync-applied changes and re-read the affected feature live. Returns an unsubscribe. */
+export function wireSyncRefresh(): () => void {
+  if (typeof window === "undefined") return () => {};
+  const onChange = (e: Event): void => {
+    const key = (e as CustomEvent<{ key?: string }>).detail?.key;
+    if (typeof key === "string") refreshForKey(key);
+  };
+  window.addEventListener(SYNC_CHANGE_EVENT, onChange);
+  return () => window.removeEventListener(SYNC_CHANGE_EVENT, onChange);
+}


### PR DESCRIPTION
## Live in-app refresh after a synced value is applied (#25)

A value pulled from another device now shows **without a reload**, on web and mobile — closing the parity gap noted across ADR 0033/0034. **Off by default** (only runs when sync is on).

> **Stacked on #173** (`feat/sync-cursor`) → #172 → #171 → #169.

### Web
The sync state store already fires `SYNC_CHANGE_EVENT(key)` on apply, but feature components listen to their **own bespoke events** (which their write-paths fire and sync bypasses by writing storage directly). New **`sync-refresh.ts`** is the single place that translates a synced key into the event(s) those components re-read on — e.g. `ul.prayerLog → "ul.prayerTracker"`, `ul.readingLog → "ul.reading"`, the reader prefs, the calendar. **Theme** is re-applied directly (no theme event exists). `SyncBootstrap` wires the listener.

Keys with no live listener today (bookmarks, notes, prayer settings, scale, …) map to `[]` and reflect on the next navigation, exactly as before — and a **test guards that every managed key has an entry**, so adding one forces a conscious choice.

### Mobile
A `DeviceEventEmitter` signal (`sync-events.ts`). `App` emits it after a sync round with `applied > 0`; **`LibraryContext`, `SettingsContext`, and the `ThemeProvider`** re-hydrate their state on it (their load is extracted into a callback re-run on the signal). No feedback loop — the refresh triggers *reads*, never writes.

### Verification
- Web: 6 `sync-refresh` tests (key→event mapping, theme re-apply, wiring, unsubscribe, the managed-key completeness guard) + `SyncBootstrap`.
- Mobile: typecheck + Metro cover the wiring (the contexts re-hydrate; `sync-events` is a thin RN `DeviceEventEmitter` wrapper not loaded in the Node test env).
- `pnpm lint && typecheck && test && build` green.

This is the **last non-Upstash sync item**. Everything remaining (dirty-push → `ul.hifz`, the atomic Upstash merge, pruning, graceful overflow) is gated on provisioning Upstash.
