### PR TITLE
feat(sync): /api/sync provisioning readiness — rate limit, atomic merge, runbook (#25)

### DIFF
--- a/apps/web/src/app/api/sync/handler.ts
+++ b/apps/web/src/app/api/sync/handler.ts
@@ -8,6 +8,7 @@
  * decrypts anything.
  */
 import { type SyncEntry, hlcCompare, mergeEntries } from "@ummahlibrary/core";
+import type { Lock } from "./lock";
 import type { ServerEntry, SyncStore } from "./sync-store";
 
 const MAX_ENTRIES = 2000; // max push entries per request (clients page well under this)
@@ -67,10 +68,15 @@ function versionOf(e: SyncEntry): number {
  * a server version to every entry the push changed, persist, and return the delta
  * newer than the client's `cursor` (paged, with a `more` flag), excluding the
  * client's own unchanged pushes (it already has those).
+ *
+ * The read → merge → write is serialized per account by the optional {@link Lock}
+ * (ADR 0035) so two devices pushing at once can't lose a write; without a lock it
+ * behaves as before (fine for a single instance / tests).
  */
 export async function handleSync(
   input: { authorization: string | null; body: unknown },
   store: SyncStore,
+  lock?: Lock,
 ): Promise<SyncResult> {
   const accountId = parseAccountId(input.authorization);
   if (!accountId) return { status: 401, body: { error: "missing or malformed account id" } };
@@ -82,43 +88,44 @@ export async function handleSync(
   if (!push.every(isValidEntry)) return { status: 400, body: { error: "malformed entry" } };
   const cursor = isClockInt(body?.cursor) ? (body!.cursor as number) : 0;
 
-  // Re-validate the stored set on read: a value persisted before this hardening (or
-  // hand-edited in Redis) must not poison the merge with a malformed clock.
-  const stored: ServerEntry[] = (await store.get(accountId))
-    .filter(isValidEntry)
-    .map((e) => ({ ...e, v: versionOf(e) }));
+  // The atomic critical section: re-read, merge, version, persist, compute the delta.
+  const exchange = async (): Promise<SyncResult> => {
+    // Re-validate the stored set on read: a value persisted before this hardening
+    // (or hand-edited in Redis) must not poison the merge with a malformed clock.
+    const stored: ServerEntry[] = (await store.get(accountId))
+      .filter(isValidEntry)
+      .map((e) => ({ ...e, v: versionOf(e) }));
 
-  let top = stored.reduce((max, e) => Math.max(max, e.v), 0);
-  const { merged, incoming } = mergeEntries(stored, push); // stored = local, push = remote ⇒ incoming = push won
-  const changedIds = new Set(incoming.map((e) => e.id));
-  const storedV = new Map(stored.map((e) => [e.id, e.v]));
-  // A push-changed entry gets a fresh (higher) version; an unchanged one keeps its
-  // version — UNLESS that version is ≤ 0, which means it was written by the pre-v3
-  // server (no `v` field, defaulted to 0). Such legacy entries must be re-stamped
-  // above 0 on the first v3 exchange, or a fresh device's cursor-0 delta (`v > 0`)
-  // would exclude them forever and never converge after the upgrade.
-  const next: ServerEntry[] = merged.map((e) => {
-    const prior = storedV.get(e.id) ?? 0;
-    return { ...e, v: changedIds.has(e.id) || prior <= 0 ? ++top : prior };
-  });
-  await store.set(accountId, next);
+    let top = stored.reduce((max, e) => Math.max(max, e.v), 0);
+    const { merged, incoming } = mergeEntries(stored, push); // stored = local, push = remote ⇒ incoming = push won
+    const changedIds = new Set(incoming.map((e) => e.id));
+    const storedV = new Map(stored.map((e) => [e.id, e.v]));
+    // A push-changed entry gets a fresh (higher) version; an unchanged one keeps its
+    // version — UNLESS that version is ≤ 0, which means it was written by the pre-v3
+    // server (no `v` field, defaulted to 0). Such legacy entries must be re-stamped
+    // above 0 on the first v3 exchange, or a fresh device's cursor-0 delta (`v > 0`)
+    // would exclude them forever and never converge after the upgrade.
+    const next: ServerEntry[] = merged.map((e) => {
+      const prior = storedV.get(e.id) ?? 0;
+      return { ...e, v: changedIds.has(e.id) || prior <= 0 ? ++top : prior };
+    });
+    await store.set(accountId, next);
 
-  const pushedHlc = new Map(push.map((e) => [e.id, e.hlc]));
-  const delta = next
-    .filter((e) => e.v > cursor)
-    // Don't echo the client's own pushes back unchanged — it already has them.
-    .filter((e) => !(pushedHlc.has(e.id) && hlcCompare(e.hlc, pushedHlc.get(e.id)!) === 0))
-    .sort((a, b) => a.v - b.v);
-  const page = delta.slice(0, MAX_DELTA);
-  const more = delta.length > page.length;
-  const nextCursor = more ? page[page.length - 1]!.v : top;
+    const pushedHlc = new Map(push.map((e) => [e.id, e.hlc]));
+    const delta = next
+      .filter((e) => e.v > cursor)
+      // Don't echo the client's own pushes back unchanged — it already has them.
+      .filter((e) => !(pushedHlc.has(e.id) && hlcCompare(e.hlc, pushedHlc.get(e.id)!) === 0))
+      .sort((a, b) => a.v - b.v);
+    const page = delta.slice(0, MAX_DELTA);
+    const more = delta.length > page.length;
+    const nextCursor = more ? page[page.length - 1]!.v : top;
 
-  return {
-    status: 200,
-    body: {
-      entries: page.map(({ v: _v, ...entry }) => entry),
-      cursor: nextCursor,
-      more,
-    },
+    return {
+      status: 200,
+      body: { entries: page.map(({ v: _v, ...entry }) => entry), cursor: nextCursor, more },
+    };
   };
+
+  return lock ? lock.withLock(accountId, exchange) : exchange();
 }

--- a/apps/web/src/app/api/sync/lock.test.ts
+++ b/apps/web/src/app/api/sync/lock.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { handleSync } from "./handler";
+import { InMemoryLock } from "./lock";
+import { InMemorySyncStore } from "./sync-store";
+
+describe("InMemoryLock", () => {
+  it("serializes critical sections for the same key (never two at once)", async () => {
+    const lock = new InMemoryLock();
+    let active = 0;
+    let maxActive = 0;
+    const task = () =>
+      lock.withLock("k", async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 5));
+        active -= 1;
+      });
+    await Promise.all([task(), task(), task()]);
+    expect(maxActive).toBe(1);
+  });
+
+  it("runs different keys concurrently", async () => {
+    const lock = new InMemoryLock();
+    let active = 0;
+    let maxActive = 0;
+    const task = (k: string) =>
+      lock.withLock(k, async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 5));
+        active -= 1;
+      });
+    await Promise.all([task("a"), task("b")]);
+    expect(maxActive).toBe(2);
+  });
+
+  it("releases the lock even when the body throws", async () => {
+    const lock = new InMemoryLock();
+    await expect(
+      lock.withLock("k", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(await lock.withLock("k", async () => "ok")).toBe("ok"); // not deadlocked
+  });
+});
+
+describe("handleSync under a lock (atomic merge, ADR 0035)", () => {
+  it("does not lose a write when two devices push the same account at once", async () => {
+    const store = new InMemorySyncStore();
+    const lock = new InMemoryLock();
+    const auth = `Bearer ${"a".repeat(64)}`;
+    const entry = (id: string) => ({
+      id,
+      hlc: { millis: 1, counter: 0, node: id },
+      ciphertext: "c",
+      nonce: "iv",
+    });
+    await Promise.all([
+      handleSync({ authorization: auth, body: { entries: [entry("X")] } }, store, lock),
+      handleSync({ authorization: auth, body: { entries: [entry("Y")] } }, store, lock),
+    ]);
+    const ids = (await store.get("a".repeat(64))).map((e) => e.id).sort();
+    expect(ids).toEqual(["X", "Y"]); // both survived — neither push clobbered the other
+  });
+});

--- a/apps/web/src/app/api/sync/lock.ts
+++ b/apps/web/src/app/api/sync/lock.ts
@@ -1,0 +1,107 @@
+/**
+ * Per-account serialization for the sync exchange (#25, ADR 0035). The handler's
+ * read → merge → write is not atomic on its own, so two devices of the same account
+ * pushing in the same instant could race and lose a write. A per-account lock
+ * around that critical section serializes them.
+ *
+ * Two implementations behind one port: an in-process one (dev / a single serverless
+ * instance, and the unit-tested path) and an Upstash one (a `SET NX PX` lock over
+ * the REST API — written for when Upstash is provisioned; its live behaviour is
+ * verified then). The Upstash lock is **best-effort**: if it can't be acquired
+ * within the wait budget (contention or a lock-service blip) it proceeds anyway,
+ * degrading to the pre-lock behaviour (a rare lost-update for one user's
+ * simultaneous multi-device push) rather than ever blocking sync.
+ */
+
+export interface Lock {
+  /** Run `fn` while holding the lock for `key`; releases on settle. */
+  withLock<T>(key: string, fn: () => Promise<T>): Promise<T>;
+}
+
+/** In-process per-key serialization — correct on one instance (dev, tests). */
+export class InMemoryLock implements Lock {
+  private readonly tail = new Map<string, Promise<unknown>>();
+  withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.tail.get(key) ?? Promise.resolve();
+    const result = prev.then(fn, fn); // run after the prior holder settles (ok or error)
+    const settled = result.then(
+      () => {},
+      () => {},
+    );
+    this.tail.set(key, settled);
+    void settled.then(() => {
+      if (this.tail.get(key) === settled) this.tail.delete(key); // GC when idle
+    });
+    return result;
+  }
+}
+
+export interface UpstashLockConfig {
+  url: string;
+  token: string;
+  /** How long the lock is held before auto-expiring (guards against a crashed holder). */
+  ttlMs?: number;
+  /** How long to wait to acquire before proceeding best-effort. */
+  maxWaitMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+/** Frees the lock only if we still hold it (token match), so we never delete another holder's lock. */
+const RELEASE_SCRIPT =
+  "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end";
+
+/** A `SET key token NX PX ttl` distributed lock over the Upstash REST API (no SDK). */
+export class UpstashLock implements Lock {
+  private readonly ttlMs: number;
+  private readonly maxWaitMs: number;
+  constructor(private readonly cfg: UpstashLockConfig) {
+    this.ttlMs = cfg.ttlMs ?? 5000;
+    this.maxWaitMs = cfg.maxWaitMs ?? 3000;
+  }
+
+  private get fetchImpl(): typeof fetch {
+    return this.cfg.fetchImpl ?? fetch;
+  }
+
+  /** Run one Redis command via the Upstash REST command endpoint; returns its `result`. */
+  private async cmd(args: (string | number)[]): Promise<unknown> {
+    const res = await this.fetchImpl(this.cfg.url, {
+      method: "POST",
+      headers: { authorization: `Bearer ${this.cfg.token}`, "content-type": "application/json" },
+      body: JSON.stringify(args),
+    });
+    if (!res.ok) throw new Error(`upstash command failed (${res.status})`);
+    return ((await res.json()) as { result?: unknown }).result;
+  }
+
+  async withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const lockKey = `sync:lock:${key}`;
+    const token = crypto.randomUUID();
+    const deadline = Date.now() + this.maxWaitMs;
+    let held = false;
+    for (let delay = 25; ; delay = Math.min(delay * 2, 250)) {
+      try {
+        held = (await this.cmd(["SET", lockKey, token, "NX", "PX", this.ttlMs])) === "OK";
+      } catch {
+        break; // lock service unavailable — proceed best-effort
+      }
+      if (held || Date.now() >= deadline) break;
+      await new Promise((r) => setTimeout(r, delay));
+    }
+    try {
+      return await fn();
+    } finally {
+      if (held) {
+        // Best-effort token-checked release; a failure just lets the TTL expire it.
+        await this.cmd(["EVAL", RELEASE_SCRIPT, 1, lockKey, token]).catch(() => {});
+      }
+    }
+  }
+}
+
+/** The configured lock from env — Upstash when provisioned, else an in-process lock. */
+export function lockFromEnv(env: Record<string, string | undefined>): Lock {
+  const url = env.UPSTASH_REDIS_REST_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN;
+  return url && token ? new UpstashLock({ url, token }) : new InMemoryLock();
+}

--- a/apps/web/src/app/api/sync/rate-limit.test.ts
+++ b/apps/web/src/app/api/sync/rate-limit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryRateLimiter, rateLimiterFromEnv } from "./rate-limit";
+
+describe("InMemoryRateLimiter", () => {
+  it("allows up to the limit, then blocks with a retry-after", async () => {
+    const now = 1000;
+    const rl = new InMemoryRateLimiter({ limit: 2, windowMs: 1000 }, () => now);
+    expect((await rl.check("ip")).ok).toBe(true);
+    expect((await rl.check("ip")).ok).toBe(true);
+    const blocked = await rl.check("ip");
+    expect(blocked.ok).toBe(false);
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it("resets after the window elapses", async () => {
+    let now = 1000;
+    const rl = new InMemoryRateLimiter({ limit: 1, windowMs: 1000 }, () => now);
+    expect((await rl.check("ip")).ok).toBe(true);
+    expect((await rl.check("ip")).ok).toBe(false);
+    now += 1001;
+    expect((await rl.check("ip")).ok).toBe(true);
+  });
+
+  it("counts each client key independently", async () => {
+    const rl = new InMemoryRateLimiter({ limit: 1, windowMs: 1000 });
+    expect((await rl.check("a")).ok).toBe(true);
+    expect((await rl.check("b")).ok).toBe(true); // a different IP isn't penalized
+  });
+});
+
+describe("rateLimiterFromEnv", () => {
+  it("falls back to an in-memory limiter when Upstash isn't configured", () => {
+    expect(rateLimiterFromEnv({})).toBeInstanceOf(InMemoryRateLimiter);
+  });
+});

--- a/apps/web/src/app/api/sync/rate-limit.ts
+++ b/apps/web/src/app/api/sync/rate-limit.ts
@@ -1,0 +1,97 @@
+/**
+ * Rate limiting for `POST /api/sync` (#25, ADR 0033 — "rate-limit per accountId/IP
+ * and cap entry size"). The endpoint accepts writes without a login (the bearer
+ * accountId is a capability, not an account), so a fixed-window per-client cap
+ * blunts a flood. Two implementations behind one port: in-process (dev / a single
+ * instance, unit-tested) and Upstash (`INCR` + `PEXPIRE` over the REST API —
+ * written for when Upstash is provisioned, verified then). A limiter that errors
+ * fails OPEN (allows the request) so a limiter blip never takes sync down.
+ */
+
+export interface RateLimitResult {
+  ok: boolean;
+  /** Seconds until the window resets, when blocked — for the `Retry-After` header. */
+  retryAfterSeconds?: number;
+}
+
+export interface RateLimiter {
+  check(key: string): Promise<RateLimitResult>;
+}
+
+/** Requests allowed per `windowMs` per key, before a 429. */
+export interface RateLimitOptions {
+  limit: number;
+  windowMs: number;
+}
+
+const DEFAULTS: RateLimitOptions = { limit: 120, windowMs: 60_000 };
+
+/** Fixed-window counter in process memory — correct on one instance (dev, tests). */
+export class InMemoryRateLimiter implements RateLimiter {
+  private readonly hits = new Map<string, { count: number; resetAt: number }>();
+  constructor(
+    private readonly opts: RateLimitOptions = DEFAULTS,
+    private readonly now: () => number = Date.now,
+  ) {}
+  async check(key: string): Promise<RateLimitResult> {
+    const t = this.now();
+    const entry = this.hits.get(key);
+    if (!entry || t >= entry.resetAt) {
+      this.hits.set(key, { count: 1, resetAt: t + this.opts.windowMs });
+      return { ok: true };
+    }
+    entry.count += 1;
+    if (entry.count > this.opts.limit) {
+      return { ok: false, retryAfterSeconds: Math.max(1, Math.ceil((entry.resetAt - t) / 1000)) };
+    }
+    return { ok: true };
+  }
+}
+
+export interface UpstashRateLimiterConfig extends Partial<RateLimitOptions> {
+  url: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** Fixed-window limiter via Upstash REST: `INCR` the window key, set its expiry on first hit. */
+export class UpstashRateLimiter implements RateLimiter {
+  private readonly opts: RateLimitOptions;
+  constructor(private readonly cfg: UpstashRateLimiterConfig) {
+    this.opts = { limit: cfg.limit ?? DEFAULTS.limit, windowMs: cfg.windowMs ?? DEFAULTS.windowMs };
+  }
+  private get fetchImpl(): typeof fetch {
+    return this.cfg.fetchImpl ?? fetch;
+  }
+  private async cmd(args: (string | number)[]): Promise<unknown> {
+    const res = await this.fetchImpl(this.cfg.url, {
+      method: "POST",
+      headers: { authorization: `Bearer ${this.cfg.token}`, "content-type": "application/json" },
+      body: JSON.stringify(args),
+    });
+    if (!res.ok) throw new Error(`upstash command failed (${res.status})`);
+    return ((await res.json()) as { result?: unknown }).result;
+  }
+  async check(key: string): Promise<RateLimitResult> {
+    const rk = `sync:rl:${key}`;
+    try {
+      const count = Number(await this.cmd(["INCR", rk]));
+      if (count === 1) await this.cmd(["PEXPIRE", rk, this.opts.windowMs]);
+      if (count > this.opts.limit) {
+        return { ok: false, retryAfterSeconds: Math.ceil(this.opts.windowMs / 1000) };
+      }
+      return { ok: true };
+    } catch {
+      return { ok: true }; // fail open — a limiter outage must not break sync
+    }
+  }
+}
+
+/** The configured limiter from env — Upstash when provisioned, else in-process. */
+export function rateLimiterFromEnv(env: Record<string, string | undefined>): RateLimiter {
+  const url = env.UPSTASH_REDIS_REST_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN;
+  const limit = Number(env.SYNC_RATE_LIMIT);
+  const opts: Partial<RateLimitOptions> = Number.isInteger(limit) && limit > 0 ? { limit } : {};
+  return url && token ? new UpstashRateLimiter({ url, token, ...opts }) : new InMemoryRateLimiter();
+}

--- a/apps/web/src/app/api/sync/route.test.ts
+++ b/apps/web/src/app/api/sync/route.test.ts
@@ -47,4 +47,22 @@ describe("POST /api/sync (dev fallback)", () => {
     expect(res.headers.get("access-control-allow-methods")).toContain("POST");
     expect(res.headers.get("access-control-allow-headers")).toContain("authorization");
   });
+
+  it("rate-limits a flooding client with 429 + Retry-After (ADR 0033)", async () => {
+    // A distinct IP so this doesn't share the default "anon" window with other tests.
+    const flood = () =>
+      new Request("http://localhost/api/sync", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: AUTH,
+          "x-forwarded-for": "203.0.113.7",
+        },
+        body: JSON.stringify({ entries: [] }),
+      });
+    let res = await POST(flood());
+    for (let i = 0; i < 500 && res.status !== 429; i++) res = await POST(flood());
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBeTruthy();
+  });
 });

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -1,10 +1,10 @@
 /**
- * `POST /api/sync` (#25, ADR 0033) — the one runtime endpoint sync adds. A thin
- * shell over {@link handleSync}: pick the store, parse the body, run the exchange.
- * Responses are never cached. In production it returns 501 until a sync store is
- * provisioned (the local-first app is unaffected); in development it falls back to
- * a process-memory store so two local profiles can sync against `pnpm dev` with no
- * credentials. This route reads no datasets, so it needs no
+ * `POST /api/sync` (#25, ADR 0033/0035) — the one runtime endpoint sync adds. A thin
+ * shell over {@link handleSync}: rate-limit, pick the store + lock, parse the body,
+ * run the exchange. Responses are never cached. In production it returns 501 until a
+ * sync store is provisioned (the local-first app is unaffected); in development it
+ * falls back to a process-memory store so two local profiles can sync against
+ * `pnpm dev` with no credentials. This route reads no datasets, so it needs no
  * `outputFileTracingIncludes` entry.
  *
  * CORS is open (like the public REST API): the browser extension calls this from a
@@ -14,6 +14,8 @@
  * the header, not a cookie), and the server only ever holds opaque ciphertext.
  */
 import { handleSync } from "./handler";
+import { type Lock, lockFromEnv } from "./lock";
+import { type RateLimiter, rateLimiterFromEnv } from "./rate-limit";
 import { InMemorySyncStore, type SyncStore, syncStoreFromEnv } from "./sync-store";
 
 export const runtime = "nodejs";
@@ -34,6 +36,9 @@ export function OPTIONS(): Response {
 // Reused across requests in one dev-server process so two profiles converge; never
 // constructed in production, where an unprovisioned endpoint stays 501.
 let devStore: SyncStore | null = null;
+// The lock + limiter are likewise reused so their in-process state persists per instance.
+let lock: Lock | null = null;
+let limiter: RateLimiter | null = null;
 
 function resolveStore(): SyncStore | null {
   const configured = syncStoreFromEnv(process.env);
@@ -43,16 +48,32 @@ function resolveStore(): SyncStore | null {
   return devStore;
 }
 
-function json(body: unknown, status: number): Response {
+function json(body: unknown, status: number, headers?: Record<string, string>): Response {
   return Response.json(body, {
     status,
-    headers: { "cache-control": "no-store", "access-control-allow-origin": "*" },
+    headers: { "cache-control": "no-store", "access-control-allow-origin": "*", ...headers },
   });
 }
 
+/** The client IP for rate-limiting, from the proxy headers Vercel sets (spoof-safe at the edge). */
+function clientKey(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  if (fwd) return fwd.split(",")[0]!.trim();
+  return req.headers.get("x-real-ip") ?? "anon";
+}
+
 export async function POST(req: Request): Promise<Response> {
+  limiter ??= rateLimiterFromEnv(process.env);
+  const rl = await limiter.check(clientKey(req));
+  if (!rl.ok) {
+    return json({ error: "rate limited" }, 429, {
+      "retry-after": String(rl.retryAfterSeconds ?? 60),
+    });
+  }
+
   const store = resolveStore();
   if (!store) return json({ error: "sync is not configured on this server" }, 501);
+  lock ??= lockFromEnv(process.env);
 
   let body: unknown;
   try {
@@ -61,6 +82,10 @@ export async function POST(req: Request): Promise<Response> {
     return json({ error: "invalid JSON body" }, 400);
   }
 
-  const result = await handleSync({ authorization: req.headers.get("authorization"), body }, store);
+  const result = await handleSync(
+    { authorization: req.headers.get("authorization"), body },
+    store,
+    lock,
+  );
   return json(result.body, result.status);
 }

--- a/docs/adr/0035-sync-incremental-cursor.md
+++ b/docs/adr/0035-sync-incremental-cursor.md
@@ -61,11 +61,18 @@ than rejecting the whole batch) ship here too.
   more}` wire on the web + mobile backends; and the **delta-pull cursor activated**
   on the web + mobile stores (`getCursor`/`setCursor`). Backward-compatible — a
   store without a cursor still whole-set syncs.
-- **Deferred (the remaining Phase-3 completion):** the **dirty/bounded push** (so a
-  steady-state round uploads ~nothing and a large set pages under the cap), which is
-  the prerequisite for **enabling `ul.hifz`**; the **atomic Upstash merge** (Lua/tx)
-  — the one part that needs live Redis to verify; and **tombstone pruning** +
-  **graceful overflow**. These land together once Upstash is provisioned.
+- **Landed since (provisioning readiness):** the **atomic merge** is now a
+  per-account lock around the read→merge→write (`lock.ts`) — an in-process lock for
+  dev/tests, a `SET NX PX` Upstash lock for production (written; live-verified on
+  provisioning); **per-IP rate limiting** with `429 + Retry-After` (`rate-limit.ts`,
+  in-process + Upstash, fails open); and a **provisioning runbook**
+  (`docs/launch/sync-provisioning.md`). The in-process lock + limiter are unit-tested
+  (incl. a two-push no-lost-update test).
+- **Deferred (the remaining Phase-3 completion, gated on Upstash):** the
+  **dirty/bounded push** (so a steady-state round uploads ~nothing and a large set
+  pages under the cap), which is the prerequisite for **enabling `ul.hifz`**;
+  **tombstone pruning**; and **graceful overflow**. These land once Upstash is
+  provisioned and the above can be verified end to end.
 
 ## Consequences
 

--- a/docs/launch/sync-provisioning.md
+++ b/docs/launch/sync-provisioning.md
@@ -1,0 +1,73 @@
+# Provisioning cross-device sync (`/api/sync`)
+
+The sync server (#25, ADR 0033/0035) is **off until you provision a datastore**.
+With no store configured, `POST /api/sync` returns **501** and the apps stay fully
+local-first — nothing breaks. This runbook flips it on. It's the one hands-on step;
+all the code (versioned store, incremental cursor, per-account lock, rate limiter)
+is already shipped behind these two env vars.
+
+## What you need
+
+A serverless Redis with an **HTTP/REST** API. The app talks to it over REST with
+**no SDK dependency** (ADR 0033), so any of these works:
+
+- **Vercel Marketplace → Upstash Redis** (simplest — auto-injects the env vars), or
+- **Upstash console** directly (create a Redis database, copy its REST creds).
+
+## Steps
+
+1. **Create the Redis database.**
+   - Vercel: Project → *Storage* → *Marketplace* → **Upstash Redis** → create. It
+     adds `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` to the project.
+   - Or Upstash console: create a database → *REST API* → copy the URL + token.
+
+2. **Set the env vars** (Production, and Preview if you want it there) — skip if the
+   Marketplace integration already added them:
+
+   ```
+   UPSTASH_REDIS_REST_URL   = https://<your-db>.upstash.io
+   UPSTASH_REDIS_REST_TOKEN = <token>
+   SYNC_RATE_LIMIT          = 120   # optional; requests per IP per minute (default 120)
+   ```
+
+   `syncStoreFromEnv` (`apps/web/src/app/api/sync/sync-store.ts`) turns sync on as
+   soon as both `UPSTASH_*` vars are present; the same two vars also switch the lock
+   and rate limiter from their in-process dev versions to the Upstash-backed ones.
+
+3. **Redeploy** so the functions pick up the env. (The route is `runtime = "nodejs"`,
+   `dynamic = "force-dynamic"` — no datasets, no build inclusion needed.)
+
+4. **Verify.**
+   - `curl -i https://app.ummahlibrary.org/api/sync -X POST -H 'content-type: application/json' -d '{"entries":[]}'`
+     → was `501`; should now be `401` ("missing account id" — i.e. the store is live
+     and it's asking for a Bearer accountId).
+   - End-to-end: enable sync in **Settings → Sync** on one device, copy the recovery
+     phrase, enter it on a second device, confirm bookmarks/last-read/etc. converge.
+   - Watch the Upstash dashboard for keys: `sync:<accountId>` (the per-account
+     ciphertext blob), `sync:rl:*` (rate-limit windows), `sync:lock:*` (transient
+     write locks).
+
+## What's guarding it
+
+- **Rate limiting** — fixed window per client IP (`SYNC_RATE_LIMIT`/min, default
+  120), `429 + Retry-After` over the cap. Fails **open** if Redis is unreachable, so
+  a limiter blip never takes sync down. (`rate-limit.ts`)
+- **Atomic merge** — a per-account `SET NX PX` lock serializes the read→merge→write
+  so two devices pushing at once can't lose an update; best-effort (proceeds if the
+  lock can't be acquired within the wait budget). (`lock.ts`)
+- **Abuse caps** — `MAX_ENTRIES` per request, `MAX_CIPHERTEXT`/nonce/node size caps,
+  strict clock validation, and re-validation of the stored set on read. (`handler.ts`)
+- **Zero-knowledge** — the server only ever holds opaque ciphertext under an
+  unguessable HMAC `accountId`; it can read neither the data nor which features a
+  user has (ADR 0033). Keep the endpoint HTTPS-only.
+
+## Operating notes
+
+- **Cost/limits:** one small Redis. Each account is a few KB (scalars + element
+  entries); `ul.hifz` (Phase 3) is the only large key and is gated until enabled.
+- **Tombstones** accumulate until the Phase-3 pruning lands; the per-request
+  `MAX_ENTRIES` cap is the backstop. Watch blob sizes if usage is heavy.
+- **Turning it off:** remove the `UPSTASH_*` vars and redeploy — back to `501`,
+  local-first, no data loss on devices (their local copies are untouched).
+- **Rotating creds:** rotate the Upstash token, update the env var, redeploy. The
+  data is keyed by `accountId`, independent of the token.


### PR DESCRIPTION
## `/api/sync` provisioning readiness — rate limit · atomic merge · runbook (#25)

Makes the sync endpoint production-ready so turning it on is just **setting two env vars**. Everything here works against the in-memory dev path (tested); the Upstash-backed paths are written and **verify once provisioned**. **Off by default** (no store ⇒ 501).

> **Stacked on #174** → #173 → #172 → #171 → #169.

### Atomic merge (ADR 0035)
A **per-account lock** around the handler's read→merge→write, so two devices pushing in the same instant can't lose an update. `lock.ts` provides an in-process lock (dev/tests) and a `SET NX PX` Upstash REST lock — **best-effort**: if it can't acquire within the wait budget it proceeds anyway (degrading to the v2 rare-race), never blocking sync. `handleSync` takes an optional `Lock`; the route injects it.

### Rate limiting (ADR 0033 abuse guard)
The endpoint takes writes without a login (the accountId is a capability), so a **fixed window per client IP** with `429 + Retry-After` blunts a flood. `rate-limit.ts`: in-process + Upstash REST (`INCR`+`PEXPIRE`), **fails open** so a limiter blip can't take sync down. Configurable via `SYNC_RATE_LIMIT` (default 120/min). Both the lock and the limiter switch to the Upstash versions automatically when `UPSTASH_*` is present.

### Runbook
`docs/launch/sync-provisioning.md` — create the Redis (Vercel Marketplace → Upstash, or the Upstash console), set `UPSTASH_REDIS_REST_URL`/`_TOKEN` (+ optional `SYNC_RATE_LIMIT`), redeploy, verify (`501 → 401 → two-device round-trip`), plus the guards, ops notes, and how to turn it off.

### Verification
- In-process **lock**: serialization (never two at once), runs different keys concurrently, releases on throw, and a **two-concurrent-push no-lost-update** test through `handleSync`.
- **Rate-limiter**: window cap, reset, per-key isolation; route **429 + Retry-After**.
- `pnpm lint && typecheck && test && build` green.

### Still deferred (gated on provisioning)
dirty/bounded push → **enable `ul.hifz`**, tombstone pruning, graceful overflow — they land once Upstash is live and can be verified end to end.

**This is the last code prep before provisioning.** With the creds set, the only remaining work is the Phase-3 completion above + the live device-verification pass.
