### PR TITLE
feat(reader): audio playback speed + A–B range repeat (#136)

### DIFF
--- a/apps/mobile/src/audio/useSurahAudio.ts
+++ b/apps/mobile/src/audio/useSurahAudio.ts
@@ -14,7 +14,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AppState } from "react-native";
 import { createAudioPlayer, setAudioModeAsync, type AudioPlayer } from "expo-audio";
-import { reciterAudioUrl, type ReciterPlugin, type VerseKey } from "@ummahlibrary/core";
+import {
+  clampPlaybackRate,
+  reciterAudioUrl,
+  repeatRange,
+  type ReciterPlugin,
+  type VerseKey,
+} from "@ummahlibrary/core";
+import { KEYS, getString, setString } from "../storage";
 
 const STALL_MS = 8000;
 const POLL_MS = 60;
@@ -61,7 +68,12 @@ export interface SurahAudio {
   activeWord: number;
   loop: boolean;
   setLoop: (on: boolean) => void;
+  /** Playback speed (clamped to [0.5, 2]); persisted across sessions. */
+  rate: number;
+  setRate: (rate: number) => void;
   playFrom: (verses: VerseKey[], start: VerseKey, advance: boolean) => void;
+  /** Loop the inclusive A→B range `count` times (Infinity = until stopped). */
+  playRange: (verses: VerseKey[], from: VerseKey, to: VerseKey, count: number) => void;
   stop: () => void;
 }
 
@@ -70,12 +82,14 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
   const [buffering, setBuffering] = useState(false);
   const [activeWord, setActiveWord] = useState(-1);
   const [loop, setLoopState] = useState(false);
+  const [rate, setRateState] = useState(1);
 
   const playerRef = useRef<AudioPlayer | null>(null);
   const tokenRef = useRef(0);
   const settleRef = useRef<(() => void) | null>(null);
   // A ref so the running playback loop reads the latest value, not a stale closure.
   const loopRef = useRef(false);
+  const rateRef = useRef(1);
   // Set when the app returns to the foreground so the next poll tick force-pushes
   // the word highlight. While backgrounded the JS poll is throttled and React
   // never commits its `setActiveWord` calls, so on return the highlight can sit
@@ -90,9 +104,35 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
     return () => sub.remove();
   }, []);
 
+  // Restore the saved playback speed once.
+  useEffect(() => {
+    void getString(KEYS.audioRate).then((saved) => {
+      if (saved === null) return;
+      const r = clampPlaybackRate(Number(saved));
+      rateRef.current = r;
+      setRateState(r);
+    });
+  }, []);
+
   const setLoop = useCallback((on: boolean) => {
     loopRef.current = on;
     setLoopState(on);
+  }, []);
+
+  const setRate = useCallback((next: number) => {
+    const r = clampPlaybackRate(next);
+    rateRef.current = r;
+    setRateState(r);
+    void setString(KEYS.audioRate, String(r));
+    try {
+      // Apply to the live player at once (pitch-corrected so the voice keeps its tone).
+      if (playerRef.current) {
+        playerRef.current.shouldCorrectPitch = true;
+        playerRef.current.playbackRate = r;
+      }
+    } catch {
+      /* no active player */
+    }
   }, []);
 
   // The one persistent player, created lazily and re-sourced with replace().
@@ -101,6 +141,13 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
       playerRef.current = createAudioPlayer({ uri: src });
     } else {
       playerRef.current.replace({ uri: src });
+    }
+    try {
+      // Re-assert the chosen speed after every (re-)source — replace() can reset it.
+      playerRef.current.shouldCorrectPitch = true;
+      playerRef.current.playbackRate = rateRef.current;
+    } catch {
+      /* rate unsupported on this platform */
     }
     return playerRef.current;
   }, []);
@@ -123,17 +170,18 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
     }
   }, []);
 
-  const playFrom = useCallback(
-    (verses: VerseKey[], start: VerseKey, advance: boolean) => {
-      const startIdx = verses.findIndex((v) => v.sura === start.sura && v.aya === start.aya);
-      if (startIdx < 0) return;
-      const queue = advance ? verses.slice(startIdx) : [verses[startIdx]!];
+  // One playback session over `queue`, repeated per `repeat`: null = a whole-list
+  // loop driven live by `loopRef`; a number = that many passes (Infinity = until
+  // stopped). The per-āyah engine below is shared by "play from here" and "loop A→B".
+  const startSession = useCallback(
+    (queue: VerseKey[], startKey: VerseKey, repeat: number | null) => {
+      if (queue.length === 0) return;
       const token = ++tokenRef.current;
       // Settle any in-flight āyah loop now so its poll/listener tear down at
       // once, and flip the UI to "playing" immediately (the audio itself still
       // has to fetch timings/buffer, but the button responds instantly).
       settleRef.current?.();
-      setPlayingKey(verseKeyOf(start));
+      setPlayingKey(verseKeyOf(startKey));
       setBuffering(true);
       setActiveWord(-1);
 
@@ -149,6 +197,7 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
         // Bring the notification/lock-screen controls up exactly once per
         // session (see below) — rebuilding them per āyah would flicker.
         let lockActive = false;
+        let plays = 0;
 
         do {
           for (const v of queue) {
@@ -298,8 +347,13 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
 
             if (tokenRef.current !== token) return;
           }
-          // Repeat the whole range while loop is on (read live via the ref).
-        } while (loopRef.current && tokenRef.current === token);
+          plays += 1;
+          // Repeat: a whole-list loop reads `loopRef` live; an A→B range runs a
+          // fixed number of passes (Infinity ⇒ until stopped).
+        } while (
+          tokenRef.current === token &&
+          (repeat === null ? loopRef.current : plays < repeat)
+        );
 
         if (tokenRef.current === token) {
           try {
@@ -318,6 +372,24 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
     [reciter, ensurePlayer],
   );
 
+  const playFrom = useCallback(
+    (verses: VerseKey[], start: VerseKey, advance: boolean) => {
+      const startIdx = verses.findIndex((v) => v.sura === start.sura && v.aya === start.aya);
+      if (startIdx < 0) return;
+      const queue = advance ? verses.slice(startIdx) : [verses[startIdx]!];
+      startSession(queue, start, null);
+    },
+    [startSession],
+  );
+
+  const playRange = useCallback(
+    (verses: VerseKey[], from: VerseKey, to: VerseKey, count: number) => {
+      const queue = repeatRange(verses, verseKeyOf(from), verseKeyOf(to));
+      if (queue[0]) startSession(queue, queue[0], count);
+    },
+    [startSession],
+  );
+
   // Tear the player down when the screen leaves so no poll/interval lingers,
   // and clear the notification so it can't outlive the reader.
   useEffect(() => {
@@ -334,5 +406,16 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
     };
   }, []);
 
-  return { playingKey, buffering, activeWord, loop, setLoop, playFrom, stop };
+  return {
+    playingKey,
+    buffering,
+    activeWord,
+    loop,
+    setLoop,
+    rate,
+    setRate,
+    playFrom,
+    playRange,
+    stop,
+  };
 }

--- a/apps/mobile/src/components/AudioRangeControls.tsx
+++ b/apps/mobile/src/components/AudioRangeControls.tsx
@@ -1,0 +1,137 @@
+/**
+ * Playback speed + A→B range-repeat controls for the reciter (#136), shared by the
+ * surah and juzʾ readers. A tap-to-cycle speed chip, plus a collapsible panel to
+ * loop an āyah range A→B a chosen number of times. The playback logic lives in
+ * {@link useSurahAudio}; this is only the UI over its `rate`/`setRate`/`playRange`.
+ */
+import { useMemo, useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "../Type";
+import { cyclePlaybackRate, type VerseKey } from "@ummahlibrary/core";
+import { useTheme, type Palette } from "../theme";
+import type { SurahAudio } from "../audio/useSurahAudio";
+
+const COUNTS = [Infinity, 2, 3, 5, 10];
+const countLabel = (n: number): string => (n === Infinity ? "∞" : `${n}×`);
+
+export function AudioRangeControls({ audio, verses }: { audio: SurahAudio; verses: VerseKey[] }) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const [open, setOpen] = useState(false);
+  const [fromIdx, setFromIdx] = useState(0);
+  const [toIdx, setToIdx] = useState(Math.max(0, verses.length - 1));
+  const [countIdx, setCountIdx] = useState(0);
+
+  if (verses.length === 0) return null;
+
+  const multiSurah = new Set(verses.map((v) => v.sura)).size > 1;
+  const label = (v: VerseKey): string => (multiSurah ? `${v.sura}:${v.aya}` : `${v.aya}`);
+  const clampIdx = (i: number): number => Math.min(verses.length - 1, Math.max(0, i));
+  const from = verses[clampIdx(fromIdx)]!;
+  const to = verses[clampIdx(toIdx)]!;
+  const count = COUNTS[countIdx]!;
+
+  const stepper = (value: string, onMinus: () => void, onPlus: () => void, a11y: string) => (
+    <View style={styles.stepper}>
+      <Pressable onPress={onMinus} hitSlop={8} accessibilityLabel={`${a11y} earlier`}>
+        <Text style={styles.stepBtn}>−</Text>
+      </Pressable>
+      <Text style={styles.stepVal}>{value}</Text>
+      <Pressable onPress={onPlus} hitSlop={8} accessibilityLabel={`${a11y} later`}>
+        <Text style={styles.stepBtn}>+</Text>
+      </Pressable>
+    </View>
+  );
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.row}>
+        <Pressable
+          onPress={() => audio.setRate(cyclePlaybackRate(audio.rate))}
+          style={styles.chip}
+          accessibilityLabel={`Playback speed ${audio.rate}×`}
+        >
+          <Text style={[styles.chipText, audio.rate !== 1 && styles.chipTextOn]}>
+            {audio.rate}×
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={() => setOpen((v) => !v)}
+          style={styles.chip}
+          accessibilityLabel="Repeat an āyah range"
+        >
+          <Text style={[styles.chipText, open && styles.chipTextOn]}>A–B</Text>
+        </Pressable>
+      </View>
+      {open && (
+        <View style={styles.panel}>
+          {stepper(
+            label(from),
+            () => setFromIdx((i) => clampIdx(i - 1)),
+            () => setFromIdx((i) => clampIdx(i + 1)),
+            "Range start",
+          )}
+          <Text style={styles.arrow}>→</Text>
+          {stepper(
+            label(to),
+            () => setToIdx((i) => clampIdx(i - 1)),
+            () => setToIdx((i) => clampIdx(i + 1)),
+            "Range end",
+          )}
+          <Pressable
+            onPress={() => setCountIdx((i) => (i + 1) % COUNTS.length)}
+            style={styles.chip}
+            accessibilityLabel={`Repeat ${countLabel(count)}`}
+          >
+            <Text style={styles.chipText}>{countLabel(count)}</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => audio.playRange(verses, from, to, count)}
+            style={styles.go}
+            accessibilityLabel="Loop the range"
+          >
+            <Text style={styles.goText}>Loop</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function makeStyles(c: Palette) {
+  return StyleSheet.create({
+    wrap: { gap: 8 },
+    row: { flexDirection: "row", gap: 8 },
+    chip: {
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bgElev,
+    },
+    chipText: { color: c.muted, fontSize: 13, fontWeight: "600" },
+    chipTextOn: { color: c.accent },
+    panel: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", gap: 8 },
+    stepper: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 10,
+      paddingHorizontal: 10,
+      paddingVertical: 4,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bgElev,
+    },
+    stepBtn: { color: c.accent, fontSize: 18, fontWeight: "700", width: 16, textAlign: "center" },
+    stepVal: { color: c.fg, fontSize: 13, fontWeight: "600", minWidth: 28, textAlign: "center" },
+    arrow: { color: c.muted, fontSize: 14 },
+    go: {
+      paddingVertical: 6,
+      paddingHorizontal: 14,
+      borderRadius: 8,
+      backgroundColor: c.accent,
+    },
+    goText: { color: c.ink, fontSize: 13, fontWeight: "700" },
+  });
+}

--- a/apps/mobile/src/screens/JuzReaderScreen.tsx
+++ b/apps/mobile/src/screens/JuzReaderScreen.tsx
@@ -8,6 +8,7 @@ import { useTheme, type Palette } from "../theme";
 import { FONT } from "../fonts";
 import { useSettings } from "../state/SettingsContext";
 import { useSurahAudio, verseKeyOf } from "../audio/useSurahAudio";
+import { AudioRangeControls } from "../components/AudioRangeControls";
 import { DEFAULT_EDITION } from "../types";
 import type { ReadStackParamList } from "../navigation/types";
 
@@ -71,13 +72,16 @@ export function JuzReaderScreen({ route }: Props) {
         const inRange = surah.ayahs.filter(
           (a) => a.aya >= p.from && (p.toExclusive === null || a.aya < p.toExclusive),
         );
-        return inRange.map((a, i): Line => ({
-          sura: p.sura,
-          aya: a.aya,
-          arabic: a.text,
-          translation: trByAya.get(a.aya) ?? "",
-          surahHeader: i === 0 ? `${surah.surah.transliteration} · ${surah.surah.englishName}` : undefined,
-        }));
+        return inRange.map(
+          (a, i): Line => ({
+            sura: p.sura,
+            aya: a.aya,
+            arabic: a.text,
+            translation: trByAya.get(a.aya) ?? "",
+            surahHeader:
+              i === 0 ? `${surah.surah.transliteration} · ${surah.surah.englishName}` : undefined,
+          }),
+        );
       }),
     )
       .then((groups) => {
@@ -90,10 +94,7 @@ export function JuzReaderScreen({ route }: Props) {
     };
   }, [juz, edition]);
 
-  const verses = useMemo(
-    () => (lines ?? []).map((l) => ({ sura: l.sura, aya: l.aya })),
-    [lines],
-  );
+  const verses = useMemo(() => (lines ?? []).map((l) => ({ sura: l.sura, aya: l.aya })), [lines]);
 
   if (error) {
     return (
@@ -133,6 +134,9 @@ export function JuzReaderScreen({ route }: Props) {
           <Text style={[styles.loopText, audio.loop && styles.loopTextOn]}>🔁 Loop</Text>
         </Pressable>
       </View>
+      <View style={styles.audioExtras}>
+        <AudioRangeControls audio={audio} verses={verses} />
+      </View>
 
       {lines.map((l) => {
         const key = verseKeyOf(l);
@@ -167,6 +171,7 @@ function makeStyles(c: Palette) {
     error: { color: c.error, fontSize: 15 },
     content: { paddingHorizontal: 18, paddingBottom: 40 },
     audioBar: { flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 12 },
+    audioExtras: { marginBottom: 12 },
     audioPlay: {
       paddingVertical: 8,
       paddingHorizontal: 18,

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -29,6 +29,7 @@ import { useLibrary } from "../state/LibraryContext";
 import { useSurahAudio, verseKeyOf } from "../audio/useSurahAudio";
 import { DEFAULT_EDITION } from "../types";
 import { ReaderControls } from "../components/ReaderControls";
+import { AudioRangeControls } from "../components/AudioRangeControls";
 import { ReadingTranslationPicker } from "../components/ReadingTranslationPicker";
 import { TranslationManager } from "../components/TranslationManager";
 import { AyahView, type TrLine } from "../components/AyahView";
@@ -178,7 +179,13 @@ export function SurahReaderScreen({ navigation, route }: Props) {
     const text = trMap.get(id)?.get(aya);
     if (!text) return null;
     const m: Translation | undefined = metaById.get(id);
-    return { id, name: m?.name ?? id, text, direction: m?.direction ?? "ltr", language: m?.language ?? "en" };
+    return {
+      id,
+      name: m?.name ?? id,
+      text,
+      direction: m?.direction ?? "ltr",
+      language: m?.language ?? "en",
+    };
   };
 
   // Stable per-ayah view-models so non-playing rows skip re-render during audio.
@@ -335,8 +342,16 @@ export function SurahReaderScreen({ navigation, route }: Props) {
             : reciter.name}
         </Text>
         <Pressable onPress={() => audio.setLoop(!audio.loop)} hitSlop={8} accessibilityLabel="Loop">
-          <Icon name="repeat" size={20} color={audio.loop ? colors.accent : colors.muted} sw={1.8} />
+          <Icon
+            name="repeat"
+            size={20}
+            color={audio.loop ? colors.accent : colors.muted}
+            sw={1.8}
+          />
         </Pressable>
+      </View>
+      <View style={styles.audioExtras}>
+        <AudioRangeControls audio={audio} verses={verses} />
       </View>
     </>
   );
@@ -438,7 +453,8 @@ export function SurahReaderScreen({ navigation, route }: Props) {
                 return text ? (
                   <Text key={a.aya}>
                     <Text style={styles.flowNum}>{a.aya}. </Text>
-                    {text}{"  "}
+                    {text}
+                    {"  "}
                   </Text>
                 ) : null;
               })}
@@ -515,7 +531,13 @@ function makeStyles(c: Palette) {
     error: { color: c.error, fontSize: 15 },
     content: { paddingHorizontal: 18, paddingBottom: 40 },
     head: { alignItems: "center", paddingVertical: 14 },
-    crest: { width: 94, height: 94, alignItems: "center", justifyContent: "center", marginBottom: 4 },
+    crest: {
+      width: 94,
+      height: 94,
+      alignItems: "center",
+      justifyContent: "center",
+      marginBottom: 4,
+    },
     crestAr: {
       position: "absolute",
       color: c.accentHi,
@@ -546,6 +568,7 @@ function makeStyles(c: Palette) {
       paddingVertical: 12,
       marginBottom: 4,
     },
+    audioExtras: { marginBottom: 10 },
     audioPlay: {
       width: 42,
       height: 42,
@@ -562,7 +585,13 @@ function makeStyles(c: Palette) {
       marginVertical: 12,
       fontFamily: FONT.ar,
     },
-    mushaf: { color: c.fg, textAlign: "right", writingDirection: "rtl", marginTop: 8, fontFamily: FONT.ar },
+    mushaf: {
+      color: c.fg,
+      textAlign: "right",
+      writingDirection: "rtl",
+      marginTop: 8,
+      fontFamily: FONT.ar,
+    },
     endMarker: { color: c.accent, fontSize: 18, fontFamily: FONT.ar },
     flow: { color: c.fg, marginTop: 4 },
     flowNum: { color: c.accent, fontWeight: "700" },

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -11,6 +11,7 @@ export const KEYS = {
   readingTranslation: "ul.readingTranslation",
   tafsir: "ul.tafsir",
   reciter: "ul.reciter",
+  audioRate: "ul.audioRate",
   scale: "ul.scale",
   theme: "ul.theme",
   bookmarks: "ul.bookmarks",

--- a/apps/web/src/components/ReadingAudio.tsx
+++ b/apps/web/src/components/ReadingAudio.tsx
@@ -1,12 +1,28 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { type ReciterPlugin, quranComAudioUrl, reciterAudioUrl } from "@ummahlibrary/core";
+import {
+  type ReciterPlugin,
+  cyclePlaybackRate,
+  quranComAudioUrl,
+  reciterAudioUrl,
+  repeatRange,
+} from "@ummahlibrary/core";
 import { N, Icon } from "@ummahlibrary/ui";
 import { readReciter, writeReciter } from "../lib/reader-prefs";
-import { readLoop, writeLoop } from "../lib/reader-prefs-store";
+import { readLoop, readRate, writeLoop, writeRate } from "../lib/reader-prefs-store";
 
 const RECITER_KEY = "ul.reciter";
+
+/** Repeat-count choices for an A→B range loop (∞ repeats until stopped). */
+const REPEAT_COUNTS: { label: string; value: number }[] = [
+  { label: "∞", value: Infinity },
+  { label: "2×", value: 2 },
+  { label: "3×", value: 3 },
+  { label: "5×", value: 5 },
+  { label: "10×", value: 10 },
+];
+const rateLabel = (rate: number): string => `${rate}×`;
 
 interface Verse {
   sura: number;
@@ -39,9 +55,7 @@ function fetchTiming(recitationId: number, verseKey: string): Promise<Timing | n
           verse?: { audio?: { url: string; segments: Segment[] } };
         };
         const audio = data.verse?.audio;
-        return audio
-          ? { url: quranComAudioUrl(audio.url), segments: audio.segments }
-          : null;
+        return audio ? { url: quranComAudioUrl(audio.url), segments: audio.segments } : null;
       } catch {
         return null;
       }
@@ -71,10 +85,22 @@ export function ReadingAudio({
   const [current, setCurrent] = useState<string | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [loop, setLoop] = useState(false);
+  const [rate, setRate] = useState(1);
+  // A→B range-repeat UI state (the panel + the chosen bounds/count).
+  const [showRange, setShowRange] = useState(false);
+  const [rangeFrom, setRangeFrom] = useState<string | null>(null);
+  const [rangeTo, setRangeTo] = useState<string | null>(null);
+  const [repeatCount, setRepeatCount] = useState<number>(Infinity);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const tokenRef = useRef(0);
   // Read live inside the playback `onended` closure, not a stale capture.
   const loopRef = useRef(false);
+  const rateRef = useRef(1);
+  // The verse list the current playback traverses — the whole list, or an A→B
+  // slice while range-repeating. `repeatRef` holds the countdown while a range
+  // loop is active (Infinity = until stopped); null otherwise.
+  const activeListRef = useRef<Verse[]>(verses);
+  const repeatRef = useRef<{ remaining: number } | null>(null);
   const versesRef = useRef(verses);
   versesRef.current = verses;
   const wordRef = useRef<{ block: HTMLElement | null; segments: Segment[] | null; last: number }>({
@@ -90,6 +116,9 @@ export function ReadingAudio({
     const savedLoop = readLoop();
     setLoop(savedLoop);
     loopRef.current = savedLoop;
+    const savedRate = readRate();
+    setRate(savedRate);
+    rateRef.current = savedRate;
 
     // The reader toolbar can change the reciter; keep the dock in sync.
     const onReciter = (e: Event) => {
@@ -108,6 +137,32 @@ export function ReadingAudio({
     loopRef.current = next;
     setLoop(next);
     writeLoop(next);
+  }
+
+  /** Cycle the playback speed, persist it, and apply it to the live audio at once. */
+  function cycleRate() {
+    const next = cyclePlaybackRate(rateRef.current);
+    rateRef.current = next;
+    setRate(next);
+    writeRate(next);
+    if (audioRef.current) audioRef.current.playbackRate = next;
+  }
+
+  /** Play the whole list from `start`, advancing ayah-to-ayah (no range loop). */
+  function playAll(start: Verse) {
+    repeatRef.current = null;
+    activeListRef.current = versesRef.current;
+    void play(start, true);
+  }
+
+  /** Loop the inclusive A→B range `count` times (Infinity = until stopped). */
+  function playRange(from: string | null, to: string | null, count: number) {
+    const slice = repeatRange(versesRef.current, from, to);
+    const start = slice[0];
+    if (!start) return;
+    repeatRef.current = { remaining: count };
+    activeListRef.current = slice;
+    void play(start, true);
   }
 
   function clearWord() {
@@ -144,6 +199,7 @@ export function ReadingAudio({
   }
 
   function stop() {
+    repeatRef.current = null;
     audioRef.current?.pause();
     setIsPlaying(false);
     setCurrent(null);
@@ -160,6 +216,13 @@ export function ReadingAudio({
     const key = keyOf(verse);
     const token = ++tokenRef.current;
     const audio = (audioRef.current ??= new Audio());
+    // Detach the previous āyah's handlers and pause it BEFORE any await: playAll/
+    // playRange mutate the shared refs (activeListRef/repeatRef) synchronously, so a
+    // stale onended firing during the fetchTiming await would advance the wrong āyah
+    // or decrement the new range's count. Neutralize it here, before we yield.
+    audio.onended = null;
+    audio.ontimeupdate = null;
+    audio.pause();
     clearWord();
 
     let src: string | undefined;
@@ -176,16 +239,24 @@ export function ReadingAudio({
 
     wordRef.current = { block: document.getElementById(key), segments, last: -1 };
     audio.src = src;
+    audio.playbackRate = rateRef.current;
     audio.ontimeupdate = segments ? onTimeUpdate : null;
     audio.onended = () => {
       if (!advance) return stop();
-      const list = versesRef.current;
+      const list = activeListRef.current;
       const idx = list.findIndex((v) => v.sura === verse.sura && v.aya === verse.aya);
       const next = idx >= 0 ? list[idx + 1] : undefined;
-      if (next) void play(next, true);
-      // End of the surah/juzʾ: repeat from the top when looping.
-      else if (loopRef.current && list[0]) void play(list[0], true);
-      else stop();
+      if (next) return void play(next, true);
+      // Reached the end of the active list.
+      const rep = repeatRef.current;
+      if (rep) {
+        rep.remaining -= 1; // Infinity - 1 stays Infinity ⇒ loops until stopped
+        if (rep.remaining > 0 && list[0]) return void play(list[0], true);
+        return stop();
+      }
+      // Whole-surah/juzʾ loop: repeat from the top.
+      if (loopRef.current && list[0]) return void play(list[0], true);
+      stop();
     };
     audio.onerror = () => stop();
     void audio.play().then(
@@ -207,7 +278,7 @@ export function ReadingAudio({
       void audio.play();
       setIsPlaying(true);
     } else if (versesRef.current[0]) {
-      void play(versesRef.current[0], true);
+      playAll(versesRef.current[0]);
     }
   }
 
@@ -223,7 +294,7 @@ export function ReadingAudio({
       const from = node.closest<HTMLElement>("[data-play-key]");
       if (!from) return;
       event.preventDefault();
-      void play(parseKey(from.dataset.playKey!), true);
+      playAll(parseKey(from.dataset.playKey!));
     }
     document.addEventListener("click", onClick);
     return () => {
@@ -234,114 +305,286 @@ export function ReadingAudio({
 
   if (reciters.length === 0) return null;
 
+  // Shared speed + A→B range controls (rendered in both variants).
+  const list = versesRef.current;
+  const multiSurah = new Set(list.map((v) => v.sura)).size > 1;
+  const ayahLabel = (v: Verse): string => (multiSurah ? `${v.sura}:${v.aya}` : `${v.aya}`);
+  const fromVal = rangeFrom ?? (list[0] ? keyOf(list[0]) : "");
+  const toVal = rangeTo ?? (list.length ? keyOf(list[list.length - 1]!) : "");
+  const ctrlStyle = {
+    background: "none",
+    border: `1px solid ${N.border}`,
+    borderRadius: 8,
+    cursor: "pointer",
+    fontFamily: N.ui,
+    fontSize: 12.5,
+    fontWeight: 600,
+    padding: "5px 8px",
+    flexShrink: 0,
+  } as const;
+  const selStyle = {
+    background: N.card,
+    color: N.fg,
+    border: `1px solid ${N.border}`,
+    borderRadius: 8,
+    padding: "5px 8px",
+    fontFamily: N.ui,
+    fontSize: 12.5,
+  } as const;
+  const speedButton = (
+    <button
+      type="button"
+      onClick={cycleRate}
+      title="Playback speed"
+      aria-label={`Playback speed ${rateLabel(rate)}`}
+      style={{ ...ctrlStyle, color: rate !== 1 ? N.gold : N.muted, minWidth: 40 }}
+    >
+      {rateLabel(rate)}
+    </button>
+  );
+  const rangeButton = (
+    <button
+      type="button"
+      onClick={() => setShowRange((v) => !v)}
+      aria-pressed={showRange}
+      title="Repeat a range of āyāt (A–B)"
+      style={{ ...ctrlStyle, color: showRange ? N.gold : N.muted }}
+    >
+      A–B
+    </button>
+  );
+  const rangePanel = showRange ? (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        flexWrap: "wrap",
+        padding: "8px clamp(14px, 4vw, 40px)",
+        borderTop: `1px solid ${N.border}`,
+        background: N.bg2,
+        fontFamily: N.ui,
+        fontSize: 12.5,
+        color: N.muted,
+      }}
+    >
+      <span style={{ fontWeight: 600, color: N.fg }}>Repeat</span>
+      <select
+        aria-label="From āyah"
+        value={fromVal}
+        onChange={(e) => setRangeFrom(e.target.value)}
+        style={selStyle}
+      >
+        {list.map((v) => (
+          <option key={keyOf(v)} value={keyOf(v)}>
+            {ayahLabel(v)}
+          </option>
+        ))}
+      </select>
+      <span aria-hidden>→</span>
+      <select
+        aria-label="To āyah"
+        value={toVal}
+        onChange={(e) => setRangeTo(e.target.value)}
+        style={selStyle}
+      >
+        {list.map((v) => (
+          <option key={keyOf(v)} value={keyOf(v)}>
+            {ayahLabel(v)}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="Repeat count"
+        value={String(repeatCount)}
+        onChange={(e) => setRepeatCount(Number(e.target.value))}
+        style={selStyle}
+      >
+        {REPEAT_COUNTS.map((c) => (
+          <option key={c.label} value={String(c.value)}>
+            {c.label}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={() => playRange(fromVal, toVal, repeatCount)}
+        style={{
+          background: N.goldGrad,
+          color: N.ink,
+          border: "none",
+          borderRadius: 8,
+          cursor: "pointer",
+          fontFamily: N.ui,
+          fontWeight: 600,
+          fontSize: 12.5,
+          padding: "6px 12px",
+        }}
+      >
+        ▶ Loop range
+      </button>
+    </div>
+  ) : null;
+
   if (variant === "dock") {
-    const list = versesRef.current;
     const pos = current ? list.findIndex((v) => keyOf(v) === current) : -1;
     const pct = pos >= 0 && list.length > 0 ? ((pos + 1) / list.length) * 100 : 0;
     const currentAya = current ? parseKey(current).aya : null;
-    const reciterName = reciters.find((r) => r.id === reciterId)?.name ?? reciters[0]?.name ?? "Reciter";
+    const reciterName =
+      reciters.find((r) => r.id === reciterId)?.name ?? reciters[0]?.name ?? "Reciter";
     return (
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 16,
-          padding: "10px clamp(14px, 4vw, 40px)",
-          borderTop: `1px solid ${N.border}`,
-          background: N.bg2,
-          flexShrink: 0,
-        }}
-      >
-        <button
-          type="button"
-          onClick={toggle}
-          aria-pressed={isPlaying}
-          aria-label={isPlaying ? "Pause" : "Play"}
+      <div style={{ display: "flex", flexDirection: "column", flexShrink: 0 }}>
+        {rangePanel}
+        <div
           style={{
-            width: 44,
-            height: 44,
-            borderRadius: 22,
-            background: N.goldGrad,
-            color: N.ink,
-            display: "grid",
-            placeItems: "center",
-            border: "none",
-            cursor: "pointer",
-            flexShrink: 0,
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            padding: "10px clamp(14px, 4vw, 40px)",
+            borderTop: `1px solid ${N.border}`,
+            background: N.bg2,
           }}
         >
-          <Icon name={isPlaying ? "pause" : "play"} size={18} color={N.ink} />
-        </button>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
+          <button
+            type="button"
+            onClick={toggle}
+            aria-pressed={isPlaying}
+            aria-label={isPlaying ? "Pause" : "Play"}
             style={{
-              display: "flex",
-              justifyContent: "space-between",
-              fontSize: 12.5,
-              color: N.muted,
-              marginBottom: 6,
-              fontFamily: N.ui,
+              width: 44,
+              height: 44,
+              borderRadius: 22,
+              background: N.goldGrad,
+              color: N.ink,
+              display: "grid",
+              placeItems: "center",
+              border: "none",
+              cursor: "pointer",
+              flexShrink: 0,
             }}
           >
-            <span
+            <Icon name={isPlaying ? "pause" : "play"} size={18} color={N.ink} />
+          </button>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
               style={{
-                fontWeight: 600,
-                color: N.fg,
-                whiteSpace: "nowrap",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: 12.5,
+                color: N.muted,
+                marginBottom: 6,
+                fontFamily: N.ui,
               }}
             >
-              {reciterName}
-              {currentAya ? ` · Āyah ${currentAya}` : ""}
-            </span>
-            <span className="noor-hide-sm" style={{ flexShrink: 0, marginLeft: 10 }}>
-              {isPlaying ? "Now playing" : current ? "Paused" : "Tap ▶ on an āyah"}
-            </span>
+              <span
+                style={{
+                  fontWeight: 600,
+                  color: N.fg,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {reciterName}
+                {currentAya ? ` · Āyah ${currentAya}` : ""}
+              </span>
+              <span className="noor-hide-sm" style={{ flexShrink: 0, marginLeft: 10 }}>
+                {isPlaying ? "Now playing" : current ? "Paused" : "Tap ▶ on an āyah"}
+              </span>
+            </div>
+            <div style={{ height: 4, borderRadius: 2, background: N.border }}>
+              <div
+                style={{
+                  width: `${pct}%`,
+                  height: "100%",
+                  borderRadius: 2,
+                  background: N.gold,
+                  transition: "width .3s",
+                }}
+              />
+            </div>
           </div>
-          <div style={{ height: 4, borderRadius: 2, background: N.border }}>
-            <div
-              style={{ width: `${pct}%`, height: "100%", borderRadius: 2, background: N.gold, transition: "width .3s" }}
-            />
-          </div>
+          {speedButton}
+          {rangeButton}
+          <button
+            type="button"
+            onClick={toggleLoop}
+            aria-pressed={loop}
+            title="Repeat the surah continuously"
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              color: loop ? N.gold : N.muted,
+              display: "grid",
+              placeItems: "center",
+              flexShrink: 0,
+              padding: 4,
+            }}
+          >
+            <Icon name="repeat" size={18} />
+          </button>
+          {reciters.length > 1 && (
+            <select
+              className="noor-hide-sm"
+              value={reciterId}
+              onChange={(e) => {
+                setReciterId(e.target.value);
+                void writeReciter(e.target.value);
+                stop();
+              }}
+              style={{
+                flexShrink: 0,
+                background: N.card,
+                color: N.muted,
+                border: `1px solid ${N.border}`,
+                borderRadius: 9,
+                padding: "7px 10px",
+                fontFamily: N.ui,
+                fontSize: 13,
+                maxWidth: 160,
+              }}
+            >
+              {reciters.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name}
+                </option>
+              ))}
+            </select>
+          )}
         </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <div className="audio-bar">
+        <button type="button" className="audio-play" onClick={toggle} aria-pressed={isPlaying}>
+          {isPlaying ? "❚❚ Pause" : "▶ Play"}
+        </button>
         <button
           type="button"
+          className={loop ? "chip chip--on" : "chip"}
           onClick={toggleLoop}
           aria-pressed={loop}
           title="Repeat the surah continuously"
-          style={{
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            color: loop ? N.gold : N.muted,
-            display: "grid",
-            placeItems: "center",
-            flexShrink: 0,
-            padding: 4,
-          }}
         >
-          <Icon name="repeat" size={18} />
+          🔁 Loop
         </button>
+        {speedButton}
+        {rangeButton}
+        <span className="audio-status">
+          {current ? `Playing ${current}` : "Tap ▶ to play one āyah, or its number to play on"}
+        </span>
         {reciters.length > 1 && (
           <select
-            className="noor-hide-sm"
+            className="audio-reciter"
             value={reciterId}
             onChange={(e) => {
               setReciterId(e.target.value);
               void writeReciter(e.target.value);
               stop();
-            }}
-            style={{
-              flexShrink: 0,
-              background: N.card,
-              color: N.muted,
-              border: `1px solid ${N.border}`,
-              borderRadius: 9,
-              padding: "7px 10px",
-              fontFamily: N.ui,
-              fontSize: 13,
-              maxWidth: 160,
             }}
           >
             {reciters.map((r) => (
@@ -352,43 +595,7 @@ export function ReadingAudio({
           </select>
         )}
       </div>
-    );
-  }
-
-  return (
-    <div className="audio-bar">
-      <button type="button" className="audio-play" onClick={toggle} aria-pressed={isPlaying}>
-        {isPlaying ? "❚❚ Pause" : "▶ Play"}
-      </button>
-      <button
-        type="button"
-        className={loop ? "chip chip--on" : "chip"}
-        onClick={toggleLoop}
-        aria-pressed={loop}
-        title="Repeat the surah continuously"
-      >
-        🔁 Loop
-      </button>
-      <span className="audio-status">
-        {current ? `Playing ${current}` : "Tap ▶ to play one āyah, or its number to play on"}
-      </span>
-      {reciters.length > 1 && (
-        <select
-          className="audio-reciter"
-          value={reciterId}
-          onChange={(e) => {
-            setReciterId(e.target.value);
-            void writeReciter(e.target.value);
-            stop();
-          }}
-        >
-          {reciters.map((r) => (
-            <option key={r.id} value={r.id}>
-              {r.name}
-            </option>
-          ))}
-        </select>
-      )}
+      {rangePanel}
     </div>
   );
 }

--- a/apps/web/src/lib/reader-prefs-store.ts
+++ b/apps/web/src/lib/reader-prefs-store.ts
@@ -6,9 +6,11 @@
  * helpers instead of touching `localStorage` / `sessionStorage` directly. This
  * `*-store` file is the sanctioned raw-storage home.
  */
+import { clampPlaybackRate } from "@ummahlibrary/core";
 
 const LAST_READ_KEY = "ul.lastRead";
 const LOOP_KEY = "ul.loop";
+const RATE_KEY = "ul.audioRate";
 // Mirrors the event key exported by components/WordByWord.
 const WBW_KEY = "ul.wbw";
 
@@ -20,7 +22,8 @@ export function readLastRead(): number | null {
     // Read during render/scroll-restore: a corrupt/peer-synced null would crash on
     // `.surah`; a non-number surah must not flow through as a bogus value.
     const v = JSON.parse(raw) as unknown;
-    const surah = v !== null && typeof v === "object" ? (v as { surah?: unknown }).surah : undefined;
+    const surah =
+      v !== null && typeof v === "object" ? (v as { surah?: unknown }).surah : undefined;
     return typeof surah === "number" ? surah : null;
   } catch {
     return null;
@@ -62,6 +65,24 @@ export function readLoop(): boolean {
 export function writeLoop(on: boolean): void {
   try {
     localStorage.setItem(LOOP_KEY, on ? "1" : "0");
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+/** The remembered playback speed (clamped); defaults to `1` (normal). */
+export function readRate(): number {
+  try {
+    const raw = Number(localStorage.getItem(RATE_KEY));
+    return clampPlaybackRate(raw || 1);
+  } catch {
+    return 1;
+  }
+}
+
+export function writeRate(rate: number): void {
+  try {
+    localStorage.setItem(RATE_KEY, String(clampPlaybackRate(rate)));
   } catch {
     /* storage unavailable */
   }

--- a/packages/core/src/audio.test.ts
+++ b/packages/core/src/audio.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { PLAYBACK_SPEEDS, clampPlaybackRate, cyclePlaybackRate, repeatRange } from "./audio";
+
+describe("clampPlaybackRate", () => {
+  it("passes through an in-band rate", () => {
+    expect(clampPlaybackRate(1.25)).toBe(1.25);
+  });
+  it("clamps to the [0.5, 2] band", () => {
+    expect(clampPlaybackRate(0.1)).toBe(0.5);
+    expect(clampPlaybackRate(5)).toBe(2);
+  });
+  it("falls back to 1 for a non-finite rate", () => {
+    expect(clampPlaybackRate(Number.NaN)).toBe(1);
+    expect(clampPlaybackRate(Number.POSITIVE_INFINITY)).toBe(1);
+  });
+});
+
+describe("cyclePlaybackRate", () => {
+  it("advances through every step and wraps to the start", () => {
+    let rate: number = PLAYBACK_SPEEDS[0]!;
+    const seen: number[] = [rate];
+    for (let i = 0; i < PLAYBACK_SPEEDS.length; i++) {
+      rate = cyclePlaybackRate(rate);
+      seen.push(rate);
+    }
+    expect(seen.slice(0, PLAYBACK_SPEEDS.length)).toEqual([...PLAYBACK_SPEEDS]);
+    expect(rate).toBe(PLAYBACK_SPEEDS[0]); // wrapped back to the first
+  });
+  it("jumps to the first step from an off-grid rate", () => {
+    expect(cyclePlaybackRate(1.1)).toBe(PLAYBACK_SPEEDS[0]);
+  });
+});
+
+describe("repeatRange", () => {
+  const verses = [
+    { sura: 2, aya: 1 },
+    { sura: 2, aya: 2 },
+    { sura: 2, aya: 3 },
+    { sura: 2, aya: 4 },
+  ];
+  it("returns the inclusive A→B slice", () => {
+    expect(repeatRange(verses, "2:2", "2:3")).toEqual([
+      { sura: 2, aya: 2 },
+      { sura: 2, aya: 3 },
+    ]);
+  });
+  it("normalizes a reversed selection", () => {
+    expect(repeatRange(verses, "2:3", "2:2")).toEqual([
+      { sura: 2, aya: 2 },
+      { sura: 2, aya: 3 },
+    ]);
+  });
+  it("returns the whole list when a bound is missing or absent", () => {
+    expect(repeatRange(verses, null, "2:3")).toHaveLength(4);
+    expect(repeatRange(verses, "2:1", undefined)).toHaveLength(4);
+    expect(repeatRange(verses, "2:1", "9:9")).toHaveLength(4);
+  });
+  it("a single-ayah range is just that ayah", () => {
+    expect(repeatRange(verses, "2:3", "2:3")).toEqual([{ sura: 2, aya: 3 }]);
+  });
+});

--- a/packages/core/src/audio.ts
+++ b/packages/core/src/audio.ts
@@ -1,0 +1,40 @@
+/**
+ * Audio playback helpers (#136) — pure and shared by the web and mobile reciters,
+ * so playback-speed steps and A→B range selection behave identically on both. No
+ * I/O, no platform APIs.
+ */
+
+/** Selectable playback speeds, slowest→fastest (`1` is normal). */
+export const PLAYBACK_SPEEDS = [0.75, 1, 1.25, 1.5, 2] as const;
+
+/** Clamp any rate into the supported `[0.5, 2]` band; a non-finite value → `1`. */
+export function clampPlaybackRate(rate: number): number {
+  if (!Number.isFinite(rate)) return 1;
+  return Math.min(2, Math.max(0.5, rate));
+}
+
+/** The next speed in {@link PLAYBACK_SPEEDS}, wrapping around — for a tap-to-cycle control. */
+export function cyclePlaybackRate(rate: number): number {
+  const i = PLAYBACK_SPEEDS.indexOf(rate as (typeof PLAYBACK_SPEEDS)[number]);
+  // From an off-grid value start at the first step; otherwise advance and wrap.
+  return PLAYBACK_SPEEDS[i < 0 ? 0 : (i + 1) % PLAYBACK_SPEEDS.length]!;
+}
+
+/**
+ * The inclusive A→B slice of an ordered verse list, for range repeat. The order is
+ * normalized (a reversed A/B selection is swapped). If either bound is missing or
+ * not present in the list, the whole list is returned — i.e. repeat-all.
+ */
+export function repeatRange<T extends { sura: number; aya: number }>(
+  verses: readonly T[],
+  from: string | null | undefined,
+  to: string | null | undefined,
+): T[] {
+  if (!from || !to) return [...verses];
+  const keyOf = (v: T): string => `${v.sura}:${v.aya}`;
+  let a = verses.findIndex((v) => keyOf(v) === from);
+  let b = verses.findIndex((v) => keyOf(v) === to);
+  if (a < 0 || b < 0) return [...verses];
+  if (a > b) [a, b] = [b, a];
+  return verses.slice(a, b + 1);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,5 +35,6 @@ export * from "./sync";
 export * from "./sync-engine";
 export * from "./collections";
 export * from "./tasbih";
+export * from "./audio";
 export type * from "./entities";
 export type * from "./ports";


### PR DESCRIPTION
## Audio playback speed + A–B range repeat (#136)

Two recitation controls aimed at study and memorization — on **web and mobile**, off `main` (independent of the sync stack).

### Playback speed
A tap-to-cycle chip: **0.75× / 1× / 1.25× / 1.5× / 2×**, **pitch-corrected** on mobile so the reciter's voice keeps its tone. Persisted (`ul.audioRate`), applied live and on every āyah.

### A–B range repeat
Pick a **From** and **To** āyah + a **repeat count** (∞ / 2 / 3 / 5 / 10) and loop just that range — reusing each player's existing queue/loop engine, so word-highlighting, the stall watchdog, and the mobile lock-screen controls all keep working.

### Shape
- **`packages/core/src/audio.ts`** (pure, **9 unit tests**): `PLAYBACK_SPEEDS`, `clampPlaybackRate`, `cyclePlaybackRate`, and `repeatRange` (order-normalized inclusive A→B slice; whole list when a bound is missing).
- **Web** — `ReadingAudio.tsx` (both the dock + inline variants): rate on the `HTMLAudioElement`; A→B via an `activeListRef` + a `repeatRef` countdown threaded through the `onended` advance. Rate persistence in `reader-prefs-store`.
- **Mobile** — `useSurahAudio` generalized to a repeat-aware `startSession` (**the delicate per-āyah engine is untouched** — `playFrom` is now a thin wrapper), plus a shared **`AudioRangeControls`** component wired into the surah + juzʾ readers.

### Review
A 5-agent adversarial review found and I fixed one real race: `play()` now **detaches the previous āyah's `onended`/`ontimeupdate` and pauses the element before the `fetchTiming` await**, so a stale handler firing mid-await can't advance the wrong āyah or skew a just-started range's repeat count. (Two other findings were refuted — the mobile range state is always clamp-validated.)

### Verification
`pnpm lint && typecheck && test && build` all green.

Closes #136.
