### PR TITLE
feat(reader): memorization hide & peek mode (#134)

### DIFF
--- a/apps/mobile/src/components/AyahView.tsx
+++ b/apps/mobile/src/components/AyahView.tsx
@@ -28,6 +28,17 @@ interface Props {
   scale: number;
   onPlayFrom: (aya: number) => void;
   onPlayOne: (aya: number) => void;
+  /** Memorize / hide-and-peek (#134). */
+  peek?: boolean;
+  /** Global word index of this āyah's first word, for the shared reveal cursor. */
+  peekStart?: number;
+  /** How many words (globally, in reading order) are revealed. */
+  peekRevealed?: number;
+  /** Global indices of words revealed ad-hoc by tapping. */
+  peekExtra?: ReadonlySet<number>;
+  /** Also conceal the translation while memorizing. */
+  peekHideTr?: boolean;
+  onPeekWord?: (globalIndex: number) => void;
 }
 
 /**
@@ -47,6 +58,12 @@ function AyahViewImpl({
   scale,
   onPlayFrom,
   onPlayOne,
+  peek = false,
+  peekStart = 0,
+  peekRevealed = 0,
+  peekExtra,
+  peekHideTr = false,
+  onPeekWord,
 }: Props) {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
@@ -86,22 +103,39 @@ function AyahViewImpl({
 
       <Text
         style={[styles.arabic, { fontSize: 26 * scale, lineHeight: 50 * scale }]}
-        onPress={() => onPlayFrom(aya)}
+        onPress={peek ? undefined : () => onPlayFrom(aya)}
       >
-        {/* Only the playing āyah splits into per-word spans (for highlighting);
-            every other āyah renders as a single text node, which keeps long
-            surahs cheap to scroll. */}
-        {playing
-          ? words.map((w, i) => (
-              <Text key={i} style={i === activeWord ? styles.wordActive : undefined}>
-                {w}
-                {i < words.length - 1 ? " " : ""}
-              </Text>
-            ))
-          : arabic}
+        {/* In peek mode every word is a tappable span — concealed until the
+            reveal cursor reaches it or it's tapped. Otherwise only the playing
+            āyah splits into per-word spans (for highlighting); every other āyah
+            renders as a single text node, which keeps long surahs cheap to scroll. */}
+        {peek
+          ? words.map((w, i) => {
+              const gi = peekStart + i;
+              const shown = gi < peekRevealed || peekExtra?.has(gi);
+              return (
+                <Text
+                  key={i}
+                  onPress={() => onPeekWord?.(gi)}
+                  style={shown ? undefined : styles.wordHidden}
+                >
+                  {w}
+                  {i < words.length - 1 ? " " : ""}
+                </Text>
+              );
+            })
+          : playing
+            ? words.map((w, i) => (
+                <Text key={i} style={i === activeWord ? styles.wordActive : undefined}>
+                  {w}
+                  {i < words.length - 1 ? " " : ""}
+                </Text>
+              ))
+            : arabic}
       </Text>
 
-      {translations.map((t) => (
+      {!peekHideTr &&
+        translations.map((t) => (
         <View key={t.id} style={styles.tr}>
           {translations.length > 1 && <Text style={styles.trName}>{t.name}</Text>}
           <Text
@@ -143,6 +177,8 @@ function makeStyles(c: Palette) {
     actions: { flexDirection: "row", alignItems: "center", gap: 20 },
     arabic: { color: c.fg, textAlign: "right", writingDirection: "rtl", fontFamily: FONT.ar },
     wordActive: { color: c.accent },
+    // Concealed word: keep its footprint (a hint of length) but hide the glyphs.
+    wordHidden: { color: "transparent", backgroundColor: c.borderSoft },
     tr: { marginTop: 12 },
     trName: { color: c.faint, fontSize: 12, marginBottom: 3, fontFamily: FONT.medium },
     trText: { color: c.muted },

--- a/apps/mobile/src/components/MemorizeBar.tsx
+++ b/apps/mobile/src/components/MemorizeBar.tsx
@@ -4,8 +4,8 @@ import { Icon } from "@ummahlibrary/ui";
 import { useTheme, type Palette } from "../theme";
 
 /**
- * Memorize / hide-and-peek controls (#134) for the mobile readers. Collapsed it
- * is a single "Memorize" pill; expanded it reveals the recitation testing
+ * Recite — hide & peek controls (#134) for the mobile readers. Collapsed it
+ * is a single "Recite" pill; expanded it reveals the recitation testing
  * controls. State lives in the screen — this is the presentation only, so the
  * surah and juzʾ readers share one bar.
  */
@@ -33,9 +33,9 @@ export function MemorizeBar({
 
   if (!on) {
     return (
-      <Pressable style={styles.pill} onPress={onToggle} accessibilityLabel="Memorize mode">
+      <Pressable style={styles.pill} onPress={onToggle} accessibilityLabel="Recite mode">
         <Icon name="eye" size={15} color={colors.accent} />
-        <Text style={styles.pillText}>Memorize</Text>
+        <Text style={styles.pillText}>Recite</Text>
       </Pressable>
     );
   }
@@ -46,10 +46,10 @@ export function MemorizeBar({
         <Pressable
           style={[styles.pill, styles.pillOn]}
           onPress={onToggle}
-          accessibilityLabel="Exit memorize mode"
+          accessibilityLabel="Exit recite mode"
         >
           <Icon name="eye" size={15} color={colors.ink} />
-          <Text style={[styles.pillText, styles.pillTextOn]}>Memorize</Text>
+          <Text style={[styles.pillText, styles.pillTextOn]}>Recite</Text>
         </Pressable>
         <Pressable
           style={[styles.ctl, hideTr && styles.ctlOn]}

--- a/apps/mobile/src/components/MemorizeBar.tsx
+++ b/apps/mobile/src/components/MemorizeBar.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "../Type";
+import { Icon } from "@ummahlibrary/ui";
+import { useTheme, type Palette } from "../theme";
+
+/**
+ * Memorize / hide-and-peek controls (#134) for the mobile readers. Collapsed it
+ * is a single "Memorize" pill; expanded it reveals the recitation testing
+ * controls. State lives in the screen — this is the presentation only, so the
+ * surah and juzʾ readers share one bar.
+ */
+export function MemorizeBar({
+  on,
+  hideTr,
+  onToggle,
+  onPeekWord,
+  onRevealAyah,
+  onShowAll,
+  onHideAll,
+  onToggleTr,
+}: {
+  on: boolean;
+  hideTr: boolean;
+  onToggle: () => void;
+  onPeekWord: () => void;
+  onRevealAyah: () => void;
+  onShowAll: () => void;
+  onHideAll: () => void;
+  onToggleTr: () => void;
+}) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+
+  if (!on) {
+    return (
+      <Pressable style={styles.pill} onPress={onToggle} accessibilityLabel="Memorize mode">
+        <Icon name="eye" size={15} color={colors.accent} />
+        <Text style={styles.pillText}>Memorize</Text>
+      </Pressable>
+    );
+  }
+
+  return (
+    <View style={styles.tray}>
+      <View style={styles.row}>
+        <Pressable
+          style={[styles.pill, styles.pillOn]}
+          onPress={onToggle}
+          accessibilityLabel="Exit memorize mode"
+        >
+          <Icon name="eye" size={15} color={colors.ink} />
+          <Text style={[styles.pillText, styles.pillTextOn]}>Memorize</Text>
+        </Pressable>
+        <Pressable
+          style={[styles.ctl, hideTr && styles.ctlOn]}
+          onPress={onToggleTr}
+          accessibilityLabel="Hide translation"
+        >
+          <Text style={[styles.ctlText, hideTr && styles.ctlTextOn]}>Translation</Text>
+        </Pressable>
+      </View>
+      <View style={styles.row}>
+        <Ctl styles={styles} label="Peek word" onPress={onPeekWord} />
+        <Ctl styles={styles} label="Reveal āyah" onPress={onRevealAyah} />
+        <Ctl styles={styles} label="Show all" onPress={onShowAll} />
+        <Ctl styles={styles} label="Hide all" onPress={onHideAll} />
+      </View>
+    </View>
+  );
+}
+
+function Ctl({
+  styles,
+  label,
+  onPress,
+}: {
+  styles: ReturnType<typeof makeStyles>;
+  label: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable style={styles.ctl} onPress={onPress}>
+      <Text style={styles.ctlText}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function makeStyles(c: Palette) {
+  return StyleSheet.create({
+    pill: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 7,
+      alignSelf: "flex-start",
+      paddingVertical: 8,
+      paddingHorizontal: 14,
+      borderRadius: 18,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bgElev,
+    },
+    pillOn: { borderColor: c.accent, backgroundColor: c.accent },
+    pillText: { color: c.accent, fontSize: 13.5, fontWeight: "700" },
+    pillTextOn: { color: c.ink },
+    tray: {
+      gap: 8,
+      padding: 10,
+      borderRadius: 14,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bgElev,
+    },
+    row: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", gap: 8 },
+    ctl: {
+      paddingVertical: 7,
+      paddingHorizontal: 12,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bg,
+    },
+    ctlOn: { borderColor: c.accent, backgroundColor: c.accentSoft },
+    ctlText: { color: c.fg, fontSize: 13, fontWeight: "600" },
+    ctlTextOn: { color: c.accent },
+  });
+}

--- a/apps/mobile/src/screens/JuzReaderScreen.tsx
+++ b/apps/mobile/src/screens/JuzReaderScreen.tsx
@@ -1,7 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from "../Type";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { JUZ_STARTS, TOTAL_JUZ, resolveActiveTranslation, type VerseKey } from "@ummahlibrary/core";
+import {
+  JUZ_STARTS,
+  TOTAL_JUZ,
+  resolveActiveTranslation,
+  revealAyah,
+  revealWord,
+  totalWords,
+  type VerseKey,
+} from "@ummahlibrary/core";
 import { api } from "../api";
 import { RECITER, RECITERS } from "../plugins";
 import { useTheme, type Palette } from "../theme";
@@ -9,6 +17,7 @@ import { FONT } from "../fonts";
 import { useSettings } from "../state/SettingsContext";
 import { useSurahAudio, verseKeyOf } from "../audio/useSurahAudio";
 import { AudioRangeControls } from "../components/AudioRangeControls";
+import { MemorizeBar } from "../components/MemorizeBar";
 import { DEFAULT_EDITION } from "../types";
 import type { ReadStackParamList } from "../navigation/types";
 
@@ -49,6 +58,12 @@ export function JuzReaderScreen({ route }: Props) {
   const edition = resolveActiveTranslation(editions, readingTranslation, DEFAULT_EDITION);
   const [lines, setLines] = useState<Line[] | null>(null);
   const [error, setError] = useState(false);
+
+  // Memorize / hide-and-peek (#134) — ephemeral, so a juzʾ never opens hidden.
+  const [peek, setPeek] = useState(false);
+  const [revealed, setRevealed] = useState(0);
+  const [peekExtra, setPeekExtra] = useState<Set<number>>(new Set());
+  const [hideTr, setHideTr] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -96,6 +111,32 @@ export function JuzReaderScreen({ route }: Props) {
 
   const verses = useMemo(() => (lines ?? []).map((l) => ({ sura: l.sura, aya: l.aya })), [lines]);
 
+  // Peek geometry: per-āyah words and the global index each āyah starts at, so the
+  // shared reveal cursor maps onto every word in reading order.
+  const peekWords = useMemo(() => (lines ?? []).map((l) => l.arabic.split(" ")), [lines]);
+  const wordsPerAyah = useMemo(() => peekWords.map((w) => w.length), [peekWords]);
+  const peekStarts = useMemo(() => {
+    const starts: number[] = [];
+    let acc = 0;
+    for (const c of wordsPerAyah) {
+      starts.push(acc);
+      acc += c;
+    }
+    return starts;
+  }, [wordsPerAyah]);
+  const peekTotal = useMemo(() => totalWords(wordsPerAyah), [wordsPerAyah]);
+
+  const onPeekWord = useCallback((gi: number) => setPeekExtra((p) => new Set(p).add(gi)), []);
+  const togglePeek = useCallback(() => {
+    setPeek((p) => {
+      const next = !p;
+      setRevealed(0);
+      setPeekExtra(new Set());
+      if (!next) setHideTr(false);
+      return next;
+    });
+  }, []);
+
   if (error) {
     return (
       <View style={styles.center}>
@@ -137,8 +178,26 @@ export function JuzReaderScreen({ route }: Props) {
       <View style={styles.audioExtras}>
         <AudioRangeControls audio={audio} verses={verses} />
       </View>
+      <View style={styles.memorize}>
+        <MemorizeBar
+          on={peek}
+          hideTr={hideTr}
+          onToggle={togglePeek}
+          onPeekWord={() => setRevealed((r) => revealWord(r, peekTotal))}
+          onRevealAyah={() => setRevealed((r) => revealAyah(r, wordsPerAyah))}
+          onShowAll={() => {
+            setRevealed(peekTotal);
+            setPeekExtra(new Set());
+          }}
+          onHideAll={() => {
+            setRevealed(0);
+            setPeekExtra(new Set());
+          }}
+          onToggleTr={() => setHideTr((v) => !v)}
+        />
+      </View>
 
-      {lines.map((l) => {
+      {lines.map((l, i) => {
         const key = verseKeyOf(l);
         const playing = audio.playingKey === key;
         return (
@@ -146,12 +205,28 @@ export function JuzReaderScreen({ route }: Props) {
             {l.surahHeader && <Text style={styles.surahHeader}>{l.surahHeader}</Text>}
             <Pressable
               style={[styles.ayah, playing && styles.ayahPlaying]}
-              onPress={() => audio.playFrom(verses, l, true)}
+              onPress={peek ? undefined : () => audio.playFrom(verses, l, true)}
             >
               <Text style={[styles.arabic, { fontSize: 24 * scale, lineHeight: 44 * scale }]}>
-                {l.arabic} <Text style={styles.marker}>﴿{l.aya}﴾</Text>
+                {peek
+                  ? peekWords[i].map((w, wi) => {
+                      const gi = peekStarts[i]! + wi;
+                      const shown = gi < revealed || peekExtra.has(gi);
+                      return (
+                        <Text
+                          key={wi}
+                          onPress={() => onPeekWord(gi)}
+                          style={shown ? undefined : styles.wordHidden}
+                        >
+                          {w}
+                          {wi < peekWords[i]!.length - 1 ? " " : ""}
+                        </Text>
+                      );
+                    })
+                  : l.arabic}{" "}
+                <Text style={styles.marker}>﴿{l.aya}﴾</Text>
               </Text>
-              {l.translation ? (
+              {l.translation && !hideTr ? (
                 <Text style={[styles.tr, { fontSize: 15 * scale, lineHeight: 23 * scale }]}>
                   {l.translation}
                 </Text>
@@ -172,6 +247,7 @@ function makeStyles(c: Palette) {
     content: { paddingHorizontal: 18, paddingBottom: 40 },
     audioBar: { flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 12 },
     audioExtras: { marginBottom: 12 },
+    memorize: { marginBottom: 14 },
     audioPlay: {
       paddingVertical: 8,
       paddingHorizontal: 18,
@@ -210,6 +286,7 @@ function makeStyles(c: Palette) {
     },
     ayahPlaying: { backgroundColor: c.bgElev, borderBottomColor: "transparent" },
     arabic: { color: c.fg, textAlign: "right", writingDirection: "rtl", fontFamily: FONT.ar },
+    wordHidden: { color: "transparent", backgroundColor: c.borderSoft },
     marker: { color: c.accent, fontSize: 17, fontFamily: FONT.ar },
     tr: { color: c.fg, marginTop: 10 },
   });

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -14,6 +14,9 @@ import {
   TOTAL_SURAHS,
   pageNumberOf,
   resolveActiveTranslation,
+  revealAyah,
+  revealWord,
+  totalWords,
   type Ayah,
   type Surah,
   type Translation,
@@ -30,6 +33,7 @@ import { useSurahAudio, verseKeyOf } from "../audio/useSurahAudio";
 import { DEFAULT_EDITION } from "../types";
 import { ReaderControls } from "../components/ReaderControls";
 import { AudioRangeControls } from "../components/AudioRangeControls";
+import { MemorizeBar } from "../components/MemorizeBar";
 import { ReadingTranslationPicker } from "../components/ReadingTranslationPicker";
 import { TranslationManager } from "../components/TranslationManager";
 import { AyahView, type TrLine } from "../components/AyahView";
@@ -68,6 +72,12 @@ export function SurahReaderScreen({ navigation, route }: Props) {
   const [trMap, setTrMap] = useState<Map<string, Map<number, string>>>(new Map());
   const [error, setError] = useState(false);
   const [managerOpen, setManagerOpen] = useState(false);
+
+  // Memorize / hide-and-peek (#134) — ephemeral, so a surah never opens hidden.
+  const [peek, setPeek] = useState(false);
+  const [revealed, setRevealed] = useState(0);
+  const [peekExtra, setPeekExtra] = useState<Set<number>>(new Set());
+  const [hideTr, setHideTr] = useState(false);
 
   // Track the topmost visible āyah so "open in Mushaf" lands on the right page.
   // Per-āyah offsets are only known in translation mode (discrete rows); the
@@ -203,6 +213,33 @@ export function SurahReaderScreen({ navigation, route }: Props) {
     [ayahs, editions, trMap, metaById, n],
   );
 
+  // Peek geometry: each āyah's word count and the global index of its first word,
+  // so AyahView can map the shared reveal cursor onto its own words.
+  const wordsPerAyah = useMemo(() => rows.map((r) => r.words.length), [rows]);
+  const peekStarts = useMemo(() => {
+    const starts: number[] = [];
+    let acc = 0;
+    for (const c of wordsPerAyah) {
+      starts.push(acc);
+      acc += c;
+    }
+    return starts;
+  }, [wordsPerAyah]);
+  const peekTotal = useMemo(() => totalWords(wordsPerAyah), [wordsPerAyah]);
+
+  const onPeekWord = useCallback((gi: number) => setPeekExtra((p) => new Set(p).add(gi)), []);
+  const togglePeek = useCallback(() => {
+    setPeek((p) => {
+      const next = !p;
+      setRevealed(0);
+      setPeekExtra(new Set());
+      // Peek needs the per-word verse layout; switch to it on enter.
+      if (next) setReadingMode("translation");
+      else setHideTr(false);
+      return next;
+    });
+  }, [setReadingMode]);
+
   // Stable so the memoized AyahView only re-renders the playing āyah as the
   // recitation moves word to word — an inline arrow would change identity every
   // render and defeat the memo, re-rendering the whole surah on each word.
@@ -217,7 +254,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
   );
 
   const renderItem = useCallback(
-    ({ item }: { item: (typeof rows)[number] }) => (
+    ({ item, index }: { item: (typeof rows)[number]; index: number }) => (
       <AyahView
         sura={n}
         aya={item.aya}
@@ -229,9 +266,28 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         scale={scale}
         onPlayFrom={playFrom}
         onPlayOne={playOne}
+        peek={peek}
+        peekStart={peekStarts[index] ?? 0}
+        peekRevealed={revealed}
+        peekExtra={peekExtra}
+        peekHideTr={hideTr}
+        onPeekWord={onPeekWord}
       />
     ),
-    [n, playingKey, activeWord, scale, playFrom, playOne],
+    [
+      n,
+      playingKey,
+      activeWord,
+      scale,
+      playFrom,
+      playOne,
+      peek,
+      peekStarts,
+      revealed,
+      peekExtra,
+      hideTr,
+      onPeekWord,
+    ],
   );
 
   // Track the topmost visible āyah for "open in Mushaf" and reading-plan
@@ -353,6 +409,24 @@ export function SurahReaderScreen({ navigation, route }: Props) {
       <View style={styles.audioExtras}>
         <AudioRangeControls audio={audio} verses={verses} />
       </View>
+      <View style={styles.memorize}>
+        <MemorizeBar
+          on={peek}
+          hideTr={hideTr}
+          onToggle={togglePeek}
+          onPeekWord={() => setRevealed((r) => revealWord(r, peekTotal))}
+          onRevealAyah={() => setRevealed((r) => revealAyah(r, wordsPerAyah))}
+          onShowAll={() => {
+            setRevealed(peekTotal);
+            setPeekExtra(new Set());
+          }}
+          onHideAll={() => {
+            setRevealed(0);
+            setPeekExtra(new Set());
+          }}
+          onToggleTr={() => setHideTr((v) => !v)}
+        />
+      </View>
     </>
   );
 
@@ -386,7 +460,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
           data={rows}
           keyExtractor={(r) => r.key}
           renderItem={renderItem}
-          extraData={`${playingKey ?? ""}:${activeWord}:${scale}`}
+          extraData={`${playingKey ?? ""}:${activeWord}:${scale}:${peek}:${revealed}:${peekExtra.size}:${hideTr}`}
           contentContainerStyle={styles.content}
           onViewableItemsChanged={onViewable}
           viewabilityConfig={viewabilityConfig}
@@ -569,6 +643,7 @@ function makeStyles(c: Palette) {
       marginBottom: 4,
     },
     audioExtras: { marginBottom: 10 },
+    memorize: { marginBottom: 12 },
     audioPlay: {
       width: 42,
       height: 42,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -603,6 +603,40 @@ html[data-reading-mode="reading-tr"] .mode-reading-tr {
   text-align: right;
 }
 
+/* ---- Memorize: hide & peek (#134) ---- */
+/* Peek operates on the per-word verse layout; force it visible whatever reading
+   mode is selected, so the .ayah-ar .w spans are always present to conceal. */
+body.peek-on .mode-translation {
+  display: block !important;
+}
+body.peek-on .mode-reading,
+body.peek-on .mode-reading-tr {
+  display: none !important;
+}
+/* Conceal each Arabic word; a tap or a reveal control lifts the blur. */
+body.peek-on .ayah-ar .w {
+  filter: blur(7px);
+  cursor: pointer;
+  user-select: none;
+  transition: filter 0.18s ease;
+}
+body.peek-on .ayah-ar .w.w--peek {
+  filter: none;
+  user-select: auto;
+}
+/* Optionally conceal the translations too. */
+body.peek-on.peek-hide-tr .ayah-tr {
+  filter: blur(6px);
+  user-select: none;
+  transition: filter 0.18s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  body.peek-on .ayah-ar .w,
+  body.peek-on.peek-hide-tr .ayah-tr {
+    transition: none;
+  }
+}
+
 /* ---- Prayer times ---- */
 .prayer-cta {
   display: flex;

--- a/apps/web/src/app/juz/[number]/page.tsx
+++ b/apps/web/src/app/juz/[number]/page.tsx
@@ -19,6 +19,7 @@ import { ReadingTranslationFlow } from "../../../components/ReadingTranslationFl
 import { ReaderShortcuts } from "../../../components/ReaderShortcuts";
 import { SITE_URL } from "../../../lib/site";
 import { WordByWord } from "../../../components/WordByWord";
+import { MemorizeBar } from "../../../components/MemorizeBar";
 
 const RECITERS = pluginRegistry.byKind("reciter");
 
@@ -142,6 +143,7 @@ export default async function JuzReaderPage({ params }: { params: Promise<{ numb
       </header>
 
       <ReadingModeToggle />
+      <MemorizeBar />
 
       <div className="mode-translation">
         <EditionManager />

--- a/apps/web/src/components/MemorizeBar.tsx
+++ b/apps/web/src/components/MemorizeBar.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { N, Icon } from "@ummahlibrary/ui";
+import { revealAyah, revealWord, totalWords } from "@ummahlibrary/core";
+
+// The verse-layout Arabic lines, in reading order. Both the surah and juzʾ
+// readers render exactly one `.mode-translation` block of these.
+const AYAH_SEL = ".mode-translation .ayah-ar";
+
+/**
+ * Memorize / hide-and-peek mode (#134): a self-contained floating control that
+ * conceals the Arabic so you can recite from memory, then reveals it — one word,
+ * one āyah, or all at once — or tap any word to peek it.
+ *
+ * It drives the existing reader markup directly (the `peek-on` body class blurs
+ * the per-word `.w` spans via CSS, regardless of the selected reading mode), so
+ * the same component works on both readers with no prop threading. Reveal state
+ * is ephemeral — peek mode always starts off, so the muṣḥaf is never hidden by
+ * surprise on the next visit.
+ */
+export function MemorizeBar() {
+  const [on, setOn] = useState(false);
+  const [revealed, setRevealed] = useState(0); // ordered prefix of revealed words
+  const [extra, setExtra] = useState<Set<number>>(new Set()); // ad-hoc tapped words
+  const [hideTr, setHideTr] = useState(false);
+
+  const ayahEls = useCallback(
+    () => Array.from(document.querySelectorAll<HTMLElement>(AYAH_SEL)),
+    [],
+  );
+  const wordCounts = useCallback(
+    () => ayahEls().map((a) => a.querySelectorAll(".w").length),
+    [ayahEls],
+  );
+
+  // Reflect the reveal cursor onto the DOM word spans.
+  const apply = useCallback(() => {
+    let idx = 0;
+    for (const ayah of ayahEls()) {
+      ayah.querySelectorAll<HTMLElement>(".w").forEach((w) => {
+        w.classList.toggle("w--peek", idx < revealed || extra.has(idx));
+        idx++;
+      });
+    }
+  }, [ayahEls, revealed, extra]);
+
+  useEffect(() => {
+    if (on) apply();
+  }, [on, apply]);
+
+  // Tidy the body classes if the reader unmounts while peek is on.
+  useEffect(
+    () => () => document.body.classList.remove("peek-on", "peek-hide-tr"),
+    [],
+  );
+
+  // While peeking, a tap on a concealed word reveals just that word. Bound on the
+  // capture phase so it pre-empts the word-by-word popover (which listens on
+  // bubble) — but non-word taps (e.g. the ▷ play marker) pass through untouched.
+  useEffect(() => {
+    if (!on) return;
+    function onClick(e: MouseEvent) {
+      const span = (e.target as HTMLElement).closest<HTMLElement>(`${AYAH_SEL} .w`);
+      if (!span) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const i = ayahEls()
+        .flatMap((a) => Array.from(a.querySelectorAll<HTMLElement>(".w")))
+        .indexOf(span);
+      if (i >= 0) setExtra((prev) => new Set(prev).add(i));
+    }
+    document.addEventListener("click", onClick, true);
+    return () => document.removeEventListener("click", onClick, true);
+  }, [on, ayahEls]);
+
+  function toggleOn() {
+    const next = !on;
+    setOn(next);
+    setRevealed(0);
+    setExtra(new Set());
+    document.body.classList.toggle("peek-on", next);
+    if (!next) {
+      setHideTr(false);
+      document.body.classList.remove("peek-hide-tr");
+      document
+        .querySelectorAll(".ayah-ar .w.w--peek")
+        .forEach((w) => w.classList.remove("w--peek"));
+    }
+  }
+
+  function toggleHideTr() {
+    const next = !hideTr;
+    setHideTr(next);
+    document.body.classList.toggle("peek-hide-tr", next);
+  }
+
+  const total = () => totalWords(wordCounts());
+
+  if (!on) {
+    return (
+      <div style={shell}>
+        <button type="button" onClick={toggleOn} style={pill(false)} aria-pressed={false}>
+          <Icon name="eye" size={16} />
+          <span style={{ fontWeight: 700 }}>Memorize</span>
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={shell}>
+      <div style={tray}>
+        <button type="button" onClick={toggleOn} style={pill(true)} aria-pressed={true}>
+          <Icon name="eye" size={16} color={N.ink} />
+          <span style={{ fontWeight: 700 }}>Memorize</span>
+        </button>
+        <div style={divider} aria-hidden="true" />
+        <Ctl onClick={() => setRevealed((r) => revealWord(r, total()))}>Peek word</Ctl>
+        <Ctl onClick={() => setRevealed((r) => revealAyah(r, wordCounts()))}>Reveal āyah</Ctl>
+        <Ctl
+          onClick={() => {
+            setRevealed(total());
+            setExtra(new Set());
+          }}
+        >
+          Show all
+        </Ctl>
+        <Ctl
+          onClick={() => {
+            setRevealed(0);
+            setExtra(new Set());
+          }}
+        >
+          Hide all
+        </Ctl>
+        <button
+          type="button"
+          onClick={toggleHideTr}
+          style={ctl(hideTr)}
+          aria-pressed={hideTr}
+          title="Also hide the translation"
+        >
+          Translation
+        </button>
+        <button type="button" onClick={toggleOn} style={closeBtn} aria-label="Exit memorize mode">
+          <Icon name="close" size={15} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Ctl({ children, onClick }: { children: React.ReactNode; onClick: () => void }) {
+  return (
+    <button type="button" onClick={onClick} style={ctl(false)}>
+      {children}
+    </button>
+  );
+}
+
+const shell: React.CSSProperties = {
+  position: "fixed",
+  right: "clamp(14px, 4vw, 40px)",
+  bottom: 80,
+  zIndex: 30,
+};
+const tray: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  padding: 6,
+  borderRadius: 14,
+  background: N.card,
+  border: `1px solid ${N.border}`,
+  boxShadow: "0 12px 32px rgba(0,0,0,.35)",
+  maxWidth: "calc(100vw - 28px)",
+  flexWrap: "wrap",
+};
+const divider: React.CSSProperties = { width: 1, alignSelf: "stretch", background: N.borderSoft };
+
+function pill(active: boolean): React.CSSProperties {
+  return {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 7,
+    padding: "9px 13px",
+    borderRadius: 11,
+    border: `1px solid ${active ? N.gold : N.border}`,
+    background: active ? N.goldGrad : N.card,
+    color: active ? N.ink : N.fg,
+    fontFamily: N.ui,
+    fontSize: 13.5,
+    cursor: "pointer",
+    boxShadow: active ? undefined : "0 12px 32px rgba(0,0,0,.35)",
+  };
+}
+
+function ctl(active: boolean): React.CSSProperties {
+  return {
+    padding: "8px 11px",
+    borderRadius: 10,
+    border: `1px solid ${active ? N.gold : N.border}`,
+    background: active ? N.goldSoft : N.card,
+    color: active ? N.gold : N.fg,
+    fontFamily: N.ui,
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+  };
+}
+
+const closeBtn: React.CSSProperties = {
+  display: "grid",
+  placeItems: "center",
+  width: 34,
+  height: 34,
+  borderRadius: 10,
+  border: `1px solid ${N.border}`,
+  background: N.card,
+  color: N.muted,
+  cursor: "pointer",
+};

--- a/apps/web/src/components/MemorizeBar.tsx
+++ b/apps/web/src/components/MemorizeBar.tsx
@@ -9,8 +9,8 @@ import { revealAyah, revealWord, totalWords } from "@ummahlibrary/core";
 const AYAH_SEL = ".mode-translation .ayah-ar";
 
 /**
- * Memorize / hide-and-peek mode (#134): a self-contained floating control that
- * conceals the Arabic so you can recite from memory, then reveals it — one word,
+ * Recite — hide & peek (#134): a self-contained floating control that conceals
+ * the Arabic so you can recite from memory, then reveals it — one word,
  * one āyah, or all at once — or tap any word to peek it.
  *
  * It drives the existing reader markup directly (the `peek-on` body class blurs
@@ -102,7 +102,7 @@ export function MemorizeBar() {
       <div style={shell}>
         <button type="button" onClick={toggleOn} style={pill(false)} aria-pressed={false}>
           <Icon name="eye" size={16} />
-          <span style={{ fontWeight: 700 }}>Memorize</span>
+          <span style={{ fontWeight: 700 }}>Recite</span>
         </button>
       </div>
     );
@@ -113,7 +113,7 @@ export function MemorizeBar() {
       <div style={tray}>
         <button type="button" onClick={toggleOn} style={pill(true)} aria-pressed={true}>
           <Icon name="eye" size={16} color={N.ink} />
-          <span style={{ fontWeight: 700 }}>Memorize</span>
+          <span style={{ fontWeight: 700 }}>Recite</span>
         </button>
         <div style={divider} aria-hidden="true" />
         <Ctl onClick={() => setRevealed((r) => revealWord(r, total()))}>Peek word</Ctl>
@@ -143,7 +143,7 @@ export function MemorizeBar() {
         >
           Translation
         </button>
-        <button type="button" onClick={toggleOn} style={closeBtn} aria-label="Exit memorize mode">
+        <button type="button" onClick={toggleOn} style={closeBtn} aria-label="Exit recite mode">
           <Icon name="close" size={15} />
         </button>
       </div>

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -8,6 +8,7 @@ import { AyahTranslations } from "./AyahTranslations";
 import { AyahActions } from "./AyahActions";
 import { AyahStar } from "./AyahStar";
 import { ReadingAudio } from "./ReadingAudio";
+import { MemorizeBar } from "./MemorizeBar";
 import { ReadingTranslationPicker } from "./ReadingTranslationPicker";
 import { ReadingTranslationFlow } from "./ReadingTranslationFlow";
 import { ReaderToolbar } from "./ReaderToolbar";
@@ -510,6 +511,9 @@ export function SurahReaderClient({
           </p>
         </div>
       </div>
+
+      {/* Memorize / hide-and-peek — floats above the dock */}
+      <MemorizeBar />
 
       {/* Audio player — fixed bottom dock, drives playback for all modes */}
       <ReadingAudio

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,5 +36,6 @@ export * from "./sync-engine";
 export * from "./collections";
 export * from "./tasbih";
 export * from "./audio";
+export * from "./peek";
 export type * from "./entities";
 export type * from "./ports";

--- a/packages/core/src/peek.test.ts
+++ b/packages/core/src/peek.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { clampReveal, isWordRevealed, revealAyah, revealWord, totalWords } from "./peek";
+
+describe("totalWords", () => {
+  it("sums the per-āyah word counts", () => {
+    expect(totalWords([3, 4, 2])).toBe(9);
+  });
+  it("is 0 for an empty passage and ignores negative counts", () => {
+    expect(totalWords([])).toBe(0);
+    expect(totalWords([3, -2, 1])).toBe(4);
+  });
+});
+
+describe("clampReveal", () => {
+  it("passes an in-range cursor through", () => {
+    expect(clampReveal(3, 9)).toBe(3);
+  });
+  it("clamps below 0 and above the total", () => {
+    expect(clampReveal(-5, 9)).toBe(0);
+    expect(clampReveal(20, 9)).toBe(9);
+  });
+  it("floors a fractional cursor and resets a non-finite one to 0", () => {
+    expect(clampReveal(2.9, 9)).toBe(2);
+    expect(clampReveal(Number.NaN, 9)).toBe(0);
+  });
+});
+
+describe("revealWord", () => {
+  it("advances one word at a time and stops at the total", () => {
+    expect(revealWord(0, 3)).toBe(1);
+    expect(revealWord(2, 3)).toBe(3);
+    expect(revealWord(3, 3)).toBe(3);
+  });
+});
+
+describe("revealAyah", () => {
+  const words = [3, 4, 2]; // boundaries at 3, 7, 9
+
+  it("reveals through the end of the first āyah from nothing", () => {
+    expect(revealAyah(0, words)).toBe(3);
+  });
+  it("reveals through the current āyah's end when mid-āyah", () => {
+    expect(revealAyah(1, words)).toBe(3);
+    expect(revealAyah(3, words)).toBe(7); // cursor sits on the 2nd āyah's first word
+    expect(revealAyah(5, words)).toBe(7);
+  });
+  it("reveals the last āyah and then is a no-op", () => {
+    expect(revealAyah(7, words)).toBe(9);
+    expect(revealAyah(9, words)).toBe(9);
+  });
+  it("handles an empty passage", () => {
+    expect(revealAyah(0, [])).toBe(0);
+  });
+});
+
+describe("isWordRevealed", () => {
+  it("is true only for indices below the cursor", () => {
+    expect(isWordRevealed(0, 2)).toBe(true);
+    expect(isWordRevealed(1, 2)).toBe(true);
+    expect(isWordRevealed(2, 2)).toBe(false);
+  });
+});

--- a/packages/core/src/peek.ts
+++ b/packages/core/src/peek.ts
@@ -1,0 +1,51 @@
+/**
+ * Hide-and-peek memorization helpers (#134) — pure and shared by the web and
+ * mobile readers, so the testing/recall mode reveals text identically on both.
+ *
+ * The model is a single monotonic **reveal cursor**: a count of how many items
+ * (words, or whole āyāt) from the start of the passage are uncovered. The reader
+ * conceals everything, then advances the cursor — by one word, or through the end
+ * of the current āyah — until the passage is fully shown. No I/O, no platform APIs.
+ */
+
+/** Granularity at which a concealed passage is progressively revealed. */
+export type PeekStep = "word" | "ayah";
+
+/** The total number of words across a passage given each āyah's word count. */
+export function totalWords(wordsPerAyah: readonly number[]): number {
+  return wordsPerAyah.reduce((sum, n) => sum + Math.max(0, n), 0);
+}
+
+/** Clamp a reveal cursor into `[0, total]`; a non-finite cursor → `0`. */
+export function clampReveal(revealed: number, total: number): number {
+  if (!Number.isFinite(revealed)) return 0;
+  return Math.min(Math.max(0, total), Math.max(0, Math.floor(revealed)));
+}
+
+/** Reveal one more word — the next concealed word — clamped to the total. */
+export function revealWord(revealed: number, total: number): number {
+  return clampReveal(revealed + 1, total);
+}
+
+/**
+ * Reveal through the end of the āyah that contains the next concealed word.
+ * If everything is already shown, the cursor is unchanged. `wordsPerAyah` lists
+ * each āyah's word count in reading order.
+ */
+export function revealAyah(revealed: number, wordsPerAyah: readonly number[]): number {
+  const total = totalWords(wordsPerAyah);
+  const cursor = clampReveal(revealed, total);
+  if (cursor >= total) return total;
+  // Walk cumulative boundaries; stop at the first āyah whose end passes the cursor.
+  let end = 0;
+  for (const count of wordsPerAyah) {
+    end += Math.max(0, count);
+    if (end > cursor) return end;
+  }
+  return total;
+}
+
+/** Whether the word at `index` (0-based, in reading order) is currently revealed. */
+export function isWordRevealed(index: number, revealed: number): boolean {
+  return index < revealed;
+}


### PR DESCRIPTION
## Hide & peek memorization mode (#134)

A study/recall mode that **conceals the Arabic** so you can recite from memory, then **reveals it progressively** — on **web and mobile**, in both the **surah** and **juzʾ** readers. The manual, non-AI version (the AI listen-and-reveal variant stays out of scope per the Phase 8 epic).

### Core (pure, 11 unit tests)
`packages/core/src/peek.ts` — a single monotonic **reveal cursor** over a flat word sequence, so both clients reveal identically:
- `clampReveal`, `revealWord` (one more word), `revealAyah` (through the current āyah's boundary), `totalWords`, `isWordRevealed`.

### Web — `MemorizeBar.tsx`
A self-contained floating control rendered in both readers (no toolbar/mode-state coupling). Toggling it adds a `peek-on` body class which, via CSS, **forces the per-word verse layout visible whatever reading mode is selected** and blurs each `.ayah-ar .w`. Controls: **Peek word**, **Reveal āyah**, **Show all**, **Hide all**, a **Translation** toggle (blurs translations too), and tap-a-word to peek just it (bound on the capture phase so it pre-empts the word-by-word popover; the ▷ play markers still pass through). Reveal state is **ephemeral** — a muṣḥaf is never hidden by surprise on the next visit.

### Mobile
The same core model with **redaction chips** (a concealed word keeps its footprint but hides the glyphs): per-word peek in `AyahView` (surah) and the juzʾ rows, a shared `MemorizeBar` controls component, ephemeral per-screen state (entering peek switches the surah reader to the verse layout).

### Acceptance
- [x] Toggle to blur/hide the Arabic (and optionally the translation) per āyah.
- [x] Progressive reveal: per-word + per-āyah, plus "show all" / "hide all" / tap-to-peek.
- [x] Works in both surah and juzʾ reading; respects the current font/script (blur/redaction scale with the text).
- [x] Available on web and mobile.

### Verification
- `pnpm lint && typecheck && test && build` — all green (267 web tests + 11 new core tests).
- **Web verified in-browser** (CDP): toggle blurs all words → Peek word reveals in reading order (āyah 1 + 3 words of āyah 2) → Reveal āyah extends to the boundary → tap reveals a single word → Show all clears the blur → Translation also blurs the translations; the bar floats cleanly above the audio dock.
- Mobile is typecheck-clean and shares the verified core model; runtime emulator check not yet run.

Closes #134.