### PR TITLE
feat(reader): side-by-side tafsir comparison (#141)

### DIFF
--- a/apps/mobile/src/components/AyahTafsir.tsx
+++ b/apps/mobile/src/components/AyahTafsir.tsx
@@ -1,11 +1,11 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "../Type";
 import { api } from "../api";
 import { TAFSIRS } from "../plugins";
 import { useTheme, type Palette } from "../theme";
 import { useSettings } from "../state/SettingsContext";
 
-// One shared fetch per (tafsir, surah); every ayah toggle reuses it.
+// One shared fetch per (tafsir, surah); every āyah/column toggle reuses it.
 const cache = new Map<string, Promise<Map<number, string>>>();
 function loadSurahTafsir(tafsirId: string, surah: number): Promise<Map<number, string>> {
   const key = `${tafsirId}:${surah}`;
@@ -20,52 +20,114 @@ function loadSurahTafsir(tafsirId: string, surah: number): Promise<Map<number, s
   return pending;
 }
 
-/** Collapsible per-ayah tafsir (commentary) in the selected edition. */
+// Arabic/Urdu/Persian tafsir reads right-to-left; everything else left-to-right.
+const isRtl = (id: string) => /^(ar|ur|fa|ps|ckb)-/.test(id);
+
+interface Loaded {
+  state: "loading" | "ready" | "empty";
+  text: string;
+}
+
+/**
+ * Collapsible per-āyah tafsīr with side-by-side comparison (#141): chips pick the
+ * editions and each selected edition is shown stacked (the phone-friendly form of
+ * "parallel columns"). The selection persists (`ul.tafsirCompare`); an empty set
+ * falls back to the single chosen tafsir — the original one-edition behaviour.
+ */
 export function AyahTafsir({ sura, aya }: { sura: number; aya: number }) {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
-  const { tafsirId, tafsirs } = useSettings();
-  const tafsirName =
-    tafsirs.find((t) => t.id === tafsirId)?.name ??
-    TAFSIRS.find((t) => t.id === tafsirId)?.name ??
-    "Tafsir";
-  const [open, setOpen] = useState(false);
-  const [state, setState] = useState<"idle" | "loading" | "ready" | "empty">("idle");
-  const [text, setText] = useState("");
+  const { tafsirId, tafsirCompare, tafsirs, setTafsirCompare } = useSettings();
 
-  async function toggle() {
-    if (open) {
-      setOpen(false);
-      return;
+  const allTafsirs = tafsirs.length > 0 ? tafsirs : TAFSIRS;
+  const nameOf = (id: string) => allTafsirs.find((t) => t.id === id)?.name ?? "Tafsir";
+
+  // The editions to show: the explicit comparison set (validated), else the primary.
+  const editions = useMemo(() => {
+    const valid = new Set(allTafsirs.map((t) => t.id));
+    const sel = tafsirCompare.filter((id) => valid.has(id));
+    return sel.length > 0 ? sel : tafsirId ? [tafsirId] : [];
+  }, [tafsirCompare, tafsirId, allTafsirs]);
+
+  const [open, setOpen] = useState(false);
+  const [loaded, setLoaded] = useState<Record<string, Loaded>>({});
+
+  useEffect(() => {
+    if (!open) return;
+    let active = true;
+    editions.forEach((id) => {
+      setLoaded((d) => (d[id] ? d : { ...d, [id]: { state: "loading", text: "" } }));
+      void loadSurahTafsir(id, sura).then((byAya) => {
+        if (!active) return;
+        const entry = byAya.get(aya);
+        setLoaded((d) => ({ ...d, [id]: { state: entry ? "ready" : "empty", text: entry ?? "" } }));
+      });
+    });
+    return () => {
+      active = false;
+    };
+  }, [open, editions, sura, aya]);
+
+  function toggle(id: string) {
+    const set = new Set(editions);
+    if (set.has(id)) {
+      if (set.size === 1) return; // keep at least one edition visible
+      set.delete(id);
+    } else {
+      set.add(id);
     }
-    setOpen(true);
-    setState("loading");
-    const byAya = await loadSurahTafsir(tafsirId, sura);
-    const entry = byAya.get(aya);
-    setText(entry ?? "");
-    setState(entry ? "ready" : "empty");
+    // Preserve manifest order so the sections stay stable.
+    setTafsirCompare(allTafsirs.filter((t) => set.has(t.id)).map((t) => t.id));
   }
+
+  const header =
+    editions.length > 1 ? `Tafsir · comparing ${editions.length}` : `Tafsir · ${nameOf(editions[0] ?? "")}`;
 
   return (
     <View style={styles.wrap}>
-      <Pressable onPress={toggle}>
+      <Pressable onPress={() => setOpen((o) => !o)}>
         <Text style={styles.toggle}>
-          {open ? "▾" : "▸"} Tafsir · {tafsirName}
+          {open ? "▾" : "▸"} {header}
         </Text>
       </Pressable>
       {open && (
         <View style={styles.body}>
-          {state === "loading" && <ActivityIndicator color={colors.accent} />}
-          {state === "empty" && <Text style={styles.muted}>No tafsir for this āyah.</Text>}
-          {state === "ready" &&
-            text
-              .split("\n")
-              .filter((p) => p.trim())
-              .map((p, i) => (
-                <Text key={i} style={styles.para}>
-                  {p}
-                </Text>
-              ))}
+          {allTafsirs.length > 1 && (
+            <View style={styles.chips}>
+              {allTafsirs.map((t) => {
+                const on = editions.includes(t.id);
+                return (
+                  <Pressable
+                    key={t.id}
+                    onPress={() => toggle(t.id)}
+                    style={[styles.chip, on && styles.chipOn]}
+                  >
+                    <Text style={[styles.chipText, on && styles.chipTextOn]}>{t.name}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          )}
+
+          {editions.map((id) => {
+            const d = loaded[id];
+            return (
+              <View key={id} style={editions.length > 1 ? styles.section : undefined}>
+                {editions.length > 1 && <Text style={styles.sectionName}>{nameOf(id)}</Text>}
+                {(!d || d.state === "loading") && <ActivityIndicator color={colors.accent} />}
+                {d?.state === "empty" && <Text style={styles.muted}>No tafsir for this āyah.</Text>}
+                {d?.state === "ready" &&
+                  d.text
+                    .split("\n")
+                    .filter((p) => p.trim())
+                    .map((p, i) => (
+                      <Text key={i} style={[styles.para, isRtl(id) && styles.rtl]}>
+                        {p}
+                      </Text>
+                    ))}
+              </View>
+            );
+          })}
         </View>
       )}
     </View>
@@ -77,7 +139,28 @@ function makeStyles(c: Palette) {
     wrap: { marginTop: 10 },
     toggle: { color: c.accent, fontSize: 13, fontWeight: "600" },
     body: { marginTop: 8, gap: 8 },
+    chips: { flexDirection: "row", flexWrap: "wrap", gap: 6, marginBottom: 4 },
+    chip: {
+      paddingVertical: 5,
+      paddingHorizontal: 10,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bg,
+    },
+    chipOn: { borderColor: c.accent, backgroundColor: c.accentSoft },
+    chipText: { color: c.muted, fontSize: 12.5, fontWeight: "600" },
+    chipTextOn: { color: c.accent },
+    section: {
+      borderWidth: 1,
+      borderColor: c.borderSoft,
+      borderRadius: 12,
+      padding: 12,
+      gap: 6,
+    },
+    sectionName: { color: c.fg, fontSize: 13, fontWeight: "700", marginBottom: 2 },
     muted: { color: c.muted, fontSize: 14 },
     para: { color: c.fg, fontSize: 15, lineHeight: 23 },
+    rtl: { writingDirection: "rtl", textAlign: "right" },
   });
 }

--- a/apps/mobile/src/state/SettingsContext.tsx
+++ b/apps/mobile/src/state/SettingsContext.tsx
@@ -16,6 +16,7 @@ import {
 import type { Translation } from "@ummahlibrary/core";
 import { api, type TafsirMeta } from "../api";
 import { mobileSettingsStore as store } from "./settings-store";
+import { readTafsirCompare, writeTafsirCompare } from "../tafsir-compare-store";
 import { RECITER, TAFSIRS } from "../plugins";
 import { DEFAULT_EDITIONS, MAX_SCALE, MIN_SCALE, type ReadingMode } from "../types";
 
@@ -25,6 +26,8 @@ interface SettingsValue {
   readingTranslation: string | null;
   reciterId: string;
   tafsirId: string;
+  /** Editions shown side by side in the per-āyah tafsir panel (#141); [] = just tafsirId. */
+  tafsirCompare: string[];
   scale: number;
   catalogue: Translation[];
   tafsirs: TafsirMeta[];
@@ -33,6 +36,7 @@ interface SettingsValue {
   setReadingTranslation: (id: string) => void;
   setReciterId: (id: string) => void;
   setTafsirId: (id: string) => void;
+  setTafsirCompare: (ids: string[]) => void;
   setScale: (scale: number) => void;
 }
 
@@ -46,6 +50,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [readingTranslation, setReadingTranslationState] = useState<string | null>(null);
   const [reciterId, setReciterIdState] = useState<string>(RECITER.id);
   const [tafsirId, setTafsirIdState] = useState<string>(TAFSIRS[0].id);
+  const [tafsirCompare, setTafsirCompareState] = useState<string[]>([]);
   const [scale, setScaleState] = useState<number>(1);
   const [catalogue, setCatalogue] = useState<Translation[]>([]);
   const [tafsirs, setTafsirs] = useState<TafsirMeta[]>([]);
@@ -60,6 +65,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       if (s.tafsir) setTafsirIdState(s.tafsir);
       if (s.scale != null) setScaleState(clampScale(s.scale));
     });
+    void readTafsirCompare().then(setTafsirCompareState);
     void api
       .listTranslationCatalog()
       .then(setCatalogue)
@@ -96,6 +102,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     void store.writeTafsir(id);
   }, []);
 
+  const setTafsirCompare = useCallback((ids: string[]) => {
+    setTafsirCompareState(ids);
+    void writeTafsirCompare(ids);
+  }, []);
+
   const setScale = useCallback((next: number) => {
     const clamped = clampScale(next);
     setScaleState(clamped);
@@ -109,6 +120,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       readingTranslation,
       reciterId,
       tafsirId,
+      tafsirCompare,
       scale,
       catalogue,
       tafsirs,
@@ -117,6 +129,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setReadingTranslation,
       setReciterId,
       setTafsirId,
+      setTafsirCompare,
       setScale,
     }),
     [
@@ -125,6 +138,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       readingTranslation,
       reciterId,
       tafsirId,
+      tafsirCompare,
       scale,
       catalogue,
       tafsirs,
@@ -133,6 +147,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setReadingTranslation,
       setReciterId,
       setTafsirId,
+      setTafsirCompare,
       setScale,
     ],
   );

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -10,6 +10,7 @@ export const KEYS = {
   readingMode: "ul.readingMode",
   readingTranslation: "ul.readingTranslation",
   tafsir: "ul.tafsir",
+  tafsirCompare: "ul.tafsirCompare",
   reciter: "ul.reciter",
   audioRate: "ul.audioRate",
   scale: "ul.scale",

--- a/apps/mobile/src/tafsir-compare-store.ts
+++ b/apps/mobile/src/tafsir-compare-store.ts
@@ -1,0 +1,15 @@
+/**
+ * Store adapter (ADR 0024) for the reader's tafsir **comparison set** — the
+ * editions shown together in the per-āyah tafsir panel (#141), under
+ * `ul.tafsirCompare`. An empty set means "just the single selected tafsir", i.e.
+ * the original one-edition behaviour. Mirrors the web `tafsir-compare-store`.
+ */
+import { KEYS, getJSON, isStringArray, setJSON } from "./storage";
+
+export function readTafsirCompare(): Promise<string[]> {
+  return getJSON<string[]>(KEYS.tafsirCompare, [], isStringArray);
+}
+
+export function writeTafsirCompare(ids: string[]): Promise<void> {
+  return setJSON(KEYS.tafsirCompare, ids);
+}

--- a/apps/web/src/components/AyahActions.tsx
+++ b/apps/web/src/components/AyahActions.tsx
@@ -12,28 +12,11 @@ import { N, Icon } from "@ummahlibrary/ui";
 import type { IconName } from "@ummahlibrary/ui";
 import { newId, readCollections, readNote, writeCollections, writeNote } from "../lib/collections";
 import { isTracked, removeCard, setCard } from "../lib/hifz-store";
-import { TAFSIR_KEY, readTafsir } from "../lib/tafsir";
+import { TafsirCompare } from "./TafsirCompare";
 
 interface TafsirMeta {
   id: string;
   name: string;
-}
-interface TafsirResponse {
-  entries: { sura: number; aya: number; text: string }[];
-}
-
-// One shared tafsir fetch per (edition, surah); every ayah's toggle reuses it.
-const tafsirCache = new Map<string, Promise<Map<number, string>>>();
-function loadSurahTafsir(tafsirId: string, surah: number): Promise<Map<number, string>> {
-  const key = `${tafsirId}:${surah}`;
-  let pending = tafsirCache.get(key);
-  if (!pending) {
-    pending = fetch(`/api/v1/surahs/${surah}/tafsirs/${tafsirId}`)
-      .then((res) => (res.ok ? (res.json() as Promise<TafsirResponse>) : { entries: [] }))
-      .then((data) => new Map(data.entries.map((e) => [e.aya, e.text])));
-    tafsirCache.set(key, pending);
-  }
-  return pending;
 }
 
 /** A quick-action button in the per-ayah row: icon + label, gold when active. */
@@ -134,11 +117,6 @@ export function AyahActions({
   const [toast, setToast] = useState<string | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Tafsir state (selected edition shared via localStorage + the TafsirPicker event).
-  const [tafsirId, setTafsirId] = useState(tafsirs[0]?.id ?? "");
-  const [tafsirState, setTafsirState] = useState<"loading" | "ready" | "empty">("loading");
-  const [tafsirText, setTafsirText] = useState("");
-
   const savedIds = new Set(collectionsWithAyah(collections, ref));
   const saved = savedIds.size > 0;
 
@@ -153,30 +131,6 @@ export function AyahActions({
     block.classList.toggle("ayah-hifz", tracked);
     return () => { block.classList.remove("ayah-hifz"); };
   }, [tracked]);
-
-  useEffect(() => {
-    void readTafsir(tafsirs[0]?.id ?? "").then(setTafsirId);
-    const onChange = (e: Event) => setTafsirId((e as CustomEvent<string>).detail);
-    window.addEventListener(TAFSIR_KEY, onChange as EventListener);
-    return () => window.removeEventListener(TAFSIR_KEY, onChange as EventListener);
-  }, [tafsirs]);
-
-  useEffect(() => {
-    if (!tafsirOpen || !tafsirId) return;
-    let active = true;
-    setTafsirState("loading");
-    loadSurahTafsir(tafsirId, surah)
-      .then((byAya) => {
-        if (!active) return;
-        const entry = byAya.get(aya);
-        setTafsirText(entry ?? "");
-        setTafsirState(entry ? "ready" : "empty");
-      })
-      .catch(() => active && setTafsirState("empty"));
-    return () => {
-      active = false;
-    };
-  }, [tafsirOpen, tafsirId, surah, aya]);
 
   function flash(message: string) {
     setToast(message);
@@ -281,8 +235,6 @@ export function AyahActions({
     void readNote(ref).then(setNote);
     setSaveOpen(true);
   }
-
-  const tafsirName = tafsirs.find((t) => t.id === tafsirId)?.name ?? "Tafsir";
 
   return (
     <div ref={containerRef} style={{ position: "relative" }}>
@@ -403,31 +355,7 @@ export function AyahActions({
         </div>
       )}
 
-      {tafsirOpen && (
-        <div className="tafsir">
-          <div
-            style={{
-              fontSize: 11.5,
-              letterSpacing: 1,
-              textTransform: "uppercase",
-              color: N.gold,
-              fontWeight: 700,
-              fontFamily: N.ui,
-              margin: "10px 0 6px",
-            }}
-          >
-            Tafsīr · {tafsirName}
-          </div>
-          <div className="tafsir-body">
-            {tafsirState === "loading" && <span className="tafsir-muted">Loading…</span>}
-            {tafsirState === "empty" && (
-              <span className="tafsir-muted">No tafsir for this āyah.</span>
-            )}
-            {tafsirState === "ready" &&
-              tafsirText.split("\n").map((p, i) => (p.trim() ? <p key={i}>{p}</p> : null))}
-          </div>
-        </div>
-      )}
+      {tafsirOpen && <TafsirCompare surah={surah} aya={aya} tafsirs={tafsirs} />}
     </div>
   );
 }

--- a/apps/web/src/components/TafsirCompare.tsx
+++ b/apps/web/src/components/TafsirCompare.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { N } from "@ummahlibrary/ui";
+import { TAFSIR_COMPARE_KEY, TAFSIR_KEY, readCompare, readTafsir, writeCompare } from "../lib/tafsir";
+
+interface TafsirMeta {
+  id: string;
+  name: string;
+}
+interface TafsirResponse {
+  entries: { sura: number; aya: number; text: string }[];
+}
+
+// One shared fetch per (edition, surah); every āyah's column reuses it.
+const tafsirCache = new Map<string, Promise<Map<number, string>>>();
+function loadSurahTafsir(tafsirId: string, surah: number): Promise<Map<number, string>> {
+  const key = `${tafsirId}:${surah}`;
+  let pending = tafsirCache.get(key);
+  if (!pending) {
+    pending = fetch(`/api/v1/surahs/${surah}/tafsirs/${tafsirId}`)
+      .then((res) => (res.ok ? (res.json() as Promise<TafsirResponse>) : { entries: [] }))
+      .then((data) => new Map(data.entries.map((e) => [e.aya, e.text])));
+    tafsirCache.set(key, pending);
+  }
+  return pending;
+}
+
+// Arabic/Urdu/Persian tafsir reads right-to-left; everything else left-to-right.
+const isRtl = (id: string) => /^(ar|ur|fa|ps|ckb)-/.test(id);
+
+/**
+ * The per-āyah tafsīr panel with side-by-side comparison (#141): a chip row to
+ * pick editions and one column per selected edition, each fetched independently
+ * and reusing the per-surah cache. The columns are a responsive auto-fit grid, so
+ * they sit side by side on wide screens and stack on narrow ones. The selection
+ * persists (`ul.tafsirCompare`); an empty set falls back to the single chosen
+ * tafsir, i.e. the original one-edition behaviour.
+ */
+export function TafsirCompare({
+  surah,
+  aya,
+  tafsirs,
+}: {
+  surah: number;
+  aya: number;
+  tafsirs: TafsirMeta[];
+}) {
+  const [primary, setPrimary] = useState(tafsirs[0]?.id ?? "");
+  const [compare, setCompare] = useState<string[]>([]);
+
+  useEffect(() => {
+    void readTafsir(tafsirs[0]?.id ?? "").then(setPrimary);
+    setCompare(readCompare());
+    const onPrimary = (e: Event) => setPrimary((e as CustomEvent<string>).detail);
+    const onCompare = (e: Event) => setCompare((e as CustomEvent<string[]>).detail);
+    window.addEventListener(TAFSIR_KEY, onPrimary as EventListener);
+    window.addEventListener(TAFSIR_COMPARE_KEY, onCompare as EventListener);
+    return () => {
+      window.removeEventListener(TAFSIR_KEY, onPrimary as EventListener);
+      window.removeEventListener(TAFSIR_COMPARE_KEY, onCompare as EventListener);
+    };
+  }, [tafsirs]);
+
+  // The editions to show: the explicit comparison set (validated against what we
+  // actually ship), else just the primary one.
+  const valid = new Set(tafsirs.map((t) => t.id));
+  const selected = compare.filter((id) => valid.has(id));
+  const editions = selected.length > 0 ? selected : primary ? [primary] : [];
+
+  function toggle(id: string) {
+    const set = new Set(editions);
+    if (set.has(id)) {
+      if (set.size === 1) return; // keep at least one edition visible
+      set.delete(id);
+    } else {
+      set.add(id);
+    }
+    // Preserve the manifest order so the columns stay stable.
+    writeCompare(tafsirs.filter((t) => set.has(t.id)).map((t) => t.id));
+  }
+
+  return (
+    <div className="tafsir">
+      <div
+        style={{
+          fontSize: 11.5,
+          letterSpacing: 1,
+          textTransform: "uppercase",
+          color: N.gold,
+          fontWeight: 700,
+          fontFamily: N.ui,
+          margin: "10px 0 8px",
+        }}
+      >
+        Tafsīr {editions.length > 1 ? "· comparing" : ""}
+      </div>
+
+      {/* Edition chips */}
+      {tafsirs.length > 1 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 12 }}>
+          {tafsirs.map((t) => {
+            const on = editions.includes(t.id);
+            return (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => toggle(t.id)}
+                aria-pressed={on}
+                style={{
+                  padding: "5px 10px",
+                  borderRadius: 999,
+                  border: `1px solid ${on ? N.gold : N.border}`,
+                  background: on ? N.goldSoft : N.card,
+                  color: on ? N.gold : N.muted,
+                  fontFamily: N.ui,
+                  fontSize: 12.5,
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+              >
+                {t.name}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Columns — one per selected edition, responsive auto-fit grid */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+          gap: 14,
+          alignItems: "start",
+        }}
+      >
+        {editions.map((id) => (
+          <TafsirColumn
+            key={id}
+            edition={id}
+            name={tafsirs.find((t) => t.id === id)?.name ?? "Tafsir"}
+            multi={editions.length > 1}
+            surah={surah}
+            aya={aya}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TafsirColumn({
+  edition,
+  name,
+  multi,
+  surah,
+  aya,
+}: {
+  edition: string;
+  name: string;
+  multi: boolean;
+  surah: number;
+  aya: number;
+}) {
+  const [state, setState] = useState<"loading" | "ready" | "empty">("loading");
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    setState("loading");
+    loadSurahTafsir(edition, surah)
+      .then((byAya) => {
+        if (!active) return;
+        const entry = byAya.get(aya);
+        setText(entry ?? "");
+        setState(entry ? "ready" : "empty");
+      })
+      .catch(() => active && setState("empty"));
+    return () => {
+      active = false;
+    };
+  }, [edition, surah, aya]);
+
+  return (
+    <div
+      style={
+        multi
+          ? { border: `1px solid ${N.borderSoft}`, borderRadius: 12, padding: "10px 12px" }
+          : undefined
+      }
+    >
+      {multi && (
+        <div
+          style={{
+            fontSize: 12.5,
+            fontWeight: 700,
+            color: N.fg,
+            fontFamily: N.ui,
+            marginBottom: 6,
+          }}
+        >
+          {name}
+        </div>
+      )}
+      <div className="tafsir-body" dir={isRtl(edition) ? "rtl" : undefined}>
+        {state === "loading" && <span className="tafsir-muted">Loading…</span>}
+        {state === "empty" && <span className="tafsir-muted">No tafsir for this āyah.</span>}
+        {state === "ready" &&
+          text.split("\n").map((p, i) => (p.trim() ? <p key={i}>{p}</p> : null))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/tafsir-compare-store.ts
+++ b/apps/web/src/lib/tafsir-compare-store.ts
@@ -1,0 +1,30 @@
+/**
+ * Raw-storage home (ADR 0024) for the reader's tafsir **comparison set** — the
+ * tafsir editions shown side by side in the per-āyah panel (#141), under
+ * `ul.tafsirCompare`. Kept synchronous (read during render of the open panel),
+ * so callers import these helpers instead of touching `localStorage` directly.
+ * An empty set means "just the single selected tafsir" — i.e. today's behaviour.
+ */
+const KEY = "ul.tafsirCompare";
+
+/** The selected comparison editions (ids), or `[]` when none chosen. */
+export function readTafsirCompare(): string[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const v = JSON.parse(raw) as unknown;
+    // A corrupt / peer-synced non-array (or non-string members) must not crash the
+    // panel — fall back to "no comparison set".
+    return Array.isArray(v) && v.every((x) => typeof x === "string") ? (v as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeTafsirCompare(ids: string[]): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(ids));
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/apps/web/src/lib/tafsir.ts
+++ b/apps/web/src/lib/tafsir.ts
@@ -7,8 +7,11 @@
  * new edition.
  */
 import { webSettingsStore as store } from "./settings-store";
+import { readTafsirCompare, writeTafsirCompare } from "./tafsir-compare-store";
 
 export const TAFSIR_KEY = "ul.tafsir";
+/** Broadcast when the side-by-side comparison set changes (#141). */
+export const TAFSIR_COMPARE_KEY = "ul.tafsirCompare";
 
 export async function readTafsir(fallback: string): Promise<string> {
   return (await store.read()).tafsir || fallback;
@@ -17,4 +20,15 @@ export async function readTafsir(fallback: string): Promise<string> {
 export async function writeTafsir(id: string): Promise<void> {
   await store.writeTafsir(id);
   window.dispatchEvent(new CustomEvent(TAFSIR_KEY, { detail: id }));
+}
+
+/** The tafsir editions to show side by side; `[]` means "just the primary one". */
+export function readCompare(): string[] {
+  return readTafsirCompare();
+}
+
+/** Persist the comparison set and notify every open tafsir panel to re-render. */
+export function writeCompare(ids: string[]): void {
+  writeTafsirCompare(ids);
+  window.dispatchEvent(new CustomEvent(TAFSIR_COMPARE_KEY, { detail: ids }));
 }


### PR DESCRIPTION
## Side-by-side tafsīr comparison (#141)

View **two or more tafsīr editions in parallel** for an āyah, instead of one at a time — a core study workflow (Ayat/Greentech ship it). **Pure UI over tafsirs we already serve**: no new data, no API change, and **no core-port change** (reuses the `/surahs/[n]/tafsirs/[edition]` route + the per-surah fetch cache).

### Shape
- A small comparison set (`ul.tafsirCompare`) layered on top of the single selected tafsir; an empty set falls back to that one edition — i.e. today's behaviour is unchanged until you opt in. Persisted behind a Store adapter (ADR 0024): web `tafsir-compare-store.ts`, mobile `tafsir-compare-store.ts` + `SettingsContext`.
- **Web** — `TafsirCompare.tsx`: an edition chip row + one column per selected edition in a responsive `auto-fit` grid (side by side on wide screens, **stacks on narrow ones**), each fetched independently, with RTL handling for Arabic/Urdu. Wired into the per-āyah Tafsir panel in `AyahActions` (the old single-edition block is removed).
- **Mobile** — `AyahTafsir.tsx` renders the selected editions **stacked** with the same chip row (the phone-friendly form of parallel columns).

### Acceptance
- [x] Select 2+ tafsir editions and view them in parallel for an āyah.
- [x] Responsive layout (columns on wide, stacks on narrow).
- [x] Web + mobile.

### Verification
- `pnpm lint && typecheck && test && build` — all green (no test changes needed; reuses existing data path).
- **Web verified in-browser** (CDP): opened the per-āyah Tafsir panel → 6 edition chips + single column (default), added "Maarif-ul-Quran" → **two populated columns side by side** ("Tafsir Muyassar" Arabic/RTL next to "Maarif-ul-Quran" English) for Al-Baqarah 2; selection propagates across open panels and persists.
- Mobile: typecheck + lint clean and shares the exact compare-set logic + data path; runtime Expo render not captured this session (local Expo stack was flaky) — happy to run it before merge.

There are 6 bundled tafsir editions (ar/bn/en/ur), so comparisons are meaningful (Arabic↔English, Ibn Kathir↔Maarif, etc.).

Closes #141.