### PR TITLE
fix(reader): resume at the saved āyah instead of the surah start

### DIFF
--- a/apps/web/src/components/NoorHomePage.test.tsx
+++ b/apps/web/src/components/NoorHomePage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NoorHomePage } from "./NoorHomePage";
@@ -75,5 +75,24 @@ describe("NoorHomePage tabs", () => {
     // Within the Meccan group, surahs keep surah-number order (Al-Fātiḥah 1 before Al-ʿAlaq 96)
     // — the opposite of the old chronological ordering, which proves the regrouping.
     expect(positionOf(/Al-Fātiḥah/)).toBeLessThan(positionOf(/Al-ʿAlaq/));
+  });
+});
+
+describe("NoorHomePage continue-reading card", () => {
+  afterEach(() => localStorage.clear());
+
+  it("resumes at the stored āyah via a #sura:aya deep link (not the surah start)", () => {
+    localStorage.setItem("ul.lastRead", JSON.stringify({ surah: 2, aya: 153, total: 286 }));
+    render(<NoorHomePage surahs={surahs} />);
+
+    const resume = screen.getByRole("link", { name: /Continue reading/i });
+    expect(resume.getAttribute("href")).toBe("/surah/2#2:153");
+  });
+
+  it("falls back to opening Al-Fātiḥah when nothing has been read yet", () => {
+    render(<NoorHomePage surahs={surahs} />);
+
+    const start = screen.getByRole("link", { name: /Start reading/i });
+    expect(start.getAttribute("href")).toBe("/surah/1");
   });
 });

--- a/apps/web/src/components/NoorHomePage.tsx
+++ b/apps/web/src/components/NoorHomePage.tsx
@@ -1,10 +1,11 @@
 "use client";
 import Link from "next/link";
-import { useState } from "react";
-import { JUZ_STARTS, TOTAL_JUZ } from "@ummahlibrary/core";
+import { useEffect, useState } from "react";
+import { JUZ_STARTS, TOTAL_JUZ, ayahKey, juzNumberOf } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
 import { HomeHeroCards } from "./HomeHeroCards";
 import { HomeVerseOfDay } from "./HomeVerseOfDay";
+import { readLastReadFull, type LastRead } from "../lib/reader-prefs-store";
 import { useSearch } from "./shell/SearchContext";
 
 interface Surah {
@@ -319,6 +320,132 @@ function RevGroups({ surahs }: { surahs: Surah[] }) {
   );
 }
 
+/**
+ * "Continue reading" card — resolves the reader's real last-read position from
+ * the reader-prefs store and resumes at the exact āyah (`#sura:aya`, scrolled to
+ * by `HashHighlighter`). Before hydration, and for first-time readers, it gently
+ * falls back to opening at Al-Fātiḥah instead of a misleading fixed position.
+ */
+function ContinueReadingCard({ surahs }: { surahs: Surah[] }) {
+  const [lr, setLr] = useState<LastRead | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setLr(readLastReadFull());
+    setMounted(true);
+  }, []);
+
+  const byNumber = new Map(surahs.map((s) => [s.number, s]));
+  const resolved = (mounted && lr && byNumber.get(lr.surah)) || byNumber.get(1);
+  if (!resolved) return null;
+
+  const isResume = mounted && !!lr && lr.surah === resolved.number;
+  const aya = isResume ? (lr!.aya ?? 1) : 1;
+  const total = (isResume && lr!.total) || resolved.ayahCount;
+  const pct = total > 0 ? Math.min(100, Math.round((aya / total) * 100)) : 0;
+  let juz = 1;
+  try {
+    juz = juzNumberOf({ sura: resolved.number, aya });
+  } catch {
+    /* an out-of-range stored āyah → keep the surah's opening juzʾ */
+  }
+  const href =
+    aya > 1
+      ? `/surah/${resolved.number}#${ayahKey({ sura: resolved.number, aya })}`
+      : `/surah/${resolved.number}`;
+
+  return (
+    <Link
+      href={href}
+      style={{
+        display: "block",
+        borderRadius: 16,
+        padding: 24,
+        background: `linear-gradient(135deg, ${N.cardHi}, ${N.card})`,
+        border: `1px solid ${N.border}`,
+        position: "relative",
+        overflow: "hidden",
+        textDecoration: "none",
+        marginBottom: 16,
+        transition: "border-color .15s",
+      }}
+    >
+      <div
+        aria-hidden="true"
+        style={{ position: "absolute", right: -30, top: -30, pointerEvents: "none" }}
+      >
+        <Khatam size={150} color={N.gold} sw={1.2} opacity={0.1} />
+      </div>
+      <div
+        style={{
+          fontSize: 11.5,
+          letterSpacing: 1.2,
+          textTransform: "uppercase",
+          color: N.faint,
+          fontWeight: 700,
+          marginBottom: 12,
+          fontFamily: N.ui,
+        }}
+      >
+        {isResume ? "Continue reading" : "Start reading"}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontSize: "clamp(20px,3vw,25px)",
+              fontWeight: 800,
+              letterSpacing: -0.5,
+              color: N.fg,
+              fontFamily: N.ui,
+            }}
+          >
+            {resolved.transliteration}
+          </div>
+          <div style={{ fontSize: 14, color: N.muted, marginTop: 3, fontFamily: N.ui }}>
+            Ayah {aya} · {resolved.englishName} · Juzʾ {juz}
+          </div>
+        </div>
+        <div className="noor-ar" style={{ fontSize: 40, color: N.goldHi }}>
+          {resolved.name}
+        </div>
+      </div>
+      <div
+        style={{
+          marginTop: 18,
+          height: 6,
+          borderRadius: 3,
+          background: N.bg,
+          overflow: "hidden",
+        }}
+      >
+        <div style={{ width: `${pct}%`, height: "100%", background: N.goldGrad }} />
+      </div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginTop: 8,
+          fontSize: 12.5,
+          color: N.faint,
+          fontFamily: N.ui,
+        }}
+      >
+        <span>{isResume ? `${pct}% through the surah` : "Begin from the first āyah"}</span>
+        <span style={{ color: N.gold, fontWeight: 600 }}>{isResume ? "Resume →" : "Open →"}</span>
+      </div>
+    </Link>
+  );
+}
+
 export function NoorHomePage({ surahs }: Props) {
   const { query } = useSearch();
   const [tab, setTab] = useState<"surah" | "juz" | "rev">("surah");
@@ -389,95 +516,8 @@ export function NoorHomePage({ surahs }: Props) {
         {/* Next prayer + today's reading summary */}
         <HomeHeroCards />
 
-        {/* Continue reading card */}
-        <Link
-          href="/surah/2"
-          style={{
-            display: "block",
-            borderRadius: 16,
-            padding: 24,
-            background: `linear-gradient(135deg, ${N.cardHi}, ${N.card})`,
-            border: `1px solid ${N.border}`,
-            position: "relative",
-            overflow: "hidden",
-            textDecoration: "none",
-            marginBottom: 16,
-            transition: "border-color .15s",
-          }}
-        >
-          <div
-            aria-hidden="true"
-            style={{ position: "absolute", right: -30, top: -30, pointerEvents: "none" }}
-          >
-            <Khatam size={150} color={N.gold} sw={1.2} opacity={0.1} />
-          </div>
-          <div
-            style={{
-              fontSize: 11.5,
-              letterSpacing: 1.2,
-              textTransform: "uppercase",
-              color: N.faint,
-              fontWeight: 700,
-              marginBottom: 12,
-              fontFamily: N.ui,
-            }}
-          >
-            Continue reading
-          </div>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 16,
-              flexWrap: "wrap",
-            }}
-          >
-            <div>
-              <div
-                style={{
-                  fontSize: "clamp(20px,3vw,25px)",
-                  fontWeight: 800,
-                  letterSpacing: -0.5,
-                  color: N.fg,
-                  fontFamily: N.ui,
-                }}
-              >
-                Al-Baqarah
-              </div>
-              <div style={{ fontSize: 14, color: N.muted, marginTop: 3, fontFamily: N.ui }}>
-                Ayah 153 · The Cow · Juzʾ 2
-              </div>
-            </div>
-            <div className="noor-ar" style={{ fontSize: 40, color: N.goldHi }}>
-              البقرة
-            </div>
-          </div>
-          <div
-            style={{
-              marginTop: 18,
-              height: 6,
-              borderRadius: 3,
-              background: N.bg,
-              overflow: "hidden",
-            }}
-          >
-            <div style={{ width: "54%", height: "100%", background: N.goldGrad }} />
-          </div>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              marginTop: 8,
-              fontSize: 12.5,
-              color: N.faint,
-              fontFamily: N.ui,
-            }}
-          >
-            <span>54% through the surah</span>
-            <span style={{ color: N.gold, fontWeight: 600 }}>Resume →</span>
-          </div>
-        </Link>
+        {/* Continue reading card — driven by the real last-read position */}
+        <ContinueReadingCard surahs={surahs} />
 
         {/* Verse of the day — deterministic per calendar date, resolved client-side */}
         <HomeVerseOfDay

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -19,6 +19,7 @@ import { ReadingTracker } from "./ReadingTracker";
 import { PlanReaderChip } from "./PlanReaderChip";
 import { recordMushafPage } from "../lib/reading-goals";
 import { writeReadingMode } from "../lib/reader-prefs";
+import { writeLastRead } from "../lib/reader-prefs-store";
 
 type ReadingMode = "translation" | "reading" | "reading-tr";
 
@@ -112,7 +113,14 @@ export function SurahReaderClient({
   const [progress, setProgress] = useState(0);
   const [mode, setMode] = useState<ReadingMode>("translation");
   const pages = useMemo(() => pagesOf(surah.number, ayahs), [surah.number, ayahs]);
+  // First āyah of each Madani page — the resume position for the continuous
+  // Reading/Mushaf modes, which have no per-āyah anchors to measure.
+  const pageFirstAya = useMemo(
+    () => new Map(pages.map((p) => [p.page, p.ayahs[0]?.aya ?? 0])),
+    [pages],
+  );
   const lastPageRef = useRef(0);
+  const lastAyaRef = useRef(0);
 
   // Restore persisted reading mode on mount. The mode is restored pre-paint into
   // `data-reading-mode` by the layout bootstrap (the sole sync read, for FOUC).
@@ -150,7 +158,22 @@ export function SurahReaderClient({
       lastPageRef.current = current;
       void recordMushafPage(current);
     }
-  }, []);
+    // Remember the āyah at the current reading line so the home "Continue
+    // reading" card can resume here. Verse mode has precise per-āyah anchors; the
+    // continuous Reading/Mushaf modes fall back to the current page's opening āyah.
+    let aya = 0;
+    box.querySelectorAll<HTMLElement>(".ayah").forEach((el) => {
+      if (el.offsetParent !== null && el.offsetTop <= top) {
+        const n = Number(el.id.split(":")[1]);
+        if (n > aya) aya = n;
+      }
+    });
+    if (aya === 0 && current > 0) aya = pageFirstAya.get(current) ?? 0;
+    if (aya > 0 && aya !== lastAyaRef.current) {
+      lastAyaRef.current = aya;
+      writeLastRead(surah.number, aya, surah.ayahCount);
+    }
+  }, [pageFirstAya, surah.number, surah.ayahCount]);
 
   // Count the opening page so short sūrahs (no scroll) still register.
   useEffect(() => {

--- a/apps/web/src/lib/reader-prefs-store.test.ts
+++ b/apps/web/src/lib/reader-prefs-store.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   readLastRead,
+  readLastReadFull,
   readLoop,
   readScroll,
   readWordByWord,
@@ -29,6 +30,29 @@ describe("reader-prefs-store", () => {
   it("returns null last-read on a malformed value", () => {
     localStorage.setItem("ul.lastRead", "{nope");
     expect(readLastRead()).toBeNull();
+  });
+
+  it("round-trips the last-read āyah position and progress total", () => {
+    writeLastRead(2, 153, 286);
+    expect(readLastReadFull()).toEqual({ surah: 2, aya: 153, total: 286 });
+    expect(readLastRead()).toBe(2);
+  });
+
+  it("preserves the stored āyah when re-opening the same surah (surah-only write)", () => {
+    writeLastRead(2, 153, 286);
+    writeLastRead(2); // reader mount records the surah again
+    expect(readLastReadFull()).toEqual({ surah: 2, aya: 153, total: 286 });
+  });
+
+  it("resets the āyah when the last-read surah changes", () => {
+    writeLastRead(2, 153, 286);
+    writeLastRead(5); // opened a different surah
+    expect(readLastReadFull()).toEqual({ surah: 5 });
+  });
+
+  it("reads back a legacy surah-only record without an āyah", () => {
+    localStorage.setItem("ul.lastRead", JSON.stringify({ surah: 18 }));
+    expect(readLastReadFull()).toEqual({ surah: 18 });
   });
 
   it("round-trips the word-by-word toggle", () => {

--- a/apps/web/src/lib/reader-prefs-store.ts
+++ b/apps/web/src/lib/reader-prefs-store.ts
@@ -14,25 +14,61 @@ const RATE_KEY = "ul.audioRate";
 // Mirrors the event key exported by components/WordByWord.
 const WBW_KEY = "ul.wbw";
 
-/** The surah number the reader last opened, or `null`. */
-export function readLastRead(): number | null {
+/** The last-read position: the surah, the furthest āyah reached, and that
+ *  surah's āyah count at write time (so the home card can show progress). */
+export interface LastRead {
+  surah: number;
+  aya?: number;
+  total?: number;
+}
+
+/** Parse the stored last-read record, tolerating corrupt / peer-synced values.
+ *  Read during render/scroll-restore: a corrupt null would crash on `.surah`;
+ *  a non-number surah must not flow through as a bogus value. */
+function parseLastRead(): LastRead | null {
   try {
     const raw = localStorage.getItem(LAST_READ_KEY);
     if (!raw) return null;
-    // Read during render/scroll-restore: a corrupt/peer-synced null would crash on
-    // `.surah`; a non-number surah must not flow through as a bogus value.
     const v = JSON.parse(raw) as unknown;
-    const surah =
-      v !== null && typeof v === "object" ? (v as { surah?: unknown }).surah : undefined;
-    return typeof surah === "number" ? surah : null;
+    if (v === null || typeof v !== "object") return null;
+    const o = v as { surah?: unknown; aya?: unknown; total?: unknown };
+    if (typeof o.surah !== "number") return null;
+    const rec: LastRead = { surah: o.surah };
+    if (typeof o.aya === "number") rec.aya = o.aya;
+    if (typeof o.total === "number") rec.total = o.total;
+    return rec;
   } catch {
     return null;
   }
 }
 
-export function writeLastRead(surah: number): void {
+/** The surah number the reader last opened, or `null`. */
+export function readLastRead(): number | null {
+  return parseLastRead()?.surah ?? null;
+}
+
+/** The full last-read position (surah + āyah + total), or `null`. */
+export function readLastReadFull(): LastRead | null {
+  return parseLastRead();
+}
+
+/**
+ * Record the last-read position. The reader writes the surah on mount and then
+ * `(surah, aya, total)` as it scrolls. A surah-only write preserves any āyah
+ * already stored for that same surah, so re-opening a surah doesn't reset the
+ * spot before the first scroll refines it.
+ */
+export function writeLastRead(surah: number, aya?: number, total?: number): void {
   try {
-    localStorage.setItem(LAST_READ_KEY, JSON.stringify({ surah }));
+    let rec: LastRead = { surah };
+    if (typeof aya === "number") {
+      rec.aya = aya;
+      if (typeof total === "number") rec.total = total;
+    } else {
+      const prev = parseLastRead();
+      if (prev && prev.surah === surah) rec = prev;
+    }
+    localStorage.setItem(LAST_READ_KEY, JSON.stringify(rec));
   } catch {
     /* storage unavailable */
   }


### PR DESCRIPTION
## Problem

Clicking **Resume** on the home "Continue reading" card always jumped to the **start of the surah**, not where the reader left off.

Two root causes:
- The card in `NoorHomePage.tsx` was **fully hardcoded** — `href="/surah/2"` with static "Al-Baqarah · Ayah 153 · 54%" text — so Resume went to the top of Al-Baqarah regardless of what had been read.
- The store only ever recorded the **surah number** (`writeLastRead(surah)`); the āyah was never tracked, so there was no position to resume to.

## Fix

1. **`reader-prefs-store.ts`** — `writeLastRead(surah, aya?, total?)` now persists `{ surah, aya, total }`; added `readLastReadFull()`. A surah-only write (reader mount) preserves the āyah already stored for the same surah, so re-opening doesn't wipe the spot. Legacy `{surah}` records and corrupt values are still tolerated.
2. **`SurahReaderClient.tsx`** — the existing scroll handler now also records the āyah at the current reading line (precise per-āyah anchors in Verse mode; page-opening āyah in Reading/Mushaf), throttled to āyah changes.
3. **`NoorHomePage.tsx`** — the hardcoded block is replaced by `ContinueReadingCard`, which reads the real position and links to `/surah/{n}#{n}:{aya}`. The already-present `HashHighlighter` scrolls to and highlights that exact āyah. First-time readers (and the pre-hydration render) fall back to "Start reading · Al-Fātiḥah" → `/surah/1`.

Result: Resume now lands on the saved āyah, e.g. `/surah/2#2:153`.

## Tests

- Store round-trip + preserve-on-same-surah + reset-on-surah-change + legacy record.
- `NoorHomePage`: asserts the resume deep link (`/surah/2#2:153`) and the first-time fallback (`/surah/1`).

`pnpm lint`, `pnpm typecheck`, and the full web vitest suite (273 tests) pass locally.