### PR TITLE
fix(reader): resume on the exact āyah, and track recitation

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -436,8 +436,10 @@ html[data-reading-mode="reading-tr"] .mode-reading-tr {
 }
 /* While audio is actively playing, the reciting highlight (.ayah--playing) is
    the single indicator — hide the reading marker so two āyāt are never lit at
-   once (e.g. you scroll ahead while a verse recites). */
-body.audio-playing .ayah--current {
+   once (e.g. you scroll ahead while a verse recites). The `:not(.ayah--playing)`
+   is essential: the reciting āyah carries BOTH classes, and without it this
+   higher-specificity rule would wipe the reciting highlight too. */
+body.audio-playing .ayah--current:not(.ayah--playing) {
   background: transparent;
   box-shadow: none;
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -434,6 +434,13 @@ html[data-reading-mode="reading-tr"] .mode-reading-tr {
   border-radius: 0 10px 10px 0;
   scroll-margin-top: 80px;
 }
+/* While audio is actively playing, the reciting highlight (.ayah--playing) is
+   the single indicator — hide the reading marker so two āyāt are never lit at
+   once (e.g. you scroll ahead while a verse recites). */
+body.audio-playing .ayah--current {
+  background: transparent;
+  box-shadow: none;
+}
 .w {
   transition:
     color 0.1s ease,

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -469,18 +469,23 @@ html[data-reading-mode="reading-tr"] .mode-reading-tr {
   gap: 0.3rem;
 }
 
+/* A brief outline pulse drawing the eye to a deep-linked / resumed āyah. Uses
+   `outline` (not background/box-shadow) so it overlays the persistent
+   .ayah--current marker cleanly instead of fighting it — the old version
+   animated the background to transparent, which wiped the marker mid-flash and
+   then snapped it back ("highlighted → removed → re-highlighted"). */
 .ayah--target {
-  animation: ayah-flash 2.2s ease-out;
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  animation: ayah-flash 1.3s ease-out;
   border-radius: 10px;
 }
 @keyframes ayah-flash {
   0% {
-    background: var(--accent-soft);
-    box-shadow: 0 0 0 1px var(--accent);
+    outline-color: var(--accent);
   }
   100% {
-    background: transparent;
-    box-shadow: none;
+    outline-color: transparent;
   }
 }
 .head-link {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -426,6 +426,14 @@ html[data-reading-mode="reading-tr"] .mode-reading-tr {
   border-radius: 10px;
   box-shadow: 0 0 0 1px var(--accent);
 }
+/* The reader's current āyah — a soft gold margin bar marking where you are. It
+   is saved as the resume point and is where the dock ▶ starts playback from. */
+.ayah--current {
+  background: var(--accent-soft);
+  box-shadow: -4px 0 0 0 var(--accent);
+  border-radius: 0 10px 10px 0;
+  scroll-margin-top: 80px;
+}
 .w {
   transition:
     color 0.1s ease,

--- a/apps/web/src/components/HashHighlighter.tsx
+++ b/apps/web/src/components/HashHighlighter.tsx
@@ -5,22 +5,53 @@ import { useEffect } from "react";
 /** Scrolls to and briefly highlights the ayah named in the URL hash (#sura:aya). */
 export function HashHighlighter() {
   useEffect(() => {
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const clearTimers = () => {
+      for (const t of timers) clearTimeout(t);
+      timers.length = 0;
+    };
+
     function apply() {
       const id = decodeURIComponent(location.hash.slice(1));
       if (!id) return;
       document.querySelectorAll(".ayah--target").forEach((e) => e.classList.remove("ayah--target"));
       const el = document.getElementById(id);
-      if (el) {
-        // restart the flash animation
-        el.classList.remove("ayah--target");
-        void el.offsetWidth;
-        el.classList.add("ayah--target");
-        el.scrollIntoView({ behavior: "smooth", block: "center" });
+      if (!el) return;
+      // restart the flash animation
+      el.classList.remove("ayah--target");
+      void el.offsetWidth;
+      el.classList.add("ayah--target");
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      // Translations and word-by-word load after mount and grow the āyāt above
+      // the target, pushing it down — so the first scroll lands several āyāt
+      // early. Re-centre a few times as the layout settles. A user scroll cancels
+      // the pending corrections (see `cancel`), so we never fight a deliberate move.
+      clearTimers();
+      for (const delay of [150, 400, 800]) {
+        timers.push(
+          setTimeout(() => {
+            const node = document.getElementById(id);
+            if (!node) return;
+            const r = node.getBoundingClientRect();
+            const offCentre = Math.abs((r.top + r.bottom) / 2 - window.innerHeight / 2);
+            if (offCentre > 80) node.scrollIntoView({ block: "center" });
+          }, delay),
+        );
       }
     }
+
     apply();
     window.addEventListener("hashchange", apply);
-    return () => window.removeEventListener("hashchange", apply);
+    window.addEventListener("wheel", clearTimers, { passive: true });
+    window.addEventListener("touchmove", clearTimers, { passive: true });
+    window.addEventListener("keydown", clearTimers);
+    return () => {
+      window.removeEventListener("hashchange", apply);
+      window.removeEventListener("wheel", clearTimers);
+      window.removeEventListener("touchmove", clearTimers);
+      window.removeEventListener("keydown", clearTimers);
+      clearTimers();
+    };
   }, []);
 
   return null;

--- a/apps/web/src/components/HashHighlighter.tsx
+++ b/apps/web/src/components/HashHighlighter.tsx
@@ -6,9 +6,9 @@ import { useEffect } from "react";
 export function HashHighlighter() {
   useEffect(() => {
     const timers: ReturnType<typeof setTimeout>[] = [];
-    const clearTimers = () => {
-      for (const t of timers) clearTimeout(t);
-      timers.length = 0;
+    let userTookOver = false;
+    const cancel = () => {
+      userTookOver = true;
     };
 
     function apply() {
@@ -17,40 +17,43 @@ export function HashHighlighter() {
       document.querySelectorAll(".ayah--target").forEach((e) => e.classList.remove("ayah--target"));
       const el = document.getElementById(id);
       if (!el) return;
-      // restart the flash animation
+      userTookOver = false;
+      // Flash once, then drop the class so it doesn't linger on the āyah.
       el.classList.remove("ayah--target");
       void el.offsetWidth;
       el.classList.add("ayah--target");
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
-      // Translations and word-by-word load after mount and grow the āyāt above
-      // the target, pushing it down — so the first scroll lands several āyāt
-      // early. Re-centre a few times as the layout settles. A user scroll cancels
-      // the pending corrections (see `cancel`), so we never fight a deliberate move.
-      clearTimers();
-      for (const delay of [150, 400, 800]) {
-        timers.push(
-          setTimeout(() => {
-            const node = document.getElementById(id);
-            if (!node) return;
-            const r = node.getBoundingClientRect();
-            const offCentre = Math.abs((r.top + r.bottom) / 2 - window.innerHeight / 2);
-            if (offCentre > 80) node.scrollIntoView({ block: "center" });
-          }, delay),
-        );
-      }
+      timers.push(setTimeout(() => el.classList.remove("ayah--target"), 1500));
+      // Position once, instantly — a single jump, not a smooth scroll that the
+      // async translation layout-shift then fights (which read as "shaky").
+      el.scrollIntoView({ block: "center" });
+      // Translations load after mount and shift the layout; the browser's
+      // scroll-anchoring keeps the āyah in place, so only nudge it back in the
+      // rare case it was actually pushed off-screen — and never after the user
+      // has taken over the scroll.
+      timers.push(
+        setTimeout(() => {
+          if (userTookOver) return;
+          const node = document.getElementById(id);
+          if (!node) return;
+          const r = node.getBoundingClientRect();
+          if (r.bottom < 90 || r.top > window.innerHeight - 90) {
+            node.scrollIntoView({ block: "center" });
+          }
+        }, 650),
+      );
     }
 
     apply();
     window.addEventListener("hashchange", apply);
-    window.addEventListener("wheel", clearTimers, { passive: true });
-    window.addEventListener("touchmove", clearTimers, { passive: true });
-    window.addEventListener("keydown", clearTimers);
+    window.addEventListener("wheel", cancel, { passive: true });
+    window.addEventListener("touchmove", cancel, { passive: true });
+    window.addEventListener("keydown", cancel);
     return () => {
       window.removeEventListener("hashchange", apply);
-      window.removeEventListener("wheel", clearTimers);
-      window.removeEventListener("touchmove", clearTimers);
-      window.removeEventListener("keydown", clearTimers);
-      clearTimers();
+      window.removeEventListener("wheel", cancel);
+      window.removeEventListener("touchmove", cancel);
+      window.removeEventListener("keydown", cancel);
+      for (const t of timers) clearTimeout(t);
     };
   }, []);
 

--- a/apps/web/src/components/ReadingAudio.tsx
+++ b/apps/web/src/components/ReadingAudio.tsx
@@ -76,6 +76,7 @@ export function ReadingAudio({
   reciters,
   variant = "inline",
   onAyah,
+  startVerse,
 }: {
   verses: Verse[];
   reciters: ReciterPlugin[];
@@ -83,6 +84,9 @@ export function ReadingAudio({
   variant?: "inline" | "dock";
   /** Called when an āyah starts playing — lets the reader advance its resume position. */
   onAyah?: (verse: Verse) => void;
+  /** Where a fresh ▶ should begin (the reader's current āyah). Falls back to the
+   *  first verse when it returns null. */
+  startVerse?: () => Verse | null;
 }) {
   const [reciterId, setReciterId] = useState(reciters[0]?.id ?? "");
   const [current, setCurrent] = useState<string | null>(null);
@@ -281,8 +285,11 @@ export function ReadingAudio({
     } else if (current && audio) {
       void audio.play();
       setIsPlaying(true);
-    } else if (versesRef.current[0]) {
-      playAll(versesRef.current[0]);
+    } else {
+      // A fresh ▶ begins at the reader's current āyah (where you are), not the
+      // surah start; fall back to the first verse before anything is marked.
+      const start = startVerse?.() ?? versesRef.current[0];
+      if (start) playAll(start);
     }
   }
 

--- a/apps/web/src/components/ReadingAudio.tsx
+++ b/apps/web/src/components/ReadingAudio.tsx
@@ -75,11 +75,14 @@ export function ReadingAudio({
   verses,
   reciters,
   variant = "inline",
+  onAyah,
 }: {
   verses: Verse[];
   reciters: ReciterPlugin[];
   /** "inline" = compact bar inside content (juzʾ); "dock" = fixed bottom player (surah reader). */
   variant?: "inline" | "dock";
+  /** Called when an āyah starts playing — lets the reader advance its resume position. */
+  onAyah?: (verse: Verse) => void;
 }) {
   const [reciterId, setReciterId] = useState(reciters[0]?.id ?? "");
   const [current, setCurrent] = useState<string | null>(null);
@@ -264,6 +267,7 @@ export function ReadingAudio({
         setCurrent(key);
         setIsPlaying(true);
         highlightAyah(key);
+        onAyah?.(verse);
       },
       () => stop(),
     );

--- a/apps/web/src/components/ReadingAudio.tsx
+++ b/apps/web/src/components/ReadingAudio.tsx
@@ -282,9 +282,13 @@ export function ReadingAudio({
     if (isPlaying && audio) {
       audio.pause();
       setIsPlaying(false);
+      // Drop the reciting highlight on pause so it can't linger on one āyah while
+      // the reader's current marker sits on another (the resume marker takes over).
+      highlightAyah(null);
     } else if (current && audio) {
       void audio.play();
       setIsPlaying(true);
+      highlightAyah(current);
     } else {
       // A fresh ▶ begins at the reader's current āyah (where you are), not the
       // surah start; fall back to the first verse before anything is marked.
@@ -292,6 +296,13 @@ export function ReadingAudio({
       if (start) playAll(start);
     }
   }
+
+  // Flag the body while audio actively plays, so the reader can hide its current
+  // marker and leave the reciting highlight as the sole indicator (see CSS).
+  useEffect(() => {
+    document.body.classList.toggle("audio-playing", isPlaying);
+    return () => document.body.classList.remove("audio-playing");
+  }, [isPlaying]);
 
   useEffect(() => {
     function onClick(event: MouseEvent) {

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -121,6 +121,13 @@ export function SurahReaderClient({
   );
   const lastPageRef = useRef(0);
   const currentAyaRef = useRef(0);
+  const markTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // True only while the *user* is driving the scroll. Programmatic scrolls — the
+  // resume scroll, audio auto-follow, and the browser's scroll-anchoring when
+  // translations load and shift the layout — must NOT move the current-āyah
+  // marker, or it flickers between āyāt. Audio sets the marker directly instead.
+  const userScrollingRef = useRef(false);
+  const userIdleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Mark, persist, and remember the reader's current āyah. The marker (a soft
   // gold bar) shows where you are; the same āyah is saved as the resume point
@@ -137,6 +144,56 @@ export function SurahReaderClient({
     },
     [surah.number, surah.ayahCount],
   );
+
+  // Scroll-driven marking is debounced to the *settled* position, so the marker
+  // doesn't race through āyāt during a programmatic resume scroll / re-centre.
+  const scheduleMark = useCallback(
+    (aya: number) => {
+      if (markTimerRef.current) clearTimeout(markTimerRef.current);
+      markTimerRef.current = setTimeout(() => markCurrentAya(aya), 140);
+    },
+    [markCurrentAya],
+  );
+
+  // Mark the resumed / deep-linked āyah immediately on open, so the marker lands
+  // on the right āyah from the start (the scroll then settles onto it) rather
+  // than appearing only after the page stops moving.
+  useEffect(() => {
+    const m = /^(\d+):(\d+)$/.exec(decodeURIComponent(window.location.hash.slice(1)));
+    if (m && Number(m[1]) === surah.number) markCurrentAya(Number(m[2]));
+    return () => {
+      if (markTimerRef.current) clearTimeout(markTimerRef.current);
+    };
+  }, [surah.number, markCurrentAya]);
+
+  // Track genuine user scrolling. A real input (wheel / touch / arrow keys)
+  // opens a short window during which scroll events may move the marker; it
+  // closes ~1s after the last input, so later programmatic scrolls don't.
+  useEffect(() => {
+    const box = scrollRef.current;
+    if (!box) return;
+    const wake = () => {
+      userScrollingRef.current = true;
+      if (userIdleRef.current) clearTimeout(userIdleRef.current);
+      userIdleRef.current = setTimeout(() => {
+        userScrollingRef.current = false;
+      }, 1000);
+    };
+    const keys = (e: KeyboardEvent) => {
+      if (["ArrowDown", "ArrowUp", "PageDown", "PageUp", "Home", "End", " "].includes(e.key)) wake();
+    };
+    box.addEventListener("wheel", wake, { passive: true });
+    box.addEventListener("touchstart", wake, { passive: true });
+    box.addEventListener("touchmove", wake, { passive: true });
+    window.addEventListener("keydown", keys);
+    return () => {
+      box.removeEventListener("wheel", wake);
+      box.removeEventListener("touchstart", wake);
+      box.removeEventListener("touchmove", wake);
+      window.removeEventListener("keydown", keys);
+      if (userIdleRef.current) clearTimeout(userIdleRef.current);
+    };
+  }, []);
 
   // Restore persisted reading mode on mount. The mode is restored pre-paint into
   // `data-reading-mode` by the layout bootstrap (the sole sync read, for FOUC).
@@ -188,8 +245,9 @@ export function SurahReaderClient({
       }
     });
     if (aya === 0 && current > 0) aya = pageFirstAya.get(current) ?? 0;
-    if (aya > 0) markCurrentAya(aya);
-  }, [pageFirstAya, markCurrentAya]);
+    // Only a user-driven scroll moves the marker; programmatic scrolls don't.
+    if (aya > 0 && userScrollingRef.current) scheduleMark(aya);
+  }, [pageFirstAya, scheduleMark]);
 
   // Count the opening page so short sūrahs (no scroll) still register.
   useEffect(() => {

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -120,7 +120,23 @@ export function SurahReaderClient({
     [pages],
   );
   const lastPageRef = useRef(0);
-  const lastAyaRef = useRef(0);
+  const currentAyaRef = useRef(0);
+
+  // Mark, persist, and remember the reader's current āyah. The marker (a soft
+  // gold bar) shows where you are; the same āyah is saved as the resume point
+  // and is where the dock ▶ starts playback from.
+  const markCurrentAya = useCallback(
+    (aya: number) => {
+      if (aya <= 0 || aya === currentAyaRef.current) return;
+      currentAyaRef.current = aya;
+      document
+        .querySelectorAll(".ayah--current")
+        .forEach((el) => el.classList.remove("ayah--current"));
+      document.getElementById(`${surah.number}:${aya}`)?.classList.add("ayah--current");
+      writeLastRead(surah.number, aya, surah.ayahCount);
+    },
+    [surah.number, surah.ayahCount],
+  );
 
   // Restore persisted reading mode on mount. The mode is restored pre-paint into
   // `data-reading-mode` by the layout bootstrap (the sole sync read, for FOUC).
@@ -172,11 +188,8 @@ export function SurahReaderClient({
       }
     });
     if (aya === 0 && current > 0) aya = pageFirstAya.get(current) ?? 0;
-    if (aya > 0 && aya !== lastAyaRef.current) {
-      lastAyaRef.current = aya;
-      writeLastRead(surah.number, aya, surah.ayahCount);
-    }
-  }, [pageFirstAya, surah.number, surah.ayahCount]);
+    if (aya > 0) markCurrentAya(aya);
+  }, [pageFirstAya, markCurrentAya]);
 
   // Count the opening page so short sūrahs (no scroll) still register.
   useEffect(() => {
@@ -546,11 +559,12 @@ export function SurahReaderClient({
         verses={ayahs.map((a) => ({ sura: surah.number, aya: a.aya }))}
         reciters={reciters}
         variant="dock"
-        onAyah={(v) => {
-          // Listening advances the resume position too, not just scrolling.
-          lastAyaRef.current = v.aya;
-          writeLastRead(v.sura, v.aya, surah.ayahCount);
-        }}
+        // Listening advances the current/resume āyah too, not just scrolling.
+        onAyah={(v) => markCurrentAya(v.aya)}
+        // The dock ▶ starts from the āyah you're on, not the surah start.
+        startVerse={() =>
+          currentAyaRef.current > 0 ? { sura: surah.number, aya: currentAyaRef.current } : null
+        }
       />
     </>
   );

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -158,12 +158,15 @@ export function SurahReaderClient({
       lastPageRef.current = current;
       void recordMushafPage(current);
     }
-    // Remember the āyah at the current reading line so the home "Continue
-    // reading" card can resume here. Verse mode has precise per-āyah anchors; the
-    // continuous Reading/Mushaf modes fall back to the current page's opening āyah.
+    // Resume position: the āyah straddling the vertical centre of the viewport.
+    // Record the centre (not the top), because resuming re-centres the āyah
+    // (HashHighlighter) — anchoring to the top made resume land several āyāt
+    // earlier. Verse mode has precise per-āyah anchors; the continuous
+    // Reading/Mushaf modes fall back to the current page's opening āyah.
+    const readingLine = box.scrollTop + box.clientHeight / 2;
     let aya = 0;
     box.querySelectorAll<HTMLElement>(".ayah").forEach((el) => {
-      if (el.offsetParent !== null && el.offsetTop <= top) {
+      if (el.offsetParent !== null && el.offsetTop <= readingLine) {
         const n = Number(el.id.split(":")[1]);
         if (n > aya) aya = n;
       }
@@ -543,6 +546,11 @@ export function SurahReaderClient({
         verses={ayahs.map((a) => ({ sura: surah.number, aya: a.aya }))}
         reciters={reciters}
         variant="dock"
+        onAyah={(v) => {
+          // Listening advances the resume position too, not just scrolling.
+          lastAyaRef.current = v.aya;
+          writeLastRead(v.sura, v.aya, surah.ayahCount);
+        }}
       />
     </>
   );


### PR DESCRIPTION
Follow-up to #179. Resume still landed several āyāt early, and audio playback didn't advance the saved position.

## Issue 1 — resume lands several āyāt early (e.g. on 30, resumes at ~26)

Two compounding causes:

- **Anchor mismatch.** The reader recorded the āyah at the **top** of the viewport (`scrollTop + 80`) while Resume **re-centres** it (`HashHighlighter`). Now it records the āyah at the **viewport centre**, so record and restore use the same anchor. (`SurahReaderClient.tsx`)
- **Async layout shift.** Translations and word-by-word are client-fetched, so the āyāt above the target start as one-line skeletons and grow after mount, shoving the target down right after the first scroll. `HashHighlighter` now **re-centres a few times (150/400/800 ms)** as the layout settles, and **cancels** the pending corrections on a user scroll/swipe/keypress so it never fights a deliberate move. (`HashHighlighter.tsx`)

## Issue 2 — audio recitation doesn't advance the resume position

`ReadingAudio` gains an optional `onAyah(verse)` callback, fired as each āyah starts playing. The surah reader uses it to record `{ surah, aya, total }`, so **listening** moves the "Continue reading" spot too, not just scrolling. (`ReadingAudio.tsx`, `SurahReaderClient.tsx`)

## Notes

This is a behavioural/UX fix; jsdom has no layout, so the centre/settle logic isn't meaningfully unit-testable — best verified on a real device/preview. `pnpm lint`, `pnpm typecheck`, and the full web vitest suite (273 tests) pass locally.