### PR TITLE
feat(reader): per-āyah transliteration toggle (#150)

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -46,7 +46,7 @@ required notices and ingest steps.
 | [api.quran.com](https://quran.com) (Quran.com API v4) | **word-by-word** word meanings in the reader popover; verse audio metadata | word-by-word lineage = Quranic Arabic Corpus morphology + **Shaikh & Khatri** English meanings (the latter is _display-only, not redistributable_). Fetched per-tap in the browser; we do not store or redistribute it. **A written grant would be required before any bundling** (permission requested: [TarteelAI/quranic-universal-library#638](https://github.com/TarteelAI/quranic-universal-library/issues/638)); until then, runtime display only. |
 | [verses.quran.com](https://quran.com) | recitation audio (web) | streamed to the client |
 | [everyayah.com](https://everyayah.com) | recitation audio (reciter plugins) | streamed to the client |
-| [jsDelivr → `fawazahmed0/quran-api`](https://github.com/fawazahmed0/quran-api) | translation text (runtime/CDN) | per-edition (see §1) |
+| [jsDelivr → `fawazahmed0/quran-api`](https://github.com/fawazahmed0/quran-api) | translation text (runtime/CDN); per-āyah **transliteration** line (`ara-quran-la`, #150) | per-edition (see §1); transliteration is Tanzil, **CC-BY-3.0**, verbatim |
 | [Google Fonts](https://fonts.google.com) | web UI typefaces | fetched at build (`next/font`) |
 
 ## 4. Code

--- a/apps/mobile/src/components/AyahView.tsx
+++ b/apps/mobile/src/components/AyahView.tsx
@@ -23,6 +23,8 @@ interface Props {
   arabic: string;
   words: string[];
   translations: TrLine[];
+  /** Latin transliteration line shown under the Arabic (#150); null when off. */
+  transliteration?: string | null;
   activeWord: number;
   playing: boolean;
   scale: number;
@@ -53,6 +55,7 @@ function AyahViewImpl({
   arabic,
   words,
   translations,
+  transliteration,
   activeWord,
   playing,
   scale,
@@ -134,6 +137,12 @@ function AyahViewImpl({
             : arabic}
       </Text>
 
+      {transliteration && !peekHideTr ? (
+        <Text style={[styles.translit, { fontSize: 14 * scale, lineHeight: 22 * scale }]}>
+          {transliteration}
+        </Text>
+      ) : null}
+
       {!peekHideTr &&
         translations.map((t) => (
         <View key={t.id} style={styles.tr}>
@@ -179,6 +188,7 @@ function makeStyles(c: Palette) {
     wordActive: { color: c.accent },
     // Concealed word: keep its footprint (a hint of length) but hide the glyphs.
     wordHidden: { color: "transparent", backgroundColor: c.borderSoft },
+    translit: { color: c.faint, marginTop: 10, fontStyle: "italic", fontFamily: FONT.medium },
     tr: { marginTop: 12 },
     trName: { color: c.faint, fontSize: 12, marginBottom: 3, fontFamily: FONT.medium },
     trText: { color: c.muted },

--- a/apps/mobile/src/components/ReaderControls.tsx
+++ b/apps/mobile/src/components/ReaderControls.tsx
@@ -15,12 +15,16 @@ export function ReaderControls({
   onMode,
   scale,
   onScale,
+  transliteration,
+  onTransliteration,
   onManage,
 }: {
   mode: ReadingMode;
   onMode: (m: ReadingMode) => void;
   scale: number;
   onScale: (n: number) => void;
+  transliteration: boolean;
+  onTransliteration: (on: boolean) => void;
   onManage: () => void;
 }) {
   const { colors } = useTheme();
@@ -56,9 +60,22 @@ export function ReaderControls({
             <Text style={styles.scaleText}>A+</Text>
           </Pressable>
         </View>
-        <Pressable style={styles.manage} onPress={onManage}>
-          <Text style={styles.manageText}>⚙ Translations</Text>
-        </Pressable>
+        <View style={styles.rightBtns}>
+          <Pressable
+            style={[styles.toggle, transliteration && styles.toggleOn]}
+            onPress={() => onTransliteration(!transliteration)}
+            accessibilityRole="switch"
+            accessibilityState={{ checked: transliteration }}
+            accessibilityLabel="Transliteration"
+          >
+            <Text style={[styles.toggleText, transliteration && styles.toggleTextOn]}>
+              Aa Translit
+            </Text>
+          </Pressable>
+          <Pressable style={styles.manage} onPress={onManage}>
+            <Text style={styles.manageText}>⚙ Translations</Text>
+          </Pressable>
+        </View>
       </View>
     </View>
   );
@@ -79,6 +96,7 @@ function makeStyles(c: Palette) {
     segText: { color: c.muted, fontSize: 13, fontWeight: "600" },
     segTextOn: { color: c.accent },
     rightRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+    rightBtns: { flexDirection: "row", gap: 8 },
     scale: { flexDirection: "row", gap: 8 },
     scaleBtn: {
       paddingVertical: 6,
@@ -98,5 +116,16 @@ function makeStyles(c: Palette) {
       backgroundColor: c.bgElev,
     },
     manageText: { color: c.accent, fontSize: 13, fontWeight: "600" },
+    toggle: {
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bgElev,
+    },
+    toggleOn: { borderColor: c.accent, backgroundColor: c.accentSoft },
+    toggleText: { color: c.muted, fontSize: 13, fontWeight: "600" },
+    toggleTextOn: { color: c.accent },
   });
 }

--- a/apps/mobile/src/screens/JuzReaderScreen.tsx
+++ b/apps/mobile/src/screens/JuzReaderScreen.tsx
@@ -18,7 +18,7 @@ import { useSettings } from "../state/SettingsContext";
 import { useSurahAudio, verseKeyOf } from "../audio/useSurahAudio";
 import { AudioRangeControls } from "../components/AudioRangeControls";
 import { MemorizeBar } from "../components/MemorizeBar";
-import { DEFAULT_EDITION } from "../types";
+import { DEFAULT_EDITION, TRANSLIT_EDITION } from "../types";
 import type { ReadStackParamList } from "../navigation/types";
 
 type Props = NativeStackScreenProps<ReadStackParamList, "JuzReader">;
@@ -28,6 +28,8 @@ interface Line {
   aya: number;
   arabic: string;
   translation: string;
+  /** Latin transliteration line (#150); empty when the toggle is off. */
+  transliteration: string;
   surahHeader?: string;
 }
 
@@ -50,7 +52,7 @@ function juzRange(juz: number): { sura: number; from: number; toExclusive: numbe
 export function JuzReaderScreen({ route }: Props) {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
-  const { editions, readingTranslation, reciterId, scale } = useSettings();
+  const { editions, readingTranslation, reciterId, scale, transliteration } = useSettings();
   const reciter = RECITERS.find((r) => r.id === reciterId) ?? RECITER;
   const audio = useSurahAudio(reciter);
 
@@ -79,11 +81,15 @@ export function JuzReaderScreen({ route }: Props) {
     const parts = juzRange(Number(juz));
     Promise.all(
       parts.map(async (p) => {
-        const [surah, tr] = await Promise.all([
+        const [surah, tr, translit] = await Promise.all([
           api.getSurah(p.sura),
           api.getCatalogTranslation(edition, p.sura).catch(() => []),
+          transliteration
+            ? api.getCatalogTranslation(TRANSLIT_EDITION, p.sura).catch(() => [])
+            : Promise.resolve([]),
         ]);
         const trByAya = new Map(tr.map((t) => [t.aya, t.text]));
+        const translitByAya = new Map(translit.map((t) => [t.aya, t.text]));
         const inRange = surah.ayahs.filter(
           (a) => a.aya >= p.from && (p.toExclusive === null || a.aya < p.toExclusive),
         );
@@ -93,6 +99,7 @@ export function JuzReaderScreen({ route }: Props) {
             aya: a.aya,
             arabic: a.text,
             translation: trByAya.get(a.aya) ?? "",
+            transliteration: translitByAya.get(a.aya) ?? "",
             surahHeader:
               i === 0 ? `${surah.surah.transliteration} · ${surah.surah.englishName}` : undefined,
           }),
@@ -107,7 +114,7 @@ export function JuzReaderScreen({ route }: Props) {
       active = false;
       audio.stop();
     };
-  }, [juz, edition]);
+  }, [juz, edition, transliteration]);
 
   const verses = useMemo(() => (lines ?? []).map((l) => ({ sura: l.sura, aya: l.aya })), [lines]);
 
@@ -226,6 +233,11 @@ export function JuzReaderScreen({ route }: Props) {
                   : l.arabic}{" "}
                 <Text style={styles.marker}>﴿{l.aya}﴾</Text>
               </Text>
+              {l.transliteration && !hideTr ? (
+                <Text style={[styles.translit, { fontSize: 14 * scale, lineHeight: 22 * scale }]}>
+                  {l.transliteration}
+                </Text>
+              ) : null}
               {l.translation && !hideTr ? (
                 <Text style={[styles.tr, { fontSize: 15 * scale, lineHeight: 23 * scale }]}>
                   {l.translation}
@@ -288,6 +300,7 @@ function makeStyles(c: Palette) {
     arabic: { color: c.fg, textAlign: "right", writingDirection: "rtl", fontFamily: FONT.ar },
     wordHidden: { color: "transparent", backgroundColor: c.borderSoft },
     marker: { color: c.accent, fontSize: 17, fontFamily: FONT.ar },
+    translit: { color: c.faint, marginTop: 10, fontStyle: "italic" },
     tr: { color: c.fg, marginTop: 10 },
   });
 }

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -30,7 +30,7 @@ import { FONT } from "../fonts";
 import { useSettings } from "../state/SettingsContext";
 import { useLibrary } from "../state/LibraryContext";
 import { useSurahAudio, verseKeyOf } from "../audio/useSurahAudio";
-import { DEFAULT_EDITION } from "../types";
+import { DEFAULT_EDITION, TRANSLIT_EDITION } from "../types";
 import { ReaderControls } from "../components/ReaderControls";
 import { AudioRangeControls } from "../components/AudioRangeControls";
 import { MemorizeBar } from "../components/MemorizeBar";
@@ -56,11 +56,13 @@ export function SurahReaderScreen({ navigation, route }: Props) {
     readingTranslation,
     reciterId,
     scale,
+    transliteration,
     catalogue,
     setEditions,
     setReadingMode,
     setReadingTranslation,
     setScale,
+    setTransliteration,
   } = settings;
   const { setLastRead, isBookmarked, toggleBookmark } = useLibrary();
 
@@ -70,6 +72,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
   const [meta, setMeta] = useState<Surah | null>(null);
   const [ayahs, setAyahs] = useState<Ayah[] | null>(null);
   const [trMap, setTrMap] = useState<Map<string, Map<number, string>>>(new Map());
+  const [translitMap, setTranslitMap] = useState<Map<number, string>>(new Map());
   const [error, setError] = useState(false);
   const [managerOpen, setManagerOpen] = useState(false);
 
@@ -182,6 +185,24 @@ export function SurahReaderScreen({ navigation, route }: Props) {
     };
   }, [n, editions]);
 
+  // Fetch the transliteration edition for this surah only while the toggle is on.
+  useEffect(() => {
+    if (!transliteration) {
+      setTranslitMap(new Map());
+      return;
+    }
+    let active = true;
+    api
+      .getCatalogTranslation(TRANSLIT_EDITION, n)
+      .then((rows) => {
+        if (active) setTranslitMap(new Map(rows.map((t) => [t.aya, t.text])));
+      })
+      .catch(() => active && setTranslitMap(new Map()));
+    return () => {
+      active = false;
+    };
+  }, [n, transliteration]);
+
   const verses = useMemo(() => (ayahs ?? []).map((a) => ({ sura: n, aya: a.aya })), [ayahs, n]);
   const metaById = useMemo(() => new Map(catalogue.map((e) => [e.id, e])), [catalogue]);
 
@@ -206,11 +227,12 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         key: verseKeyOf({ sura: n, aya: a.aya }),
         arabic: a.text,
         words: a.text.split(" "),
+        transliteration: transliteration ? (translitMap.get(a.aya) ?? null) : null,
         translations: editions
           .map((id) => trLineFor(id, a.aya))
           .filter((x): x is TrLine => x !== null),
       })),
-    [ayahs, editions, trMap, metaById, n],
+    [ayahs, editions, trMap, metaById, n, transliteration, translitMap],
   );
 
   // Peek geometry: each āyah's word count and the global index of its first word,
@@ -261,6 +283,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         arabic={item.arabic}
         words={item.words}
         translations={item.translations}
+        transliteration={item.transliteration}
         activeWord={playingKey === item.key ? activeWord : -1}
         playing={playingKey === item.key}
         scale={scale}
@@ -377,6 +400,8 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         onMode={setReadingMode}
         scale={scale}
         onScale={setScale}
+        transliteration={transliteration}
+        onTransliteration={setTransliteration}
         onManage={() => setManagerOpen(true)}
       />
 
@@ -460,7 +485,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
           data={rows}
           keyExtractor={(r) => r.key}
           renderItem={renderItem}
-          extraData={`${playingKey ?? ""}:${activeWord}:${scale}:${peek}:${revealed}:${peekExtra.size}:${hideTr}`}
+          extraData={`${playingKey ?? ""}:${activeWord}:${scale}:${peek}:${revealed}:${peekExtra.size}:${hideTr}:${transliteration}:${translitMap.size}`}
           contentContainerStyle={styles.content}
           onViewableItemsChanged={onViewable}
           viewabilityConfig={viewabilityConfig}

--- a/apps/mobile/src/state/SettingsContext.tsx
+++ b/apps/mobile/src/state/SettingsContext.tsx
@@ -29,6 +29,8 @@ interface SettingsValue {
   /** Editions shown side by side in the per-āyah tafsir panel (#141); [] = just tafsirId. */
   tafsirCompare: string[];
   scale: number;
+  /** Show the per-āyah Latin transliteration line under the Arabic (#150). */
+  transliteration: boolean;
   catalogue: Translation[];
   tafsirs: TafsirMeta[];
   setEditions: (ids: string[]) => void;
@@ -38,6 +40,7 @@ interface SettingsValue {
   setTafsirId: (id: string) => void;
   setTafsirCompare: (ids: string[]) => void;
   setScale: (scale: number) => void;
+  setTransliteration: (on: boolean) => void;
 }
 
 const SettingsContext = createContext<SettingsValue | null>(null);
@@ -52,6 +55,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [tafsirId, setTafsirIdState] = useState<string>(TAFSIRS[0].id);
   const [tafsirCompare, setTafsirCompareState] = useState<string[]>([]);
   const [scale, setScaleState] = useState<number>(1);
+  const [transliteration, setTransliterationState] = useState<boolean>(false);
   const [catalogue, setCatalogue] = useState<Translation[]>([]);
   const [tafsirs, setTafsirs] = useState<TafsirMeta[]>([]);
 
@@ -64,6 +68,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       if (s.reciter) setReciterIdState(s.reciter);
       if (s.tafsir) setTafsirIdState(s.tafsir);
       if (s.scale != null) setScaleState(clampScale(s.scale));
+      if (s.transliteration != null) setTransliterationState(s.transliteration);
     });
     void readTafsirCompare().then(setTafsirCompareState);
     void api
@@ -113,6 +118,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     void store.writeScale(clamped);
   }, []);
 
+  const setTransliteration = useCallback((on: boolean) => {
+    setTransliterationState(on);
+    void store.writeTransliteration(on);
+  }, []);
+
   const value = useMemo<SettingsValue>(
     () => ({
       editions,
@@ -122,6 +132,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       tafsirId,
       tafsirCompare,
       scale,
+      transliteration,
       catalogue,
       tafsirs,
       setEditions,
@@ -131,6 +142,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setTafsirId,
       setTafsirCompare,
       setScale,
+      setTransliteration,
     }),
     [
       editions,
@@ -140,6 +152,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       tafsirId,
       tafsirCompare,
       scale,
+      transliteration,
       catalogue,
       tafsirs,
       setEditions,
@@ -149,6 +162,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setTafsirId,
       setTafsirCompare,
       setScale,
+      setTransliteration,
     ],
   );
 

--- a/apps/mobile/src/state/settings-store.ts
+++ b/apps/mobile/src/state/settings-store.ts
@@ -10,6 +10,7 @@ import {
   KEYS,
   getJSON,
   getString,
+  isBoolean,
   isFiniteNumber,
   isStringArray,
   setJSON,
@@ -18,15 +19,17 @@ import {
 
 export const mobileSettingsStore: SettingsStore = {
   read: async (): Promise<StoredSettings> => {
-    const [editions, readingMode, readingTranslation, reciter, tafsir, scale] = await Promise.all([
-      getJSON<string[] | null>(KEYS.editions, null, isStringArray),
-      getString(KEYS.readingMode),
-      getString(KEYS.readingTranslation),
-      getString(KEYS.reciter),
-      getString(KEYS.tafsir),
-      getJSON<number | null>(KEYS.scale, null, isFiniteNumber),
-    ]);
-    return { editions, readingMode, readingTranslation, reciter, tafsir, scale };
+    const [editions, readingMode, readingTranslation, reciter, tafsir, scale, transliteration] =
+      await Promise.all([
+        getJSON<string[] | null>(KEYS.editions, null, isStringArray),
+        getString(KEYS.readingMode),
+        getString(KEYS.readingTranslation),
+        getString(KEYS.reciter),
+        getString(KEYS.tafsir),
+        getJSON<number | null>(KEYS.scale, null, isFiniteNumber),
+        getJSON<boolean | null>(KEYS.transliteration, null, isBoolean),
+      ]);
+    return { editions, readingMode, readingTranslation, reciter, tafsir, scale, transliteration };
   },
   writeEditions: (ids) => setJSON(KEYS.editions, ids),
   writeReadingMode: (mode) => setString(KEYS.readingMode, mode),
@@ -34,4 +37,5 @@ export const mobileSettingsStore: SettingsStore = {
   writeReciter: (id) => setString(KEYS.reciter, id),
   writeTafsir: (id) => setString(KEYS.tafsir, id),
   writeScale: (scale) => setJSON(KEYS.scale, scale),
+  writeTransliteration: (on) => setJSON(KEYS.transliteration, on),
 };

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -14,6 +14,7 @@ export const KEYS = {
   reciter: "ul.reciter",
   audioRate: "ul.audioRate",
   scale: "ul.scale",
+  transliteration: "ul.transliteration",
   theme: "ul.theme",
   bookmarks: "ul.bookmarks",
   collections: "ul.collections",
@@ -75,6 +76,8 @@ export const isFiniteNumber = (v: unknown): boolean => typeof v === "number" && 
 /** A string[] — guards list prefs (e.g. editions). */
 export const isStringArray = (v: unknown): boolean =>
   Array.isArray(v) && v.every((x) => typeof x === "string");
+/** A boolean — guards on/off prefs (e.g. transliteration). */
+export const isBoolean = (v: unknown): boolean => typeof v === "boolean";
 
 export async function setJSON(key: string, value: unknown): Promise<void> {
   try {

--- a/apps/mobile/src/types.ts
+++ b/apps/mobile/src/types.ts
@@ -5,5 +5,9 @@ export type ReadingMode = "translation" | "reading" | "reading-tr";
 export const DEFAULT_EDITION = "eng-mustafakhattaba";
 export const DEFAULT_EDITIONS = [DEFAULT_EDITION];
 
+// The catalogue edition for the per-āyah transliteration line (#150) — Tanzil's
+// verbatim Latin transliteration (CC-BY 3.0), fetched at runtime like any edition.
+export const TRANSLIT_EDITION = "ara-quran-la";
+
 export const MIN_SCALE = 0.8;
 export const MAX_SCALE = 1.6;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1873,6 +1873,13 @@ body.peek-on.peek-hide-tr .ayah-tr {
   font-size: 0.8rem;
   margin-inline-end: 0.4rem;
 }
+/* Latin transliteration line (#150), shown between the Arabic and translations. */
+.ayah-translit {
+  color: var(--faint);
+  font-style: italic;
+  font-size: calc(0.95rem * var(--reading-scale, 1));
+  margin-bottom: 0.35rem;
+}
 
 /* ---- Nav ---- */
 .reader-nav {

--- a/apps/web/src/app/juz/[number]/page.tsx
+++ b/apps/web/src/app/juz/[number]/page.tsx
@@ -14,6 +14,7 @@ import { ReadingModeToggle } from "../../../components/ReadingModeToggle";
 import { EditionManager } from "../../../components/EditionManager";
 import { ReadingTranslationPicker } from "../../../components/ReadingTranslationPicker";
 import { AyahTranslations } from "../../../components/AyahTranslations";
+import { AyahTransliteration } from "../../../components/AyahTransliteration";
 import { AyahStar } from "../../../components/AyahStar";
 import { ReadingTranslationFlow } from "../../../components/ReadingTranslationFlow";
 import { ReaderShortcuts } from "../../../components/ReaderShortcuts";
@@ -179,6 +180,7 @@ export default async function JuzReaderPage({ params }: { params: Promise<{ numb
                     ﴿{toArabicDigits(ayah.aya)}﴾
                   </button>
                 </p>
+                <AyahTransliteration surah={section.surah.number} aya={ayah.aya} />
                 <AyahTranslations surah={section.surah.number} aya={ayah.aya} />
                 <div className="ayah-actions">
                   <button

--- a/apps/web/src/components/AyahTransliteration.tsx
+++ b/apps/web/src/components/AyahTransliteration.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { TRANSLIT_EDITION, TRANSLIT_KEY, readTransliteration } from "../lib/transliteration";
+import { fetchEditionSurah } from "../lib/catalogue";
+
+/**
+ * The Latin transliteration line for one āyah (#150), shown under the Arabic when
+ * the reader enables it. The text is fetched once per surah from the runtime
+ * catalogue (memoised by `fetchEditionSurah`) and re-checked when the toggle
+ * broadcasts `ul.transliteration`. Renders nothing when the toggle is off or the
+ * edition has no line for this āyah.
+ */
+export function AyahTransliteration({ surah, aya }: { surah: number; aya: number }) {
+  const [text, setText] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      if (!(await readTransliteration())) {
+        if (active) setText(null);
+        return;
+      }
+      const map = await fetchEditionSurah(TRANSLIT_EDITION, surah);
+      if (active) setText(map.get(aya) ?? null);
+    }
+    void load();
+    const onChange = () => void load();
+    window.addEventListener(TRANSLIT_KEY, onChange);
+    return () => {
+      active = false;
+      window.removeEventListener(TRANSLIT_KEY, onChange);
+    };
+  }, [surah, aya]);
+
+  if (!text) return null;
+  return (
+    <p className="ayah-translit" dir="ltr" lang="la">
+      {text}
+    </p>
+  );
+}

--- a/apps/web/src/components/ReaderToolbar.tsx
+++ b/apps/web/src/components/ReaderToolbar.tsx
@@ -9,6 +9,7 @@ import { fetchCatalogue } from "../lib/catalogue";
 import { readBookmarks, toggleBookmark as toggleBm } from "../lib/bookmarks";
 import { readReciter, readScale, writeReciter, writeScale } from "../lib/reader-prefs";
 import { readWordByWord, writeLastRead, writeWordByWord } from "../lib/reader-prefs-store";
+import { readTransliteration, writeTransliteration } from "../lib/transliteration";
 import { TranslationSettings } from "./TranslationSettings";
 import { TafsirPicker } from "./TafsirPicker";
 import { WBW_KEY } from "./WordByWord";
@@ -49,6 +50,7 @@ export function ReaderToolbar({
   const [bookmarked, setBookmarked] = useState(false);
   const [reciterId, setReciterId] = useState(reciters[0]?.id ?? "");
   const [wbw, setWbw] = useState(false);
+  const [translit, setTranslit] = useState(false);
   const [managing, setManaging] = useState(false);
   const [catalogue, setCatalogue] = useState<EditionChoice[]>([]);
   const [selected, setSelected] = useState<Set<string>>(() => new Set(DEFAULT_EDITIONS));
@@ -66,6 +68,7 @@ export function ReaderToolbar({
     const wbwOn = readWordByWord();
     setWbw(wbwOn);
     document.body.classList.toggle("wbw-on", wbwOn);
+    void readTransliteration().then(setTranslit);
     void readEditions().then((ids) => setSelected(new Set(ids)));
     void fetchCatalogue().then(setCatalogue);
   }, [surahNumber, reciters]);
@@ -76,6 +79,12 @@ export function ReaderToolbar({
     document.body.classList.toggle("wbw-on", next);
     writeWordByWord(next);
     window.dispatchEvent(new CustomEvent(WBW_KEY, { detail: next }));
+  }
+
+  function toggleTranslit() {
+    const next = !translit;
+    setTranslit(next);
+    void writeTransliteration(next); // persists + broadcasts `ul.transliteration`
   }
 
   function changeScale(delta: number) {
@@ -213,6 +222,34 @@ export function ReaderToolbar({
                 <Icon name="type" size={15} color={wbw ? N.gold : N.muted} /> Word by word
               </span>
               {wbw && <Icon name="check" size={15} color={N.gold} />}
+            </button>
+
+            <button
+              type="button"
+              onClick={toggleTranslit}
+              aria-pressed={translit}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 10,
+                width: "100%",
+                marginTop: 8,
+                padding: "9px 11px",
+                borderRadius: 10,
+                border: `1px solid ${translit ? N.gold : N.border}`,
+                background: translit ? N.goldSoft : N.card,
+                color: translit ? N.gold : N.fg,
+                cursor: "pointer",
+                fontFamily: N.ui,
+                fontSize: 13.5,
+                fontWeight: 600,
+              }}
+            >
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                <Icon name="globe" size={15} color={translit ? N.gold : N.muted} /> Transliteration
+              </span>
+              {translit && <Icon name="check" size={15} color={N.gold} />}
             </button>
 
             {tafsirs.length > 1 && (

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { type ReciterPlugin, pageNumberOf } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
 import { AyahTranslations } from "./AyahTranslations";
+import { AyahTransliteration } from "./AyahTransliteration";
 import { AyahActions } from "./AyahActions";
 import { AyahStar } from "./AyahStar";
 import { ReadingAudio } from "./ReadingAudio";
@@ -484,6 +485,7 @@ export function SurahReaderClient({
                           ﴿{toArabicDigits(ayah.aya)}﴾
                         </button>
                       </p>
+                      <AyahTransliteration surah={surah.number} aya={ayah.aya} />
                       <AyahTranslations surah={surah.number} aya={ayah.aya} />
                       <AyahActions surah={surah.number} aya={ayah.aya} tafsirs={tafsirs} />
                     </div>

--- a/apps/web/src/lib/settings-store.test.ts
+++ b/apps/web/src/lib/settings-store.test.ts
@@ -13,6 +13,7 @@ describe("webSettingsStore", () => {
       reciter: null,
       tafsir: null,
       scale: null,
+      transliteration: null,
     });
   });
 
@@ -23,6 +24,7 @@ describe("webSettingsStore", () => {
     await store.writeReciter("alafasy");
     await store.writeTafsir("ar-muyassar");
     await store.writeScale(1.4);
+    await store.writeTransliteration(true);
 
     const s = await store.read();
     expect(s.editions).toEqual(["eng-sahih"]);
@@ -31,6 +33,7 @@ describe("webSettingsStore", () => {
     expect(s.reciter).toBe("alafasy");
     expect(s.tafsir).toBe("ar-muyassar");
     expect(s.scale).toBe(1.4);
+    expect(s.transliteration).toBe(true);
 
     // editions and scale are JSON; the rest are plain strings (unchanged format)
     expect(localStorage.getItem("ul.editions")).toBe('["eng-sahih"]');

--- a/apps/web/src/lib/settings-store.ts
+++ b/apps/web/src/lib/settings-store.ts
@@ -14,6 +14,7 @@ const READING_TR_KEY = "ul.readingTranslation";
 const RECITER_KEY = "ul.reciter";
 const TAFSIR_KEY = "ul.tafsir";
 const SCALE_KEY = "ul.scale";
+const TRANSLIT_KEY = "ul.transliteration";
 
 function getJSON<T>(key: string, fallback: T, isValid?: (v: unknown) => boolean): T {
   try {
@@ -30,6 +31,7 @@ function getJSON<T>(key: string, fallback: T, isValid?: (v: unknown) => boolean)
 const isStringArray = (v: unknown): boolean =>
   Array.isArray(v) && v.every((x) => typeof x === "string");
 const isFiniteNumber = (v: unknown): boolean => typeof v === "number" && Number.isFinite(v);
+const isBoolean = (v: unknown): boolean => typeof v === "boolean";
 function getStr(key: string): string | null {
   try {
     return localStorage.getItem(key);
@@ -53,6 +55,7 @@ export const webSettingsStore: SettingsStore = {
     reciter: getStr(RECITER_KEY),
     tafsir: getStr(TAFSIR_KEY),
     scale: getJSON<number | null>(SCALE_KEY, null, isFiniteNumber),
+    transliteration: getJSON<boolean | null>(TRANSLIT_KEY, null, isBoolean),
   }),
   writeEditions: async (ids) => setItem(EDITIONS_KEY, JSON.stringify(ids)),
   writeReadingMode: async (mode) => setItem(READING_MODE_KEY, mode),
@@ -60,4 +63,5 @@ export const webSettingsStore: SettingsStore = {
   writeReciter: async (id) => setItem(RECITER_KEY, id),
   writeTafsir: async (id) => setItem(TAFSIR_KEY, id),
   writeScale: async (scale) => setItem(SCALE_KEY, JSON.stringify(scale)),
+  writeTransliteration: async (on) => setItem(TRANSLIT_KEY, JSON.stringify(on)),
 };

--- a/apps/web/src/lib/transliteration.test.ts
+++ b/apps/web/src/lib/transliteration.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TRANSLIT_KEY, readTransliteration, writeTransliteration } from "./transliteration";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("transliteration toggle", () => {
+  it("defaults to off when never set", async () => {
+    expect(await readTransliteration()).toBe(false);
+  });
+
+  it("round-trips the flag and emits a change event", async () => {
+    const handler = vi.fn();
+    window.addEventListener(TRANSLIT_KEY, handler);
+
+    await writeTransliteration(true);
+    expect(await readTransliteration()).toBe(true);
+    expect(handler).toHaveBeenCalledOnce();
+
+    await writeTransliteration(false);
+    expect(await readTransliteration()).toBe(false);
+
+    window.removeEventListener(TRANSLIT_KEY, handler);
+  });
+});

--- a/apps/web/src/lib/transliteration.ts
+++ b/apps/web/src/lib/transliteration.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared "show per-āyah transliteration" state (#150): a reader toggle that
+ * renders a Latin transliteration line under each āyah's Arabic.
+ *
+ * The transliteration text is one of the runtime-catalogue editions (ADR 0011) —
+ * Tanzil's verbatim Latin transliteration, served through the same
+ * `/api/v1/translations/:edition/...` path the reader already uses, so nothing
+ * new is bundled. The on/off flag persists through the `SettingsStore` port and,
+ * like editions, broadcasts a window event so the per-āyah components update live.
+ */
+import { webSettingsStore as store } from "./settings-store";
+
+/** The catalogue edition id for the transliteration line — Tanzil (CC-BY 3.0). */
+export const TRANSLIT_EDITION = "ara-quran-la";
+
+/** Window event broadcast when the transliteration toggle changes. */
+export const TRANSLIT_KEY = "ul.transliteration";
+
+export async function readTransliteration(): Promise<boolean> {
+  return (await store.read()).transliteration ?? false;
+}
+
+export async function writeTransliteration(on: boolean): Promise<void> {
+  await store.writeTransliteration(on);
+  window.dispatchEvent(new CustomEvent(TRANSLIT_KEY, { detail: on }));
+}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -319,6 +319,8 @@ export interface StoredSettings {
   tafsir: string | null;
   /** Reading font scale. */
   scale: number | null;
+  /** Show the per-āyah Latin transliteration line under the Arabic (#150). */
+  transliteration: boolean | null;
 }
 
 /**
@@ -335,6 +337,8 @@ export interface SettingsStore {
   writeReciter(id: string): Promise<void>;
   writeTafsir(id: string): Promise<void>;
   writeScale(scale: number): Promise<void>;
+  /** Toggle the per-āyah transliteration line (#150). */
+  writeTransliteration(on: boolean): Promise<void>;
 }
 
 /** The reader's prayer-times location and calculation config as persisted. */

--- a/packages/data/ATTRIBUTION.md
+++ b/packages/data/ATTRIBUTION.md
@@ -61,6 +61,18 @@ of its author/publisher and is included under the upstream terms.
 > guardrail). To swap or add a translation, edit the `TRANSLATIONS` list in
 > `scripts/ingest.ts` — no other code changes required.
 
+## Transliteration (runtime — #150)
+
+The reader's per-āyah **Latin transliteration** line is **not bundled**. Like the
+full translation catalogue (ADR 0011) it is fetched at runtime, by edition id,
+from [`fawazahmed0/quran-api`](https://github.com/fawazahmed0/quran-api).
+
+- **Edition:** `ara-quran-la` — a verbatim Latin transliteration of the Arabic.
+- **Upstream source:** [Tanzil](https://tanzil.net).
+- **License:** Creative Commons **Attribution 3.0** (CC-BY 3.0) — same notice as
+  the Arabic text above. The transliteration is shown verbatim, attributed; no
+  scholar review is required (mechanical romanisation, not interpretation).
+
 ## 99 Names of Allah — `asma.json`
 
 - **Source:** the Names are from the **Qurʾān and Sunnah** (public domain). The


### PR DESCRIPTION
## What

Adds an opt-in **Transliteration** toggle to the reader. When on, a Latin transliteration line is shown under each āyah's Arabic — for non-Arabic readers learning to recite.

Closes #150.

## Approach

The transliteration text is **Tanzil's verbatim Latin transliteration** (`ara-quran-la`, **CC-BY 3.0**), served through the **existing runtime translation catalogue** (ADR 0011) — the same `/api/v1/translations/:edition/...` path the reader already uses for translations.

**No new bundled dataset.** This deliberately diverges from the issue's "ingest a new edition" wording: the web reader's per-āyah translations already come from the full runtime catalogue (ADR 0011), and the data-distribution stance prefers client-fetch over shipping JSON. The edition is therefore already reachable at runtime — what was missing was a **first-class, discoverable toggle** plus a distinct render slot. Adding it to the curated bundled set wouldn't have surfaced it in the reader (which reads the catalogue, not the bundled `FileTranslationRepository`).

## Changes

- **core** — `transliteration: boolean | null` on `StoredSettings`; `writeTransliteration` on the `SettingsStore` port.
- **web** — toggle in the reader toolbar's display panel (next to Word-by-word); `AyahTransliteration` line rendered in the surah reader **and** the juz page; persisted via `webSettingsStore` with a `ul.transliteration` broadcast so the per-āyah components update live; `.ayah-translit` styling.
- **mobile** — toggle in `ReaderControls`; transliteration line in `AyahView` and the juz reader, fetched only while enabled; persisted via `mobileSettingsStore` + `SettingsContext`.
- **attribution** — recorded in `packages/data/ATTRIBUTION.md` and the top-level `ATTRIBUTION.md` (runtime services).

## Acceptance (from #150)

- [x] Transliteration edition available + attributed (Tanzil, CC-BY 3.0; runtime-served per ADR 0011).
- [x] Reader toggle to show per-āyah transliteration; works in surah **and** juz.
- [x] Web + mobile.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (275 web + core/data/adapters/mobile), `pnpm build` — all pass.
- New tests: `transliteration.ts` round-trip + event; `settings-store` round-trips the new field.
- Runtime: against the production build, `/api/v1/translations` lists `ara-quran-la` and `/api/v1/translations/ara-quran-la/surahs/1` returns the 7 Al-Fātiḥah lines ("Bismi Allahi alrrahmani alrraheemi", …) — the exact path the reader fetches.