### PR TITLE
feat(tracker): make-up fasts from the ḥayḍ pause (#155)

### DIFF
--- a/apps/mobile/src/fasting-qada-store.ts
+++ b/apps/mobile/src/fasting-qada-store.ts
@@ -1,0 +1,16 @@
+/**
+ * Mobile `FastingQadaStore` adapter (ADR 0024, 0034): the fasting-qaḍāʾ made-up
+ * count in AsyncStorage under `ul.fastingQada` (mirrors the web key so the two
+ * clients describe the same local-first state). Persistence only — the maths
+ * lives in `@ummahlibrary/core`.
+ */
+import type { FastingQadaLog, FastingQadaStore } from "@ummahlibrary/core";
+import { KEYS, getJSON, setJSON } from "./storage";
+
+const isLog = (v: unknown): boolean =>
+  v !== null && typeof v === "object" && typeof (v as FastingQadaLog).madeUp === "number";
+
+export const mobileFastingQadaStore: FastingQadaStore = {
+  read: () => getJSON<FastingQadaLog>(KEYS.fastingQada, { madeUp: 0 }, isLog),
+  write: (log) => setJSON(KEYS.fastingQada, log),
+};

--- a/apps/mobile/src/screens/PrayerTrackerScreen.tsx
+++ b/apps/mobile/src/screens/PrayerTrackerScreen.tsx
@@ -3,12 +3,17 @@ import { Pressable, ScrollView, StyleSheet, Text, View } from "../Type";
 import {
   OBLIGATORY_PRAYERS,
   PRAYER_LABELS,
+  type FastingQadaLog,
   type HaidLog,
   type PrayerStatus,
   type PrayerTrackerLog,
   type QadaLog,
+  adjustFastingMadeUp,
   adjustQada,
   currentPeriod,
+  fastingMadeUp,
+  fastingQadaOwed,
+  fastingQadaRemaining,
   isDatePaused,
   longestPrayerStreakWithPause,
   nextPrayerStatus,
@@ -27,6 +32,8 @@ import { useTheme, type Palette } from "../theme";
 import { mobilePrayerTrackerStore as prayerStore } from "../prayer-tracker-store";
 import { mobileQadaStore as qadaStore } from "../qada-store";
 import { mobileHaidStore as haidStore } from "../haid-store";
+import { mobileFastingQadaStore as fastingQadaStore } from "../fasting-qada-store";
+import { KEYS, getString } from "../storage";
 import { localISODate } from "../utils";
 
 const STATUS_LABEL: Record<PrayerStatus, string> = {
@@ -45,12 +52,19 @@ export function PrayerTrackerScreen() {
   const [log, setLog] = useState<PrayerTrackerLog>({});
   const [qada, setQadaLog] = useState<QadaLog>({});
   const [haid, setHaid] = useState<HaidLog>([]);
+  const [fastingQada, setFastingQada] = useState<FastingQadaLog>({ madeUp: 0 });
+  const [hijriAdjust, setHijriAdjust] = useState(0);
   const today = localISODate(new Date());
 
   useEffect(() => {
     void prayerStore.read().then(setLog);
     void qadaStore.read().then(setQadaLog);
     void haidStore.read().then(setHaid);
+    void fastingQadaStore.read().then(setFastingQada);
+    void getString(KEYS.hijriAdjust).then((raw) => {
+      const n = Number(raw);
+      if (Number.isFinite(n)) setHijriAdjust(n);
+    });
   }, []);
 
   function adjustQadaFor(prayer: (typeof OBLIGATORY_PRAYERS)[number], delta: number) {
@@ -69,6 +83,14 @@ export function PrayerTrackerScreen() {
     });
   }
 
+  function adjustFasting(delta: number, owed: number) {
+    setFastingQada((prev) => {
+      const next = adjustFastingMadeUp(prev, delta, owed);
+      void fastingQadaStore.write(next);
+      return next;
+    });
+  }
+
   function cycle(prayer: (typeof OBLIGATORY_PRAYERS)[number]) {
     setLog((prev) => {
       const next = setPrayerStatus(prev, today, prayer, nextPrayerStatus(statusFor(prev[today], prayer)));
@@ -81,6 +103,9 @@ export function PrayerTrackerScreen() {
   const days = recentDays(log, today, 7);
   const haidCurrent = currentPeriod(haid);
   const haidDays = haidCurrent ? periodLength(haidCurrent, today) : 0;
+  const fastingOwed = fastingQadaOwed(haid, today, hijriAdjust);
+  const fastingRemaining = fastingQadaRemaining(fastingQada, fastingOwed);
+  const fastingDone = fastingMadeUp(fastingQada, fastingOwed);
   const stats: [string, string][] = [
     [`${prayedCount(todayLog)}/5`, "Prayed today"],
     [`${prayerStreakWithPause(log, haid, today)} 🔥`, "Day streak"],
@@ -221,6 +246,45 @@ export function PrayerTrackerScreen() {
           );
         })}
       </View>
+
+      <Text style={styles.sectionLabel}>
+        Make-up fasts · ṣawm qaḍāʾ ({fastingRemaining} to make up)
+      </Text>
+      {fastingOwed === 0 ? (
+        <Text style={styles.fastingHint}>
+          No fasts to make up. Days missed during a ḥayḍ pause in Ramaḍān appear here automatically.
+        </Text>
+      ) : (
+        <View style={styles.qadaList}>
+          <View style={styles.qadaRow}>
+            <Text style={styles.qadaName}>Ramaḍān fasts</Text>
+            <View style={styles.qadaCtrls}>
+              <Pressable
+                style={[styles.step, fastingRemaining === 0 && styles.stepDisabled]}
+                disabled={fastingRemaining === 0}
+                onPress={() => adjustFasting(1, fastingOwed)}
+                accessibilityLabel="Mark one fast made up"
+              >
+                <Text style={styles.stepMark}>−</Text>
+              </Pressable>
+              <Text style={[styles.qadaCount, { color: fastingRemaining ? colors.accent : colors.faint }]}>
+                {fastingRemaining}
+              </Text>
+              <Pressable
+                style={[styles.step, fastingDone === 0 && styles.stepDisabled]}
+                disabled={fastingDone === 0}
+                onPress={() => adjustFasting(-1, fastingOwed)}
+                accessibilityLabel="Undo one made-up fast"
+              >
+                <Text style={styles.stepMark}>+</Text>
+              </Pressable>
+            </View>
+          </View>
+          <Text style={styles.fastingHint}>
+            {fastingDone} of {fastingOwed} made up. Tap − as you fast each one back.
+          </Text>
+        </View>
+      )}
     </ScrollView>
   );
 }
@@ -345,5 +409,6 @@ function makeStyles(c: Palette) {
     stepDisabled: { backgroundColor: "transparent", opacity: 0.5 },
     stepMark: { color: c.accent, fontSize: 20, fontWeight: "700", lineHeight: 22 },
     qadaCount: { minWidth: 26, textAlign: "center", fontSize: 16, fontWeight: "800" },
+    fastingHint: { color: c.faint, fontSize: 12.5, marginTop: 6 },
   });
 }

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -39,6 +39,7 @@ export const KEYS = {
   prayerLog: "ul.prayerLog",
   qada: "ul.qada",
   haid: "ul.haid",
+  fastingQada: "ul.fastingQada",
   badges: "ul.badges",
   hijriAdjust: "ul.hijriAdjust",
   zakat: "ul.zakat",

--- a/apps/mobile/src/stores-corrupt.test.ts
+++ b/apps/mobile/src/stores-corrupt.test.ts
@@ -24,6 +24,7 @@ import { mobileSettingsStore } from "./state/settings-store";
 import { mobileQadaStore } from "./qada-store";
 import { mobilePrayerTrackerStore } from "./prayer-tracker-store";
 import { mobileHaidStore } from "./haid-store";
+import { mobileFastingQadaStore } from "./fasting-qada-store";
 import { mobileAchievementsStore } from "./achievements-store";
 import { mobileReadingGoalsStore } from "./reading-goals-store";
 import { mobileTasbihStore } from "./tasbih-store";
@@ -69,6 +70,7 @@ describe("mobile store read() corrupt-value hardening", () => {
         "ul.qada",
         "ul.prayerLog",
         "ul.haid",
+        "ul.fastingQada",
         "ul.badges",
         "ul.readingActive",
         "ul.readingLog",
@@ -81,6 +83,7 @@ describe("mobile store read() corrupt-value hardening", () => {
       expect(await mobileQadaStore.read()).toEqual({});
       expect(await mobilePrayerTrackerStore.read()).toEqual({});
       expect(await mobileHaidStore.read()).toEqual([]);
+      expect(await mobileFastingQadaStore.read()).toEqual({ madeUp: 0 });
       expect(await mobileAchievementsStore.read()).toEqual([]);
       const g = await mobileReadingGoalsStore.read();
       expect(g.log).toEqual({});

--- a/apps/web/src/app/tracker/page.tsx
+++ b/apps/web/src/app/tracker/page.tsx
@@ -3,6 +3,7 @@ import { NoorPageFrame } from "../../components/NoorPageFrame";
 import { PrayerTracker } from "../../components/PrayerTracker";
 import { CyclePause } from "../../components/CyclePause";
 import { QadaTracker } from "../../components/QadaTracker";
+import { FastingQadaTracker } from "../../components/FastingQadaTracker";
 
 export const metadata: Metadata = {
   title: "Prayer Tracker",
@@ -23,6 +24,7 @@ export default function PrayerTrackerPage() {
       <PrayerTracker />
       <CyclePause />
       <QadaTracker />
+      <FastingQadaTracker />
     </NoorPageFrame>
   );
 }

--- a/apps/web/src/components/FastingQadaTracker.test.tsx
+++ b/apps/web/src/components/FastingQadaTracker.test.tsx
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { hijriToGregorian } from "@ummahlibrary/core";
+import { FastingQadaTracker } from "./FastingQadaTracker";
+
+// A Ramaḍān (Hijri month 9) day as YYYY-MM-DD, for building a ḥayḍ pause whose
+// days fall inside Ramaḍān regardless of the real "today".
+const ram = (day: number): string => {
+  const d = hijriToGregorian({ year: 1447, month: 9, day });
+  return `${d.year}-${String(d.month).padStart(2, "0")}-${String(d.day).padStart(2, "0")}`;
+};
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("FastingQadaTracker", () => {
+  it("shows the empty state when no ḥayḍ pause fell in Ramaḍān", async () => {
+    render(<FastingQadaTracker />);
+    expect(await screen.findByText(/No fasts to make up/i)).toBeInTheDocument();
+  });
+
+  it("derives owed fasts from a Ramaḍān pause and makes them up", async () => {
+    // A closed pause over Ramaḍān 5–7 → three fasts owed.
+    localStorage.setItem("ul.haid", JSON.stringify([{ start: ram(5), end: ram(7) }]));
+    render(<FastingQadaTracker />);
+
+    const makeUp = await screen.findByRole("button", { name: "Mark one fast made up" });
+    expect(screen.getByText(/0 of 3 made up/i)).toBeInTheDocument();
+
+    await userEvent.click(makeUp);
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem("ul.fastingQada") ?? "{}").madeUp).toBe(1),
+    );
+    expect(screen.getByText(/1 of 3 made up/i)).toBeInTheDocument();
+
+    // Undo brings it back down.
+    await userEvent.click(screen.getByRole("button", { name: "Undo one made-up fast" }));
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem("ul.fastingQada") ?? "{}").madeUp).toBe(0),
+    );
+  });
+});

--- a/apps/web/src/components/FastingQadaTracker.tsx
+++ b/apps/web/src/components/FastingQadaTracker.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
+import {
+  type FastingQadaLog,
+  type HaidLog,
+  fastingMadeUp,
+  fastingQadaOwed,
+  fastingQadaRemaining,
+} from "@ummahlibrary/core";
+import { N } from "@ummahlibrary/ui";
+import { HAID_EVENT, readHaid } from "../lib/haid";
+import { FASTING_QADA_EVENT, adjustFastingMadeUpCount, readFastingQada } from "../lib/fasting-qada";
+import { readHijriAdjust } from "../lib/hijri";
+import { today } from "../lib/prayer-tracker";
+
+const card: CSSProperties = {
+  background: N.card,
+  border: `1px solid ${N.border}`,
+  borderRadius: 16,
+};
+const sectionLabel: CSSProperties = {
+  fontSize: 12,
+  letterSpacing: 1,
+  textTransform: "uppercase",
+  color: N.faint,
+  fontWeight: 700,
+};
+
+/**
+ * Make-up fasts (ṣawm qaḍāʾ, #155). The number owed is derived from the ḥayḍ
+ * pauses that fall in Ramaḍān (not entered by hand); the reader ticks them off as
+ * they fast them back. Re-reads on either the ḥayḍ or the fasting-qaḍāʾ event.
+ */
+export function FastingQadaTracker() {
+  const [ready, setReady] = useState(false);
+  const [haid, setHaid] = useState<HaidLog>([]);
+  const [log, setLog] = useState<FastingQadaLog>({ madeUp: 0 });
+  const [todayStr, setTodayStr] = useState("");
+  const [adjust, setAdjust] = useState(0);
+
+  useEffect(() => {
+    setTodayStr(today());
+    setAdjust(readHijriAdjust());
+    void readHaid().then(setHaid);
+    void readFastingQada().then(setLog);
+    setReady(true);
+    const onHaid = () => void readHaid().then(setHaid);
+    const onQada = () => void readFastingQada().then(setLog);
+    window.addEventListener(HAID_EVENT, onHaid);
+    window.addEventListener(FASTING_QADA_EVENT, onQada);
+    return () => {
+      window.removeEventListener(HAID_EVENT, onHaid);
+      window.removeEventListener(FASTING_QADA_EVENT, onQada);
+    };
+  }, []);
+
+  if (!ready) return null;
+
+  const owed = todayStr ? fastingQadaOwed(haid, todayStr, adjust) : 0;
+  const remaining = fastingQadaRemaining(log, owed);
+  const madeUp = fastingMadeUp(log, owed);
+
+  return (
+    <div style={{ ...card, padding: 24, marginTop: 18 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          gap: 12,
+          flexWrap: "wrap",
+          marginBottom: owed > 0 ? 16 : 8,
+        }}
+      >
+        <div style={sectionLabel}>Make-up fasts · ṣawm qaḍāʾ</div>
+        <div style={{ fontSize: 13, color: N.faint }}>
+          <span style={{ color: N.gold, fontWeight: 800, fontSize: 18 }}>{remaining}</span> to make up
+        </div>
+      </div>
+
+      {owed === 0 ? (
+        <p style={{ fontSize: 13, color: N.faint, margin: 0 }}>
+          No fasts to make up. Days missed during a ḥayḍ pause in Ramaḍān appear here automatically.
+        </p>
+      ) : (
+        <>
+          <div
+            style={{ display: "grid", gridTemplateColumns: "1fr auto", alignItems: "center", gap: 12 }}
+          >
+            <span style={{ fontSize: 14, fontWeight: 700, color: N.fg }}>Ramaḍān fasts to make up</span>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <Step
+                label="Mark one fast made up"
+                symbol="−"
+                disabled={remaining === 0}
+                onClick={() => void adjustFastingMadeUpCount(1, owed).then(setLog)}
+              />
+              <span
+                aria-live="polite"
+                style={{
+                  minWidth: 28,
+                  textAlign: "center",
+                  fontSize: 16,
+                  fontWeight: 800,
+                  color: remaining ? N.gold : N.faint,
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                {remaining}
+              </span>
+              <Step
+                label="Undo one made-up fast"
+                symbol="+"
+                disabled={madeUp === 0}
+                onClick={() => void adjustFastingMadeUpCount(-1, owed).then(setLog)}
+              />
+            </div>
+          </div>
+          <p style={{ fontSize: 12, color: N.faint, marginTop: 14, marginBottom: 0 }}>
+            {madeUp} of {owed} made up. Tap − as you fast each one back. Stored on your device.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Step({
+  label,
+  symbol,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  symbol: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        width: 34,
+        height: 34,
+        borderRadius: 10,
+        border: `1px solid ${N.border}`,
+        background: disabled ? "transparent" : N.goldSoft,
+        color: disabled ? N.faint : N.gold,
+        cursor: disabled ? "default" : "pointer",
+        fontSize: 20,
+        fontWeight: 700,
+        lineHeight: 1,
+        fontFamily: N.ui,
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      {symbol}
+    </button>
+  );
+}

--- a/apps/web/src/lib/fasting-qada-store.ts
+++ b/apps/web/src/lib/fasting-qada-store.ts
@@ -1,0 +1,40 @@
+/**
+ * Web `FastingQadaStore` adapter (ADR 0024, 0034): the fasting-qaḍāʾ made-up
+ * count in `localStorage` under `ul.fastingQada`. Persistence only — the maths
+ * lives in `@ummahlibrary/core` — so a synced adapter (#25) can replace it
+ * without touching the feature. Mirrors mobile.
+ */
+import type { FastingQadaLog, FastingQadaStore } from "@ummahlibrary/core";
+
+const KEY = "ul.fastingQada";
+
+/** A `{ madeUp: number }` record — guards a corrupt/peer-synced value. */
+function parse(raw: string | null): FastingQadaLog {
+  if (!raw) return { madeUp: 0 };
+  try {
+    const v = JSON.parse(raw) as unknown;
+    if (v !== null && typeof v === "object" && typeof (v as FastingQadaLog).madeUp === "number") {
+      return { madeUp: (v as FastingQadaLog).madeUp };
+    }
+  } catch {
+    /* fall through to default */
+  }
+  return { madeUp: 0 };
+}
+
+export const webFastingQadaStore: FastingQadaStore = {
+  read: async () => {
+    try {
+      return parse(localStorage.getItem(KEY));
+    } catch {
+      return { madeUp: 0 };
+    }
+  },
+  write: async (log) => {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(log));
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};

--- a/apps/web/src/lib/fasting-qada.ts
+++ b/apps/web/src/lib/fasting-qada.ts
@@ -1,0 +1,31 @@
+/**
+ * Local-first fasting qaḍāʾ (make-up fasts, #155, ADR 0034). The count *owed* is
+ * derived from the ḥayḍ pauses ∩ Ramaḍān (`fastingQadaOwed` in core); only how
+ * many have been made up is persisted, through the `FastingQadaStore` port (web
+ * adapter `webFastingQadaStore`, ADR 0024). A window event lets the tracker page
+ * re-render on change — the established pattern from the prayer/qaḍāʾ trackers.
+ */
+import { type FastingQadaLog, adjustFastingMadeUp } from "@ummahlibrary/core";
+import { webFastingQadaStore as store } from "./fasting-qada-store";
+
+export const FASTING_QADA_EVENT = "ul.fastingQada";
+
+function emit(): void {
+  try {
+    window.dispatchEvent(new CustomEvent(FASTING_QADA_EVENT));
+  } catch {
+    /* non-browser */
+  }
+}
+
+export function readFastingQada(): Promise<FastingQadaLog> {
+  return store.read();
+}
+
+/** Make up one fast (`+1`) or undo (`-1`), clamped to `[0, owed]`, and persist. */
+export async function adjustFastingMadeUpCount(delta: number, owed: number): Promise<FastingQadaLog> {
+  const next = adjustFastingMadeUp(await store.read(), delta, owed);
+  await store.write(next);
+  emit();
+  return next;
+}

--- a/apps/web/src/lib/store-corruption.test.ts
+++ b/apps/web/src/lib/store-corruption.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { webQadaStore } from "./qada-store";
 import { webPrayerTrackerStore } from "./prayer-tracker-store";
 import { webHaidStore } from "./haid-store";
+import { webFastingQadaStore } from "./fasting-qada-store";
 import { readHistory } from "./search-history-store";
 import { webAchievementsStore } from "./achievements-store";
 import { readLearned } from "./asma-store";
@@ -26,9 +27,11 @@ describe("store read() corrupt-value hardening (web)", () => {
       localStorage.setItem("ul.qada", bad);
       localStorage.setItem("ul.prayerLog", bad);
       localStorage.setItem("ul.asmaLearned", bad);
+      localStorage.setItem("ul.fastingQada", bad);
       expect(await webQadaStore.read()).toEqual({});
       expect(await webPrayerTrackerStore.read()).toEqual({});
       expect(readLearned()).toEqual({});
+      expect(await webFastingQadaStore.read()).toEqual({ madeUp: 0 });
     }
   });
 

--- a/docs/adr/0034-fasting-qada.md
+++ b/docs/adr/0034-fasting-qada.md
@@ -1,0 +1,64 @@
+# ADR 0034 — Fasting qaḍāʾ derived from the ḥayḍ pause
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+
+## Context
+
+The ḥayḍ pause ([0031](0031-haid-pause.md)) shipped the **prayer** side of #138:
+paused days don't break the streak and aren't owed as prayer qaḍāʾ (menstrual
+prayers are not made up). The **fasting** side was explicitly deferred — and
+[0031](0031-haid-pause.md) closes by naming the blocker: "When a date-based
+fasting tracker lands, wire the pause range into fast make-up." That follow-up is
+#155.
+
+Per fiqh the asymmetry is the whole point: the Ramaḍān fast-days a woman misses
+during ḥayḍ **are** made up later (ṣawm qaḍāʾ), even though the prayers are not.
+The existing Ramaḍān tracker is **day-number indexed** (`Record<number, true>`
+for fasts 1–30 of the current Ramaḍān), so it cannot answer "which dated fasts do
+I owe from a Gregorian pause range." We need a date-aware accounting that joins
+the pause ranges against Ramaḍān.
+
+Like the pause and the prayer backlog ([0006](0006-local-first-persistence.md)),
+this is purely the user's own habit data — no external system.
+
+## Decision
+
+**1. Owed is derived, not stored.** `core/fasting-qada.ts` computes the fasts
+owed from the existing `HaidLog` ∩ Ramaḍān: `ramadanPauseDays` walks each pause
+period (bounding an open period to the injected "today") and keeps the Gregorian
+days whose tabular Hijri month is Ramaḍān (month 9), de-duplicated via a `Set`.
+`fastingQadaOwed` is just its length. The Hijri conversion ([0014](0014-hijri-calendar.md))
+takes the same user `adjustmentDays` offset the rest of the app uses, so the
+±1-day sighting preference is honoured. Pure, deterministic, clock-injected,
+unit-tested.
+
+**2. Only the made-up count is persisted.** The single piece of state is
+`FastingQadaLog = { madeUp: number }` — how many of the owed fasts have been
+completed. `fastingQadaRemaining` = owed − made-up (clamped), and
+`adjustFastingMadeUp` ticks it within `[0, owed]`. Because owed is recomputed
+from the live pause log, deleting or extending a pause re-derives the total
+without migration.
+
+**3. A separate domain behind its own port.** It does **not** touch
+`haid.ts`, `qada.ts`, or the day-indexed Ramaḍān tracker. It is persisted behind
+a `FastingQadaStore` (`read`/`write`) under `ul.fastingQada`, with a
+`localStorage` web adapter and an `AsyncStorage` mobile adapter
+([0024](0024-local-storage-ports.md), enforced by [0028](0028-persistence-enforcement.md)).
+The web glue emits a window event so the tracker page re-renders; the mobile
+screen holds it in component state. Both surface a make-up counter next to the
+prayer qaḍāʾ tracker ([0030](0030-qada-tracker.md)).
+
+## Consequences
+
+- **Good:** completes #138's deferred fasting item and closes #155. Fully local —
+  no backend, accounts, or PII. `ul.fastingQada` rides the key-agnostic backup
+  ([0018](0018-local-data-backup.md)) for free, and the port is the seam for sync.
+- **Deliberately excluded:** the counter only covers fasts missed to a **ḥayḍ
+  pause in Ramaḍān**. Qaḍāʾ from other causes (travel, illness) is not modelled
+  here; it can be a later manual-entry addition without changing this port. Like
+  the other logs/counters, `ul.fastingQada` is **not** in `MANAGED_KEYS` — it
+  awaits the v2 element-level merge ([0033](0033-account-sync.md)).
+- **Limit & trigger to revisit:** tabular Hijri can differ from a local sighting
+  by ±1 day (mitigated by the shared `hijriAdjust`); revisit if we adopt a
+  sighting-based calendar. Per-device until the export bridge (0018) or sync (#25).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,6 +42,7 @@ through Phases 1–3; later decisions get their own record at the time they're m
 | [0031](0031-haid-pause.md)                    | Ḥayḍ pause: menstrual pause preserves the prayer streak                | Accepted |
 | [0032](0032-achievements.md)                  | Achievements: declarative badge engine over existing local data        | Accepted |
 | [0033](0033-account-sync.md)                  | Cross-device sync: opt-in, E2E-encrypted, zero-PII (amends 0003, 0006) | Accepted |
+| [0034](0034-fasting-qada.md)                  | Fasting qaḍāʾ: make-up fasts derived from the ḥayḍ pause ∩ Ramaḍān     | Accepted |
 
 ## Writing a new ADR
 

--- a/packages/core/src/fasting-qada.test.ts
+++ b/packages/core/src/fasting-qada.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { hijriToGregorian } from "./hijri";
+import { addDays } from "./reading-goals";
+import type { HaidLog } from "./haid";
+import {
+  EMPTY_FASTING_QADA,
+  adjustFastingMadeUp,
+  fastingMadeUp,
+  fastingQadaOwed,
+  fastingQadaRemaining,
+  isRamadanDate,
+  ramadanPauseDays,
+} from "./fasting-qada";
+
+// Build YYYY-MM-DD fixtures from the calendar itself, so the tests track the
+// tabular conversion rather than hard-coded magic dates.
+const iso = (d: { year: number; month: number; day: number }): string =>
+  `${d.year}-${String(d.month).padStart(2, "0")}-${String(d.day).padStart(2, "0")}`;
+const ram = (day: number, year = 1447): string => iso(hijriToGregorian({ year, month: 9, day }));
+const shaban = (day: number, year = 1447): string => iso(hijriToGregorian({ year, month: 8, day }));
+const shawwal = (day: number, year = 1447): string => iso(hijriToGregorian({ year, month: 10, day }));
+
+describe("isRamadanDate", () => {
+  it("is true inside Ramaḍān and false outside it", () => {
+    expect(isRamadanDate(ram(10))).toBe(true);
+    expect(isRamadanDate(shaban(10))).toBe(false);
+    expect(isRamadanDate(shawwal(1))).toBe(false);
+  });
+
+  it("rejects a malformed date string", () => {
+    expect(isRamadanDate("not-a-date")).toBe(false);
+    expect(isRamadanDate("")).toBe(false);
+  });
+
+  it("honours the Hijri adjustment", () => {
+    // The Gregorian day before Ramaḍān 1 reads as Shaʿbān normally, but with a
+    // +1 adjustment the tabular month shifts so it reads as Ramaḍān 1.
+    const dayBeforeRamadan = addDays(ram(1), -1);
+    expect(isRamadanDate(dayBeforeRamadan)).toBe(false);
+    expect(isRamadanDate(dayBeforeRamadan, 1)).toBe(true);
+  });
+});
+
+describe("fastingQadaOwed", () => {
+  const today = ram(20);
+
+  it("is zero with no pauses", () => {
+    expect(fastingQadaOwed([], today)).toBe(0);
+  });
+
+  it("ignores a pause entirely outside Ramaḍān", () => {
+    const log: HaidLog = [{ start: shaban(5), end: shaban(9) }];
+    expect(fastingQadaOwed(log, today)).toBe(0);
+  });
+
+  it("counts every paused day inside Ramaḍān", () => {
+    const log: HaidLog = [{ start: ram(5), end: ram(9) }]; // 5,6,7,8,9 → 5 days
+    expect(fastingQadaOwed(log, today)).toBe(5);
+  });
+
+  it("counts only the Ramaḍān portion of a straddling pause", () => {
+    const log: HaidLog = [{ start: shaban(27), end: ram(3) }]; // Ramaḍān 1,2,3 → 3
+    expect(fastingQadaOwed(log, today)).toBe(3);
+  });
+
+  it("bounds an open (ongoing) pause to today", () => {
+    const log: HaidLog = [{ start: ram(8) }]; // no end → ongoing
+    // Counts Ramaḍān days from the start up to the injected "today" (ram 10).
+    expect(fastingQadaOwed(log, ram(10))).toBe(3); // 8, 9, 10
+  });
+
+  it("does not double-count overlapping periods", () => {
+    const log: HaidLog = [
+      { start: ram(5), end: ram(9) },
+      { start: ram(8), end: ram(11) },
+    ];
+    expect(ramadanPauseDays(log, today)).toHaveLength(7); // 5..11 distinct
+  });
+
+  it("skips a corrupt range (end before start)", () => {
+    const log: HaidLog = [{ start: ram(9), end: ram(5) }];
+    expect(fastingQadaOwed(log, today)).toBe(0);
+  });
+});
+
+describe("made-up accounting", () => {
+  it("clamps the made-up count into [0, owed]", () => {
+    expect(fastingMadeUp({ madeUp: -3 }, 5)).toBe(0);
+    expect(fastingMadeUp({ madeUp: 9 }, 5)).toBe(5);
+    expect(fastingMadeUp({ madeUp: 2 }, 5)).toBe(2);
+    expect(fastingMadeUp({ madeUp: NaN }, 5)).toBe(0);
+  });
+
+  it("remaining is owed minus made-up, never negative", () => {
+    expect(fastingQadaRemaining(EMPTY_FASTING_QADA, 5)).toBe(5);
+    expect(fastingQadaRemaining({ madeUp: 2 }, 5)).toBe(3);
+    expect(fastingQadaRemaining({ madeUp: 9 }, 5)).toBe(0);
+  });
+
+  it("adjust makes one up / undoes, clamped to [0, owed]", () => {
+    let log = EMPTY_FASTING_QADA;
+    log = adjustFastingMadeUp(log, 1, 3); // make up one
+    expect(log.madeUp).toBe(1);
+    log = adjustFastingMadeUp(log, 1, 3);
+    log = adjustFastingMadeUp(log, 1, 3); // all three
+    expect(log.madeUp).toBe(3);
+    log = adjustFastingMadeUp(log, 1, 3); // can't exceed owed
+    expect(log.madeUp).toBe(3);
+    log = adjustFastingMadeUp(log, -1, 3); // undo one
+    expect(log.madeUp).toBe(2);
+  });
+});

--- a/packages/core/src/fasting-qada.ts
+++ b/packages/core/src/fasting-qada.ts
@@ -1,0 +1,86 @@
+/**
+ * Fasting qaḍāʾ (make-up fasts) domain (#155, ADR 0034). A woman does not fast
+ * during ḥayḍ, and the Ramaḍān fast-days she misses **are** made up later —
+ * unlike the prayers in that pause, which are not owed (see `haid.ts`).
+ *
+ * The count *owed* is derived, not stored: it is the ḥayḍ pause ranges
+ * (`haid.ts`) intersected with Ramaḍān (Hijri month 9) — each paused Gregorian
+ * day that falls in Ramaḍān is one fast to make up. The only persisted state is
+ * how many of those have been completed (`FastingQadaLog`), kept behind the
+ * `FastingQadaStore` port. Pure and deterministic — "today" and the Hijri
+ * adjustment are injected, never read from the clock.
+ */
+import { addDays, daysBetween } from "./reading-goals";
+import { gregorianToHijri } from "./hijri";
+import type { HaidLog } from "./haid";
+
+/** Ramaḍān is the 9th Hijri month. */
+const RAMADAN_MONTH = 9;
+/** Skip a pause range longer than this (corrupt or foreign data) to bound the loop. */
+const MAX_SPAN_DAYS = 1000;
+
+/** Stored fasting-qaḍāʾ state: how many of the owed make-up fasts are completed. */
+export interface FastingQadaLog {
+  madeUp: number;
+}
+
+/** The empty log — nothing made up yet. */
+export const EMPTY_FASTING_QADA: FastingQadaLog = { madeUp: 0 };
+
+/** Whether a `YYYY-MM-DD` date falls in Ramaḍān, under the given Hijri adjustment. */
+export function isRamadanDate(date: string, hijriAdjust = 0): boolean {
+  const parts = date.split("-");
+  if (parts.length !== 3) return false;
+  const year = Number(parts[0]);
+  const month = Number(parts[1]);
+  const day = Number(parts[2]);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
+  return gregorianToHijri({ year, month, day }, hijriAdjust).month === RAMADAN_MONTH;
+}
+
+/**
+ * The distinct Gregorian days inside any ḥayḍ pause that fall in Ramaḍān, bounded
+ * to `today` for an open (ongoing) period. These are the fasts owed as qaḍāʾ. A
+ * `Set` keeps the count correct even if two periods overlap; a corrupt or absurdly
+ * long range is skipped rather than looped over.
+ */
+export function ramadanPauseDays(haid: HaidLog, today: string, hijriAdjust = 0): string[] {
+  const days = new Set<string>();
+  for (const period of haid) {
+    const end = period.end ?? today;
+    const span = daysBetween(period.start, end);
+    if (!Number.isFinite(span) || span < 0 || span > MAX_SPAN_DAYS) continue;
+    let date = period.start;
+    for (let i = 0; i <= span; i++) {
+      if (isRamadanDate(date, hijriAdjust)) days.add(date);
+      date = addDays(date, 1);
+    }
+  }
+  return [...days];
+}
+
+/** How many qaḍāʾ fasts are owed — derived from ḥayḍ pauses ∩ Ramaḍān. */
+export function fastingQadaOwed(haid: HaidLog, today: string, hijriAdjust = 0): number {
+  return ramadanPauseDays(haid, today, hijriAdjust).length;
+}
+
+/** The made-up count, clamped into the valid range `[0, owed]` for display. */
+export function fastingMadeUp(log: FastingQadaLog, owed: number): number {
+  const n = Math.trunc(log.madeUp);
+  return Number.isFinite(n) ? Math.min(Math.max(0, n), Math.max(0, owed)) : 0;
+}
+
+/** Fasts still to make up: owed minus made-up, never below zero. */
+export function fastingQadaRemaining(log: FastingQadaLog, owed: number): number {
+  return Math.max(0, owed) - fastingMadeUp(log, owed);
+}
+
+/** Adjust the made-up count by `delta` (`+1` makes one up, `-1` undoes), clamped to `[0, owed]`. */
+export function adjustFastingMadeUp(
+  log: FastingQadaLog,
+  delta: number,
+  owed: number,
+): FastingQadaLog {
+  const next = Math.min(Math.max(0, fastingMadeUp(log, owed) + Math.trunc(delta)), Math.max(0, owed));
+  return { madeUp: next };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * from "./prayer";
 export * from "./prayer-tracker";
 export * from "./qada";
 export * from "./haid";
+export * from "./fasting-qada";
 export * from "./achievements";
 export * from "./qibla";
 export * from "./hijri";

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -20,6 +20,7 @@ import type { Collection } from "./collections";
 import type { PrayerTrackerLog } from "./prayer-tracker";
 import type { QadaLog } from "./qada";
 import type { HaidLog } from "./haid";
+import type { FastingQadaLog } from "./fasting-qada";
 import type { TasbihRecord } from "./tasbih";
 import type { HifzCard } from "./hifz";
 import type {
@@ -270,6 +271,18 @@ export interface PrayerTrackerStore {
 export interface QadaStore {
   read(): Promise<QadaLog>;
   write(log: QadaLog): Promise<void>;
+}
+
+/**
+ * Persists fasting-qaḍāʾ progress on-device (ADR 0024, 0034): how many of the
+ * make-up fasts owed — derived from ḥayḍ pauses ∩ Ramaḍān (`fasting-qada.ts`) —
+ * have been completed. Web uses `localStorage`, mobile `AsyncStorage`; a synced
+ * adapter (#25) replaces either without touching the maths. `read()` returns
+ * `{ madeUp: 0 }` when nothing is recorded.
+ */
+export interface FastingQadaStore {
+  read(): Promise<FastingQadaLog>;
+  write(log: FastingQadaLog): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## What

Completes the **fasting** side of #138, which ADR 0031 deferred: Ramaḍān fast-days missed during a ḥayḍ pause are now surfaced as **ṣawm qaḍāʾ** (make-up fasts) with a counter to tick them off. Closes #155.

ADR 0031 itself ended with *"When a date-based fasting tracker lands, wire the pause range into fast make-up"* — this is that follow-up.

## Approach

- **Owed is derived, not stored.** `core/fasting-qada.ts` intersects the existing `HaidLog` with Ramaḍān (Hijri month 9): each paused Gregorian day in Ramaḍān is one fast owed (`ramadanPauseDays` → `fastingQadaOwed`), bounding an open period to the injected "today" and honouring the user's `hijriAdjust`. Pure, deterministic, clock-injected.
- **Only the made-up count is persisted** — `FastingQadaLog = { madeUp: number }` behind a new `FastingQadaStore` port (`localStorage` web / `AsyncStorage` mobile, ADR 0024). Because owed is recomputed from the live pause log, editing a pause re-derives the total with no migration.
- This is the per-fiqh asymmetry: prayers in a ḥayḍ pause are **not** owed (ADR 0031), but the fasts **are**.

## Changes

- **core** — `fasting-qada.ts` + `FastingQadaStore` port; exported; **13 unit tests** (intersection, straddling pause, open period, overlap de-dupe, corrupt range, clamping).
- **web** — `FastingQadaTracker` on `/tracker` (next to the prayer qaḍāʾ tracker) with an empty state; `lib/fasting-qada.ts` + store adapter; component test.
- **mobile** — make-up section on the prayer-tracker screen; store adapter.
- **docs** — ADR 0034 + index row.
- **hardening** — corrupt-value fallback tests for `ul.fastingQada` on both platforms.

## Acceptance (from #155)

- [x] Date-based fasting/qaḍāʾ model behind a store port (ADR 0024).
- [x] "Fasts to make up" derived from pause ∩ Ramaḍān, feeding a make-up counter (sibling of the prayer qaḍāʾ tracker, ADR 0030).
- [x] Web + mobile.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (core 388 incl. 13 new; web 277 incl. the tracker test; mobile/adapters/data/extension green), `pnpm build` — all pass.
- The `/tracker` page prerenders cleanly in the production build.

## Note

`ul.fastingQada` is intentionally **not** added to `MANAGED_KEYS` — like the other counters/logs (`ul.qada`, `ul.haid`), it awaits the v2 element-level sync merge (ADR 0033).