### PR TITLE
fix(e2e): disambiguate the home-nav surah locator

### DIFF
--- a/e2e/home-nav.spec.ts
+++ b/e2e/home-nav.spec.ts
@@ -4,13 +4,17 @@ test.describe("Home navigation", () => {
   test("opening a surah from the home list lands in the reader", async ({ page }) => {
     await page.goto("/");
 
-    // The surah index lists Al-Fātiḥah ("The Opening").
-    const opening = page.getByRole("link", { name: /The Opening/ });
+    // The surah index row for Al-Fātiḥah ("The Opening"). The home page also shows
+    // a "Start reading" card linking to the same surah (it defaults to Al-Fātiḥah
+    // when there's no last-read), so match the index row's distinctive "· N ayahs"
+    // subtitle — the card reads "· Juzʾ N" instead — to keep the locator unique.
+    const opening = page.getByRole("link", { name: /The Opening · \d+ ayahs/ });
     await expect(opening).toBeVisible();
     await opening.click();
 
-    // We land on the surah-1 reader, with its mode chrome present.
-    await expect(page).toHaveURL(/\/surah\/1$/);
-    await expect(page.getByRole("button", { name: "Verse" })).toBeVisible();
+    // We land on the surah-1 reader, with its mode chrome present. Generous
+    // timeouts so a cold dev-server compile of /surah/[number] doesn't flake.
+    await expect(page).toHaveURL(/\/surah\/1$/, { timeout: 30_000 });
+    await expect(page.getByRole("button", { name: "Verse" })).toBeVisible({ timeout: 30_000 });
   });
 });


### PR DESCRIPTION
## What

Fixes the **E2E (Playwright)** check, which has been **red on `main`** (and every PR) at `home-nav.spec.ts:9`.

## Root cause

The home page (`NoorHomePage`) always renders a **"Start reading" card** that links to the same surah as the index row — `ContinueReadingCard` **defaults to Al-Fātiḥah** when there's no last-read position (`byNumber.get(1)`). So both the card and the surah-index row carry "The Opening" in their accessible names, and `getByRole('link', { name: /The Opening/ })` matched **two** elements → strict-mode violation. This is deterministic, not a flake.

## Fix (test-only)

- Match the index row's distinctive **"· N ayahs"** subtitle (`/The Opening · \d+ ayahs/`). The card reads "· Juzʾ N" instead, so the locator now resolves to exactly one element.
- Give the post-navigation assertions a 30s timeout so a cold dev-server compile of `/surah/[number]` doesn't flake `toHaveURL`.

No source/behaviour change — one spec file.

## Verification

Ran locally against Chromium:
- `home-nav.spec.ts` now **passes** (cold-compile nav ~31s, within the new window).
- A throwaway proof spec (seeding `ul.lastRead` to force the card) confirmed the OLD locator matches **2** links while the new `/The Opening · \d+ ayahs/` matches exactly **1** — then removed.

This should return the E2E check to green on `main`.