### PR TITLE
feat(reader): word-by-word transliteration toggle (#144)

### DIFF
--- a/apps/mobile/src/components/AyahView.tsx
+++ b/apps/mobile/src/components/AyahView.tsx
@@ -25,6 +25,8 @@ interface Props {
   translations: TrLine[];
   /** Latin transliteration line shown under the Arabic (#150); null when off. */
   transliteration?: string | null;
+  /** Per-word Latin transliteration (#144); when present, words stack over it. */
+  translitWords?: string[] | null;
   activeWord: number;
   playing: boolean;
   scale: number;
@@ -56,6 +58,7 @@ function AyahViewImpl({
   words,
   translations,
   transliteration,
+  translitWords,
   activeWord,
   playing,
   scale,
@@ -91,7 +94,9 @@ function AyahViewImpl({
             <Icon name="play" size={17} color={playing ? colors.accent : colors.faint} />
           </Pressable>
           <Pressable
-            onPress={() => (memorized ? removeHifzCard(ref) : setHifzCard(ref, createCard(new Date())))}
+            onPress={() =>
+              memorized ? removeHifzCard(ref) : setHifzCard(ref, createCard(new Date()))
+            }
             hitSlop={8}
             accessibilityLabel={memorized ? "Stop memorizing" : "Memorize āyah"}
           >
@@ -104,38 +109,54 @@ function AyahViewImpl({
         </View>
       </View>
 
-      <Text
-        style={[styles.arabic, { fontSize: 26 * scale, lineHeight: 50 * scale }]}
-        onPress={peek ? undefined : () => onPlayFrom(aya)}
-      >
-        {/* In peek mode every word is a tappable span — concealed until the
+      {translitWords && translitWords.length > 0 && !peek ? (
+        // Word-by-word transliteration (#144): each word stacks over its Latin
+        // reading, flowing right-to-left with wrap. Audio highlight is dropped in
+        // this learning view.
+        <View style={styles.wbwRow}>
+          {words.map((w, i) => (
+            <Pressable key={i} style={styles.wbwUnit} onPress={() => onPlayFrom(aya)}>
+              <Text style={[styles.wbwAr, { fontSize: 26 * scale, lineHeight: 40 * scale }]}>
+                {w}
+              </Text>
+              <Text style={[styles.wbwTr, { fontSize: 12 * scale }]}>{translitWords[i] ?? ""}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : (
+        <Text
+          style={[styles.arabic, { fontSize: 26 * scale, lineHeight: 50 * scale }]}
+          onPress={peek ? undefined : () => onPlayFrom(aya)}
+        >
+          {/* In peek mode every word is a tappable span — concealed until the
             reveal cursor reaches it or it's tapped. Otherwise only the playing
             āyah splits into per-word spans (for highlighting); every other āyah
             renders as a single text node, which keeps long surahs cheap to scroll. */}
-        {peek
-          ? words.map((w, i) => {
-              const gi = peekStart + i;
-              const shown = gi < peekRevealed || peekExtra?.has(gi);
-              return (
-                <Text
-                  key={i}
-                  onPress={() => onPeekWord?.(gi)}
-                  style={shown ? undefined : styles.wordHidden}
-                >
-                  {w}
-                  {i < words.length - 1 ? " " : ""}
-                </Text>
-              );
-            })
-          : playing
-            ? words.map((w, i) => (
-                <Text key={i} style={i === activeWord ? styles.wordActive : undefined}>
-                  {w}
-                  {i < words.length - 1 ? " " : ""}
-                </Text>
-              ))
-            : arabic}
-      </Text>
+          {peek
+            ? words.map((w, i) => {
+                const gi = peekStart + i;
+                const shown = gi < peekRevealed || peekExtra?.has(gi);
+                return (
+                  <Text
+                    key={i}
+                    onPress={() => onPeekWord?.(gi)}
+                    style={shown ? undefined : styles.wordHidden}
+                  >
+                    {w}
+                    {i < words.length - 1 ? " " : ""}
+                  </Text>
+                );
+              })
+            : playing
+              ? words.map((w, i) => (
+                  <Text key={i} style={i === activeWord ? styles.wordActive : undefined}>
+                    {w}
+                    {i < words.length - 1 ? " " : ""}
+                  </Text>
+                ))
+              : arabic}
+        </Text>
+      )}
 
       {transliteration && !peekHideTr ? (
         <Text style={[styles.translit, { fontSize: 14 * scale, lineHeight: 22 * scale }]}>
@@ -145,19 +166,19 @@ function AyahViewImpl({
 
       {!peekHideTr &&
         translations.map((t) => (
-        <View key={t.id} style={styles.tr}>
-          {translations.length > 1 && <Text style={styles.trName}>{t.name}</Text>}
-          <Text
-            style={[
-              styles.trText,
-              { fontSize: 15 * scale, lineHeight: 24 * scale },
-              t.direction === "rtl" && styles.rtl,
-            ]}
-          >
-            {t.text}
-          </Text>
-        </View>
-      ))}
+          <View key={t.id} style={styles.tr}>
+            {translations.length > 1 && <Text style={styles.trName}>{t.name}</Text>}
+            <Text
+              style={[
+                styles.trText,
+                { fontSize: 15 * scale, lineHeight: 24 * scale },
+                t.direction === "rtl" && styles.rtl,
+              ]}
+            >
+              {t.text}
+            </Text>
+          </View>
+        ))}
 
       <AyahTafsir sura={sura} aya={aya} />
     </View>
@@ -189,6 +210,17 @@ function makeStyles(c: Palette) {
     // Concealed word: keep its footprint (a hint of length) but hide the glyphs.
     wordHidden: { color: "transparent", backgroundColor: c.borderSoft },
     translit: { color: c.faint, marginTop: 10, fontStyle: "italic", fontFamily: FONT.medium },
+    // Word-by-word transliteration (#144): RTL flow of stacked word units.
+    wbwRow: {
+      flexDirection: "row-reverse",
+      flexWrap: "wrap",
+      alignItems: "flex-start",
+      justifyContent: "flex-start",
+      gap: 12,
+    },
+    wbwUnit: { alignItems: "center" },
+    wbwAr: { color: c.fg, fontFamily: FONT.ar, textAlign: "center" },
+    wbwTr: { color: c.faint, marginTop: 2, fontFamily: FONT.medium, textAlign: "center" },
     tr: { marginTop: 12 },
     trName: { color: c.faint, fontSize: 12, marginBottom: 3, fontFamily: FONT.medium },
     trText: { color: c.muted },

--- a/apps/mobile/src/components/ReaderControls.tsx
+++ b/apps/mobile/src/components/ReaderControls.tsx
@@ -17,6 +17,8 @@ export function ReaderControls({
   onScale,
   transliteration,
   onTransliteration,
+  wordTransliteration,
+  onWordTransliteration,
   onManage,
 }: {
   mode: ReadingMode;
@@ -25,6 +27,8 @@ export function ReaderControls({
   onScale: (n: number) => void;
   transliteration: boolean;
   onTransliteration: (on: boolean) => void;
+  wordTransliteration: boolean;
+  onWordTransliteration: (on: boolean) => void;
   onManage: () => void;
 }) {
   const { colors } = useTheme();
@@ -68,12 +72,21 @@ export function ReaderControls({
             accessibilityState={{ checked: transliteration }}
             accessibilityLabel="Transliteration"
           >
-            <Text style={[styles.toggleText, transliteration && styles.toggleTextOn]}>
-              Aa Translit
+            <Text style={[styles.toggleText, transliteration && styles.toggleTextOn]}>Aa Line</Text>
+          </Pressable>
+          <Pressable
+            style={[styles.toggle, wordTransliteration && styles.toggleOn]}
+            onPress={() => onWordTransliteration(!wordTransliteration)}
+            accessibilityRole="switch"
+            accessibilityState={{ checked: wordTransliteration }}
+            accessibilityLabel="Word transliteration"
+          >
+            <Text style={[styles.toggleText, wordTransliteration && styles.toggleTextOn]}>
+              Aa Word
             </Text>
           </Pressable>
           <Pressable style={styles.manage} onPress={onManage}>
-            <Text style={styles.manageText}>⚙ Translations</Text>
+            <Text style={styles.manageText}>⚙</Text>
           </Pressable>
         </View>
       </View>
@@ -95,8 +108,14 @@ function makeStyles(c: Palette) {
     segItemOn: { backgroundColor: c.accentSoft },
     segText: { color: c.muted, fontSize: 13, fontWeight: "600" },
     segTextOn: { color: c.accent },
-    rightRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
-    rightBtns: { flexDirection: "row", gap: 8 },
+    rightRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      flexWrap: "wrap",
+      rowGap: 8,
+    },
+    rightBtns: { flexDirection: "row", gap: 8, flexWrap: "wrap" },
     scale: { flexDirection: "row", gap: 8 },
     scaleBtn: {
       paddingVertical: 6,

--- a/apps/mobile/src/screens/JuzReaderScreen.tsx
+++ b/apps/mobile/src/screens/JuzReaderScreen.tsx
@@ -19,6 +19,7 @@ import { useSurahAudio, verseKeyOf } from "../audio/useSurahAudio";
 import { AudioRangeControls } from "../components/AudioRangeControls";
 import { MemorizeBar } from "../components/MemorizeBar";
 import { DEFAULT_EDITION, TRANSLIT_EDITION } from "../types";
+import { fetchSurahWordTranslit } from "../word-translit";
 import type { ReadStackParamList } from "../navigation/types";
 
 type Props = NativeStackScreenProps<ReadStackParamList, "JuzReader">;
@@ -30,6 +31,8 @@ interface Line {
   translation: string;
   /** Latin transliteration line (#150); empty when the toggle is off. */
   transliteration: string;
+  /** Per-word transliteration (#144); empty when the toggle is off. */
+  translitWords: string[];
   surahHeader?: string;
 }
 
@@ -52,7 +55,8 @@ function juzRange(juz: number): { sura: number; from: number; toExclusive: numbe
 export function JuzReaderScreen({ route }: Props) {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
-  const { editions, readingTranslation, reciterId, scale, transliteration } = useSettings();
+  const { editions, readingTranslation, reciterId, scale, transliteration, wordTransliteration } =
+    useSettings();
   const reciter = RECITERS.find((r) => r.id === reciterId) ?? RECITER;
   const audio = useSurahAudio(reciter);
 
@@ -81,12 +85,15 @@ export function JuzReaderScreen({ route }: Props) {
     const parts = juzRange(Number(juz));
     Promise.all(
       parts.map(async (p) => {
-        const [surah, tr, translit] = await Promise.all([
+        const [surah, tr, translit, wordTranslit] = await Promise.all([
           api.getSurah(p.sura),
           api.getCatalogTranslation(edition, p.sura).catch(() => []),
           transliteration
             ? api.getCatalogTranslation(TRANSLIT_EDITION, p.sura).catch(() => [])
             : Promise.resolve([]),
+          wordTransliteration
+            ? fetchSurahWordTranslit(p.sura).catch(() => new Map<number, string[]>())
+            : Promise.resolve(new Map<number, string[]>()),
         ]);
         const trByAya = new Map(tr.map((t) => [t.aya, t.text]));
         const translitByAya = new Map(translit.map((t) => [t.aya, t.text]));
@@ -100,6 +107,7 @@ export function JuzReaderScreen({ route }: Props) {
             arabic: a.text,
             translation: trByAya.get(a.aya) ?? "",
             transliteration: translitByAya.get(a.aya) ?? "",
+            translitWords: wordTranslit.get(a.aya) ?? [],
             surahHeader:
               i === 0 ? `${surah.surah.transliteration} · ${surah.surah.englishName}` : undefined,
           }),
@@ -114,7 +122,7 @@ export function JuzReaderScreen({ route }: Props) {
       active = false;
       audio.stop();
     };
-  }, [juz, edition, transliteration]);
+  }, [juz, edition, transliteration, wordTransliteration]);
 
   const verses = useMemo(() => (lines ?? []).map((l) => ({ sura: l.sura, aya: l.aya })), [lines]);
 
@@ -214,25 +222,43 @@ export function JuzReaderScreen({ route }: Props) {
               style={[styles.ayah, playing && styles.ayahPlaying]}
               onPress={peek ? undefined : () => audio.playFrom(verses, l, true)}
             >
-              <Text style={[styles.arabic, { fontSize: 24 * scale, lineHeight: 44 * scale }]}>
-                {peek
-                  ? peekWords[i].map((w, wi) => {
-                      const gi = peekStarts[i]! + wi;
-                      const shown = gi < revealed || peekExtra.has(gi);
-                      return (
-                        <Text
-                          key={wi}
-                          onPress={() => onPeekWord(gi)}
-                          style={shown ? undefined : styles.wordHidden}
-                        >
-                          {w}
-                          {wi < peekWords[i]!.length - 1 ? " " : ""}
-                        </Text>
-                      );
-                    })
-                  : l.arabic}{" "}
-                <Text style={styles.marker}>﴿{l.aya}﴾</Text>
-              </Text>
+              {wordTransliteration && l.translitWords.length > 0 && !peek ? (
+                <View style={styles.wbwRow}>
+                  {peekWords[i]!.map((w, wi) => (
+                    <View key={wi} style={styles.wbwUnit}>
+                      <Text
+                        style={[styles.wbwAr, { fontSize: 24 * scale, lineHeight: 38 * scale }]}
+                      >
+                        {w}
+                      </Text>
+                      <Text style={[styles.wbwTr, { fontSize: 11 * scale }]}>
+                        {l.translitWords[wi] ?? ""}
+                      </Text>
+                    </View>
+                  ))}
+                  <Text style={styles.marker}>﴿{l.aya}﴾</Text>
+                </View>
+              ) : (
+                <Text style={[styles.arabic, { fontSize: 24 * scale, lineHeight: 44 * scale }]}>
+                  {peek
+                    ? peekWords[i].map((w, wi) => {
+                        const gi = peekStarts[i]! + wi;
+                        const shown = gi < revealed || peekExtra.has(gi);
+                        return (
+                          <Text
+                            key={wi}
+                            onPress={() => onPeekWord(gi)}
+                            style={shown ? undefined : styles.wordHidden}
+                          >
+                            {w}
+                            {wi < peekWords[i]!.length - 1 ? " " : ""}
+                          </Text>
+                        );
+                      })
+                    : l.arabic}{" "}
+                  <Text style={styles.marker}>﴿{l.aya}﴾</Text>
+                </Text>
+              )}
               {l.transliteration && !hideTr ? (
                 <Text style={[styles.translit, { fontSize: 14 * scale, lineHeight: 22 * scale }]}>
                   {l.transliteration}
@@ -302,5 +328,16 @@ function makeStyles(c: Palette) {
     marker: { color: c.accent, fontSize: 17, fontFamily: FONT.ar },
     translit: { color: c.faint, marginTop: 10, fontStyle: "italic" },
     tr: { color: c.fg, marginTop: 10 },
+    // Word-by-word transliteration (#144): RTL flow of stacked word units.
+    wbwRow: {
+      flexDirection: "row-reverse",
+      flexWrap: "wrap",
+      alignItems: "flex-start",
+      justifyContent: "flex-start",
+      gap: 11,
+    },
+    wbwUnit: { alignItems: "center" },
+    wbwAr: { color: c.fg, fontFamily: FONT.ar, textAlign: "center" },
+    wbwTr: { color: c.faint, marginTop: 2, fontFamily: FONT.medium, textAlign: "center" },
   });
 }

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -31,6 +31,7 @@ import { useSettings } from "../state/SettingsContext";
 import { useLibrary } from "../state/LibraryContext";
 import { useSurahAudio, verseKeyOf } from "../audio/useSurahAudio";
 import { DEFAULT_EDITION, TRANSLIT_EDITION } from "../types";
+import { fetchSurahWordTranslit } from "../word-translit";
 import { ReaderControls } from "../components/ReaderControls";
 import { AudioRangeControls } from "../components/AudioRangeControls";
 import { MemorizeBar } from "../components/MemorizeBar";
@@ -57,12 +58,14 @@ export function SurahReaderScreen({ navigation, route }: Props) {
     reciterId,
     scale,
     transliteration,
+    wordTransliteration,
     catalogue,
     setEditions,
     setReadingMode,
     setReadingTranslation,
     setScale,
     setTransliteration,
+    setWordTransliteration,
   } = settings;
   const { setLastRead, isBookmarked, toggleBookmark } = useLibrary();
 
@@ -73,6 +76,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
   const [ayahs, setAyahs] = useState<Ayah[] | null>(null);
   const [trMap, setTrMap] = useState<Map<string, Map<number, string>>>(new Map());
   const [translitMap, setTranslitMap] = useState<Map<number, string>>(new Map());
+  const [wordTranslitMap, setWordTranslitMap] = useState<Map<number, string[]>>(new Map());
   const [error, setError] = useState(false);
   const [managerOpen, setManagerOpen] = useState(false);
 
@@ -203,6 +207,23 @@ export function SurahReaderScreen({ navigation, route }: Props) {
     };
   }, [n, transliteration]);
 
+  // Fetch per-word transliteration (#144) for this surah only while enabled.
+  useEffect(() => {
+    if (!wordTransliteration) {
+      setWordTranslitMap(new Map());
+      return;
+    }
+    let active = true;
+    fetchSurahWordTranslit(n)
+      .then((map) => {
+        if (active) setWordTranslitMap(map);
+      })
+      .catch(() => active && setWordTranslitMap(new Map()));
+    return () => {
+      active = false;
+    };
+  }, [n, wordTransliteration]);
+
   const verses = useMemo(() => (ayahs ?? []).map((a) => ({ sura: n, aya: a.aya })), [ayahs, n]);
   const metaById = useMemo(() => new Map(catalogue.map((e) => [e.id, e])), [catalogue]);
 
@@ -228,11 +249,22 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         arabic: a.text,
         words: a.text.split(" "),
         transliteration: transliteration ? (translitMap.get(a.aya) ?? null) : null,
+        translitWords: wordTransliteration ? (wordTranslitMap.get(a.aya) ?? null) : null,
         translations: editions
           .map((id) => trLineFor(id, a.aya))
           .filter((x): x is TrLine => x !== null),
       })),
-    [ayahs, editions, trMap, metaById, n, transliteration, translitMap],
+    [
+      ayahs,
+      editions,
+      trMap,
+      metaById,
+      n,
+      transliteration,
+      translitMap,
+      wordTransliteration,
+      wordTranslitMap,
+    ],
   );
 
   // Peek geometry: each āyah's word count and the global index of its first word,
@@ -284,6 +316,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         words={item.words}
         translations={item.translations}
         transliteration={item.transliteration}
+        translitWords={item.translitWords}
         activeWord={playingKey === item.key ? activeWord : -1}
         playing={playingKey === item.key}
         scale={scale}
@@ -402,6 +435,8 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         onScale={setScale}
         transliteration={transliteration}
         onTransliteration={setTransliteration}
+        wordTransliteration={wordTransliteration}
+        onWordTransliteration={setWordTransliteration}
         onManage={() => setManagerOpen(true)}
       />
 
@@ -485,7 +520,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
           data={rows}
           keyExtractor={(r) => r.key}
           renderItem={renderItem}
-          extraData={`${playingKey ?? ""}:${activeWord}:${scale}:${peek}:${revealed}:${peekExtra.size}:${hideTr}:${transliteration}:${translitMap.size}`}
+          extraData={`${playingKey ?? ""}:${activeWord}:${scale}:${peek}:${revealed}:${peekExtra.size}:${hideTr}:${transliteration}:${translitMap.size}:${wordTransliteration}:${wordTranslitMap.size}`}
           contentContainerStyle={styles.content}
           onViewableItemsChanged={onViewable}
           viewabilityConfig={viewabilityConfig}

--- a/apps/mobile/src/state/SettingsContext.tsx
+++ b/apps/mobile/src/state/SettingsContext.tsx
@@ -31,6 +31,8 @@ interface SettingsValue {
   scale: number;
   /** Show the per-āyah Latin transliteration line under the Arabic (#150). */
   transliteration: boolean;
+  /** Show per-word Latin transliteration beneath each Arabic word (#144). */
+  wordTransliteration: boolean;
   catalogue: Translation[];
   tafsirs: TafsirMeta[];
   setEditions: (ids: string[]) => void;
@@ -41,6 +43,7 @@ interface SettingsValue {
   setTafsirCompare: (ids: string[]) => void;
   setScale: (scale: number) => void;
   setTransliteration: (on: boolean) => void;
+  setWordTransliteration: (on: boolean) => void;
 }
 
 const SettingsContext = createContext<SettingsValue | null>(null);
@@ -56,19 +59,25 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [tafsirCompare, setTafsirCompareState] = useState<string[]>([]);
   const [scale, setScaleState] = useState<number>(1);
   const [transliteration, setTransliterationState] = useState<boolean>(false);
+  const [wordTransliteration, setWordTransliterationState] = useState<boolean>(false);
   const [catalogue, setCatalogue] = useState<Translation[]>([]);
   const [tafsirs, setTafsirs] = useState<TafsirMeta[]>([]);
 
   useEffect(() => {
     void store.read().then((s) => {
       if (s.editions && s.editions.length > 0) setEditionsState(s.editions);
-      if (s.readingMode === "translation" || s.readingMode === "reading" || s.readingMode === "reading-tr")
+      if (
+        s.readingMode === "translation" ||
+        s.readingMode === "reading" ||
+        s.readingMode === "reading-tr"
+      )
         setReadingModeState(s.readingMode);
       if (s.readingTranslation) setReadingTranslationState(s.readingTranslation);
       if (s.reciter) setReciterIdState(s.reciter);
       if (s.tafsir) setTafsirIdState(s.tafsir);
       if (s.scale != null) setScaleState(clampScale(s.scale));
       if (s.transliteration != null) setTransliterationState(s.transliteration);
+      if (s.wordTransliteration != null) setWordTransliterationState(s.wordTransliteration);
     });
     void readTafsirCompare().then(setTafsirCompareState);
     void api
@@ -123,6 +132,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     void store.writeTransliteration(on);
   }, []);
 
+  const setWordTransliteration = useCallback((on: boolean) => {
+    setWordTransliterationState(on);
+    void store.writeWordTransliteration(on);
+  }, []);
+
   const value = useMemo<SettingsValue>(
     () => ({
       editions,
@@ -133,6 +147,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       tafsirCompare,
       scale,
       transliteration,
+      wordTransliteration,
       catalogue,
       tafsirs,
       setEditions,
@@ -143,6 +158,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setTafsirCompare,
       setScale,
       setTransliteration,
+      setWordTransliteration,
     }),
     [
       editions,
@@ -153,6 +169,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       tafsirCompare,
       scale,
       transliteration,
+      wordTransliteration,
       catalogue,
       tafsirs,
       setEditions,
@@ -163,6 +180,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setTafsirCompare,
       setScale,
       setTransliteration,
+      setWordTransliteration,
     ],
   );
 

--- a/apps/mobile/src/state/settings-store.ts
+++ b/apps/mobile/src/state/settings-store.ts
@@ -19,17 +19,35 @@ import {
 
 export const mobileSettingsStore: SettingsStore = {
   read: async (): Promise<StoredSettings> => {
-    const [editions, readingMode, readingTranslation, reciter, tafsir, scale, transliteration] =
-      await Promise.all([
-        getJSON<string[] | null>(KEYS.editions, null, isStringArray),
-        getString(KEYS.readingMode),
-        getString(KEYS.readingTranslation),
-        getString(KEYS.reciter),
-        getString(KEYS.tafsir),
-        getJSON<number | null>(KEYS.scale, null, isFiniteNumber),
-        getJSON<boolean | null>(KEYS.transliteration, null, isBoolean),
-      ]);
-    return { editions, readingMode, readingTranslation, reciter, tafsir, scale, transliteration };
+    const [
+      editions,
+      readingMode,
+      readingTranslation,
+      reciter,
+      tafsir,
+      scale,
+      transliteration,
+      wordTransliteration,
+    ] = await Promise.all([
+      getJSON<string[] | null>(KEYS.editions, null, isStringArray),
+      getString(KEYS.readingMode),
+      getString(KEYS.readingTranslation),
+      getString(KEYS.reciter),
+      getString(KEYS.tafsir),
+      getJSON<number | null>(KEYS.scale, null, isFiniteNumber),
+      getJSON<boolean | null>(KEYS.transliteration, null, isBoolean),
+      getJSON<boolean | null>(KEYS.wbwTranslit, null, isBoolean),
+    ]);
+    return {
+      editions,
+      readingMode,
+      readingTranslation,
+      reciter,
+      tafsir,
+      scale,
+      transliteration,
+      wordTransliteration,
+    };
   },
   writeEditions: (ids) => setJSON(KEYS.editions, ids),
   writeReadingMode: (mode) => setString(KEYS.readingMode, mode),
@@ -38,4 +56,5 @@ export const mobileSettingsStore: SettingsStore = {
   writeTafsir: (id) => setString(KEYS.tafsir, id),
   writeScale: (scale) => setJSON(KEYS.scale, scale),
   writeTransliteration: (on) => setJSON(KEYS.transliteration, on),
+  writeWordTransliteration: (on) => setJSON(KEYS.wbwTranslit, on),
 };

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -15,6 +15,7 @@ export const KEYS = {
   audioRate: "ul.audioRate",
   scale: "ul.scale",
   transliteration: "ul.transliteration",
+  wbwTranslit: "ul.wbwTranslit",
   theme: "ul.theme",
   bookmarks: "ul.bookmarks",
   collections: "ul.collections",

--- a/apps/mobile/src/word-translit.ts
+++ b/apps/mobile/src/word-translit.ts
@@ -1,0 +1,44 @@
+/**
+ * Per-word transliteration for the reader (#144), fetched at runtime from
+ * quran.com — display-only, not bundled (mirrors the web `lib/word-translit`).
+ * One request per surah (a surah fits in a single page at `per_page=300`),
+ * memoised so a surah is fetched at most once per session.
+ */
+interface QuranComWord {
+  char_type_name?: string;
+  transliteration?: { text: string | null } | null;
+}
+interface QuranComVerse {
+  verse_key?: string;
+  words?: QuranComWord[];
+}
+
+const cache = new Map<number, Promise<Map<number, string[]>>>();
+
+/** `āyah → [transliteration per word]` for a whole surah; empty map on any failure. */
+export function fetchSurahWordTranslit(surah: number): Promise<Map<number, string[]>> {
+  let pending = cache.get(surah);
+  if (!pending) {
+    pending = fetch(
+      `https://api.quran.com/api/v4/verses/by_chapter/${surah}?words=true&word_fields=transliteration&per_page=300`,
+    )
+      .then((r) => (r.ok ? (r.json() as Promise<{ verses?: QuranComVerse[] }>) : { verses: [] }))
+      .then((d) => {
+        const map = new Map<number, string[]>();
+        for (const v of d.verses ?? []) {
+          const aya = Number(v.verse_key?.split(":")[1]);
+          if (!Number.isInteger(aya)) continue;
+          map.set(
+            aya,
+            (v.words ?? [])
+              .filter((w) => w.char_type_name === "word")
+              .map((w) => w.transliteration?.text ?? ""),
+          );
+        }
+        return map;
+      })
+      .catch(() => new Map<number, string[]>());
+    cache.set(surah, pending);
+  }
+  return pending;
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -457,6 +457,30 @@ body.audio-playing .ayah--current:not(.ayah--playing) {
   background: var(--accent-soft);
 }
 
+/* Word-by-word transliteration (#144): when enabled, each word stacks over its
+   Latin transliteration and the āyah flows the units right-to-left with wrap. */
+body.wbw-translit-on .ayah-ar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.5em 0.55em;
+  line-height: 1.35;
+}
+.w-unit {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+}
+.w-tr {
+  direction: ltr;
+  font-family: var(--font-ui, inherit);
+  font-size: 0.42em;
+  line-height: 1.3;
+  color: var(--faint);
+  margin-top: 0.2em;
+  white-space: nowrap;
+}
+
 .surah-search {
   width: 100%;
   font: inherit;

--- a/apps/web/src/app/juz/[number]/page.tsx
+++ b/apps/web/src/app/juz/[number]/page.tsx
@@ -15,6 +15,7 @@ import { EditionManager } from "../../../components/EditionManager";
 import { ReadingTranslationPicker } from "../../../components/ReadingTranslationPicker";
 import { AyahTranslations } from "../../../components/AyahTranslations";
 import { AyahTransliteration } from "../../../components/AyahTransliteration";
+import { AyahWords } from "../../../components/AyahWords";
 import { AyahStar } from "../../../components/AyahStar";
 import { ReadingTranslationFlow } from "../../../components/ReadingTranslationFlow";
 import { ReaderShortcuts } from "../../../components/ReaderShortcuts";
@@ -165,12 +166,7 @@ export default async function JuzReaderPage({ params }: { params: Promise<{ numb
             {section.ayahs.map((ayah) => (
               <div key={ayah.aya} id={`${section.surah.number}:${ayah.aya}`} className="ayah">
                 <p className="ayah-ar arabic">
-                  {ayah.text.split(" ").flatMap((word, i) => [
-                    <span key={i} className="w" data-w={i}>
-                      {word}
-                    </span>,
-                    " ",
-                  ])}
+                  <AyahWords surah={section.surah.number} aya={ayah.aya} text={ayah.text} />
                   <button
                     type="button"
                     className="ayah-marker"

--- a/apps/web/src/components/AyahWords.test.tsx
+++ b/apps/web/src/components/AyahWords.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { AyahWords } from "./AyahWords";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("AyahWords", () => {
+  it("renders plain word spans with the toggle off (highlighting untouched)", async () => {
+    const { container } = render(<AyahWords surah={1} aya={1} text="بِسْمِ ٱللَّهِ" />);
+    await waitFor(() => expect(container.querySelectorAll(".w")).toHaveLength(2));
+    expect(container.querySelector(".w-tr")).toBeNull();
+    // data-w indices preserved for the audio highlighter.
+    expect(container.querySelector('.w[data-w="0"]')).not.toBeNull();
+  });
+
+  it("stacks each word over its transliteration when enabled", async () => {
+    localStorage.setItem("ul.wbwTranslit", "true");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          verses: [
+            {
+              verse_key: "1:1",
+              words: [
+                { char_type_name: "word", transliteration: { text: "bis'mi" } },
+                { char_type_name: "word", transliteration: { text: "l-lahi" } },
+              ],
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const { container } = render(<AyahWords surah={1} aya={1} text="بِسْمِ ٱللَّهِ" />);
+    await waitFor(() => expect(container.querySelectorAll(".w-tr")).toHaveLength(2));
+    const trs = [...container.querySelectorAll(".w-tr")].map((el) => el.textContent);
+    expect(trs).toEqual(["bis'mi", "l-lahi"]);
+    // The .w spans (and their data-w) still exist inside the stacked units.
+    expect(container.querySelector('.w-unit .w[data-w="1"]')).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/AyahWords.tsx
+++ b/apps/web/src/components/AyahWords.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Fragment, useEffect, useState } from "react";
+import { WORD_TRANSLIT_KEY, fetchSurahWordTranslit, readWordTranslit } from "../lib/word-translit";
+
+/**
+ * The Arabic words of one āyah (#144). With the word-transliteration toggle off
+ * it renders exactly the plain `.w` spans the reader has always used (so audio
+ * highlighting, which targets `.w[data-w]`, is untouched). With it on, each word
+ * becomes a stacked unit — Arabic over its Latin transliteration — and the CSS
+ * `body.wbw-translit-on .ayah-ar` flex layout flows them right-to-left.
+ *
+ * Server-rendered in the off state (the toggle/fetch run only after hydration),
+ * so the Arabic stays in the initial HTML for both the surah and juz readers.
+ */
+export function AyahWords({ surah, aya, text }: { surah: number; aya: number; text: string }) {
+  const words = text.split(" ");
+  const [translit, setTranslit] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      if (!(await readWordTranslit())) {
+        if (active) setTranslit(null);
+        return;
+      }
+      const map = await fetchSurahWordTranslit(surah);
+      if (active) setTranslit(map.get(aya) ?? []);
+    }
+    void load();
+    const onChange = () => void load();
+    window.addEventListener(WORD_TRANSLIT_KEY, onChange);
+    return () => {
+      active = false;
+      window.removeEventListener(WORD_TRANSLIT_KEY, onChange);
+    };
+  }, [surah, aya]);
+
+  if (!translit) {
+    // Off — identical to the reader's long-standing inline rendering.
+    return (
+      <>
+        {words.flatMap((word, i) => [
+          <span key={i} className="w" data-w={i}>
+            {word}
+          </span>,
+          " ",
+        ])}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {words.map((word, i) => (
+        <Fragment key={i}>
+          <span className="w-unit">
+            <span className="w" data-w={i}>
+              {word}
+            </span>
+            <span className="w-tr" aria-hidden="true">
+              {translit[i] ?? ""}
+            </span>
+          </span>{" "}
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/apps/web/src/components/ReaderToolbar.tsx
+++ b/apps/web/src/components/ReaderToolbar.tsx
@@ -10,6 +10,7 @@ import { readBookmarks, toggleBookmark as toggleBm } from "../lib/bookmarks";
 import { readReciter, readScale, writeReciter, writeScale } from "../lib/reader-prefs";
 import { readWordByWord, writeLastRead, writeWordByWord } from "../lib/reader-prefs-store";
 import { readTransliteration, writeTransliteration } from "../lib/transliteration";
+import { WORD_TRANSLIT_CLASS, readWordTranslit, writeWordTranslit } from "../lib/word-translit";
 import { TranslationSettings } from "./TranslationSettings";
 import { TafsirPicker } from "./TafsirPicker";
 import { WBW_KEY } from "./WordByWord";
@@ -51,6 +52,7 @@ export function ReaderToolbar({
   const [reciterId, setReciterId] = useState(reciters[0]?.id ?? "");
   const [wbw, setWbw] = useState(false);
   const [translit, setTranslit] = useState(false);
+  const [wordTranslit, setWordTranslit] = useState(false);
   const [managing, setManaging] = useState(false);
   const [catalogue, setCatalogue] = useState<EditionChoice[]>([]);
   const [selected, setSelected] = useState<Set<string>>(() => new Set(DEFAULT_EDITIONS));
@@ -69,6 +71,10 @@ export function ReaderToolbar({
     setWbw(wbwOn);
     document.body.classList.toggle("wbw-on", wbwOn);
     void readTransliteration().then(setTranslit);
+    void readWordTranslit().then((on) => {
+      setWordTranslit(on);
+      document.body.classList.toggle(WORD_TRANSLIT_CLASS, on);
+    });
     void readEditions().then((ids) => setSelected(new Set(ids)));
     void fetchCatalogue().then(setCatalogue);
   }, [surahNumber, reciters]);
@@ -85,6 +91,13 @@ export function ReaderToolbar({
     const next = !translit;
     setTranslit(next);
     void writeTransliteration(next); // persists + broadcasts `ul.transliteration`
+  }
+
+  function toggleWordTranslit() {
+    const next = !wordTranslit;
+    setWordTranslit(next);
+    document.body.classList.toggle(WORD_TRANSLIT_CLASS, next);
+    void writeWordTranslit(next); // persists + broadcasts `ul.wbwTranslit`
   }
 
   function changeScale(delta: number) {
@@ -151,7 +164,13 @@ export function ReaderToolbar({
     onClick: () => void;
   }) {
     return (
-      <button type="button" title={title} aria-label={title} onClick={onClick} style={iconBtn(!!on)}>
+      <button
+        type="button"
+        title={title}
+        aria-label={title}
+        onClick={onClick}
+        style={iconBtn(!!on)}
+      >
         <Icon name={icon} size={18} />
       </button>
     );
@@ -176,12 +195,24 @@ export function ReaderToolbar({
                 onClick={() => changeScale(-0.1)}
                 disabled={scale <= SCALE_MIN}
                 aria-label="Decrease text size"
-                style={{ ...iconBtn(false), width: 34, height: 34, opacity: scale <= SCALE_MIN ? 0.4 : 1 }}
+                style={{
+                  ...iconBtn(false),
+                  width: 34,
+                  height: 34,
+                  opacity: scale <= SCALE_MIN ? 0.4 : 1,
+                }}
               >
                 <Icon name="minus" size={16} />
               </button>
               <span
-                style={{ minWidth: 44, textAlign: "center", color: N.fg, fontFamily: N.ui, fontSize: 13.5, fontWeight: 700 }}
+                style={{
+                  minWidth: 44,
+                  textAlign: "center",
+                  color: N.fg,
+                  fontFamily: N.ui,
+                  fontSize: 13.5,
+                  fontWeight: 700,
+                }}
               >
                 {Math.round(scale * 100)}%
               </span>
@@ -190,7 +221,12 @@ export function ReaderToolbar({
                 onClick={() => changeScale(0.1)}
                 disabled={scale >= SCALE_MAX}
                 aria-label="Increase text size"
-                style={{ ...iconBtn(false), width: 34, height: 34, opacity: scale >= SCALE_MAX ? 0.4 : 1 }}
+                style={{
+                  ...iconBtn(false),
+                  width: 34,
+                  height: 34,
+                  opacity: scale >= SCALE_MAX ? 0.4 : 1,
+                }}
               >
                 <Icon name="plus" size={16} />
               </button>
@@ -252,13 +288,41 @@ export function ReaderToolbar({
               {translit && <Icon name="check" size={15} color={N.gold} />}
             </button>
 
+            <button
+              type="button"
+              onClick={toggleWordTranslit}
+              aria-pressed={wordTranslit}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 10,
+                width: "100%",
+                marginTop: 8,
+                padding: "9px 11px",
+                borderRadius: 10,
+                border: `1px solid ${wordTranslit ? N.gold : N.border}`,
+                background: wordTranslit ? N.goldSoft : N.card,
+                color: wordTranslit ? N.gold : N.fg,
+                cursor: "pointer",
+                fontFamily: N.ui,
+                fontSize: 13.5,
+                fontWeight: 600,
+              }}
+            >
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                <Icon name="globe" size={15} color={wordTranslit ? N.gold : N.muted} /> Word
+                transliteration
+              </span>
+              {wordTranslit && <Icon name="check" size={15} color={N.gold} />}
+            </button>
+
             {tafsirs.length > 1 && (
               <div style={{ marginTop: 12 }}>
                 <div style={sectionLabel}>Tafsir edition</div>
                 <TafsirPicker tafsirs={tafsirs} />
               </div>
             )}
-
           </div>
         )}
       </div>
@@ -273,7 +337,10 @@ export function ReaderToolbar({
             onClick={() => setPanel((p) => (p === "reciter" ? null : "reciter"))}
           />
           {panel === "reciter" && (
-            <div className="noor-pop-sm-left" style={{ ...popover, minWidth: 220, maxHeight: 320, overflowY: "auto" }}>
+            <div
+              className="noor-pop-sm-left"
+              style={{ ...popover, minWidth: 220, maxHeight: 320, overflowY: "auto" }}
+            >
               <div style={sectionLabel}>Reciter</div>
               {reciters.map((r) => {
                 const on = r.id === reciterId;
@@ -300,7 +367,9 @@ export function ReaderToolbar({
                       textAlign: "left",
                     }}
                   >
-                    <span style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    <span
+                      style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}
+                    >
                       {r.name}
                     </span>
                     {on && <Icon name="check" size={15} color={N.gold} />}
@@ -352,7 +421,12 @@ export function ReaderToolbar({
       </div>
 
       {/* Bookmark this surah */}
-      <IconBtn icon="bookmark" title={bookmarked ? "Bookmarked" : "Bookmark surah"} on={bookmarked} onClick={toggleBookmark} />
+      <IconBtn
+        icon="bookmark"
+        title={bookmarked ? "Bookmarked" : "Bookmark surah"}
+        on={bookmarked}
+        onClick={toggleBookmark}
+      />
 
       {/* Click-away for the popovers */}
       {panel && (

--- a/apps/web/src/components/SurahReaderClient.tsx
+++ b/apps/web/src/components/SurahReaderClient.tsx
@@ -6,6 +6,7 @@ import { type ReciterPlugin, pageNumberOf } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
 import { AyahTranslations } from "./AyahTranslations";
 import { AyahTransliteration } from "./AyahTransliteration";
+import { AyahWords } from "./AyahWords";
 import { AyahActions } from "./AyahActions";
 import { AyahStar } from "./AyahStar";
 import { ReadingAudio } from "./ReadingAudio";
@@ -470,12 +471,7 @@ export function SurahReaderClient({
                   {pg.ayahs.map((ayah) => (
                     <div key={ayah.aya} id={`${surah.number}:${ayah.aya}`} className="ayah">
                       <p className="ayah-ar arabic">
-                        {ayah.text.split(" ").flatMap((word, i) => [
-                          <span key={i} className="w" data-w={i}>
-                            {word}
-                          </span>,
-                          " ",
-                        ])}
+                        <AyahWords surah={surah.number} aya={ayah.aya} text={ayah.text} />
                         <button
                           type="button"
                           className="ayah-marker"

--- a/apps/web/src/lib/settings-store.test.ts
+++ b/apps/web/src/lib/settings-store.test.ts
@@ -14,6 +14,7 @@ describe("webSettingsStore", () => {
       tafsir: null,
       scale: null,
       transliteration: null,
+      wordTransliteration: null,
     });
   });
 
@@ -25,6 +26,7 @@ describe("webSettingsStore", () => {
     await store.writeTafsir("ar-muyassar");
     await store.writeScale(1.4);
     await store.writeTransliteration(true);
+    await store.writeWordTransliteration(true);
 
     const s = await store.read();
     expect(s.editions).toEqual(["eng-sahih"]);
@@ -34,6 +36,7 @@ describe("webSettingsStore", () => {
     expect(s.tafsir).toBe("ar-muyassar");
     expect(s.scale).toBe(1.4);
     expect(s.transliteration).toBe(true);
+    expect(s.wordTransliteration).toBe(true);
 
     // editions and scale are JSON; the rest are plain strings (unchanged format)
     expect(localStorage.getItem("ul.editions")).toBe('["eng-sahih"]');

--- a/apps/web/src/lib/settings-store.ts
+++ b/apps/web/src/lib/settings-store.ts
@@ -15,6 +15,7 @@ const RECITER_KEY = "ul.reciter";
 const TAFSIR_KEY = "ul.tafsir";
 const SCALE_KEY = "ul.scale";
 const TRANSLIT_KEY = "ul.transliteration";
+const WORD_TRANSLIT_KEY = "ul.wbwTranslit";
 
 function getJSON<T>(key: string, fallback: T, isValid?: (v: unknown) => boolean): T {
   try {
@@ -56,6 +57,7 @@ export const webSettingsStore: SettingsStore = {
     tafsir: getStr(TAFSIR_KEY),
     scale: getJSON<number | null>(SCALE_KEY, null, isFiniteNumber),
     transliteration: getJSON<boolean | null>(TRANSLIT_KEY, null, isBoolean),
+    wordTransliteration: getJSON<boolean | null>(WORD_TRANSLIT_KEY, null, isBoolean),
   }),
   writeEditions: async (ids) => setItem(EDITIONS_KEY, JSON.stringify(ids)),
   writeReadingMode: async (mode) => setItem(READING_MODE_KEY, mode),
@@ -64,4 +66,5 @@ export const webSettingsStore: SettingsStore = {
   writeTafsir: async (id) => setItem(TAFSIR_KEY, id),
   writeScale: async (scale) => setItem(SCALE_KEY, JSON.stringify(scale)),
   writeTransliteration: async (on) => setItem(TRANSLIT_KEY, JSON.stringify(on)),
+  writeWordTransliteration: async (on) => setItem(WORD_TRANSLIT_KEY, JSON.stringify(on)),
 };

--- a/apps/web/src/lib/sync/managed-keys.ts
+++ b/apps/web/src/lib/sync/managed-keys.ts
@@ -27,6 +27,8 @@ export const MANAGED_KEYS: readonly string[] = [
   "ul.reciter",
   "ul.scale",
   "ul.wbw",
+  "ul.transliteration",
+  "ul.wbwTranslit",
   "ul.loop",
   // Last-read position — "continue where you left off" across devices
   "ul.lastRead",

--- a/apps/web/src/lib/word-translit.test.ts
+++ b/apps/web/src/lib/word-translit.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  WORD_TRANSLIT_KEY,
+  fetchSurahWordTranslit,
+  readWordTranslit,
+  writeWordTranslit,
+} from "./word-translit";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("word-transliteration toggle", () => {
+  it("defaults to off and round-trips with a change event", async () => {
+    expect(await readWordTranslit()).toBe(false);
+    const handler = vi.fn();
+    window.addEventListener(WORD_TRANSLIT_KEY, handler);
+
+    await writeWordTranslit(true);
+    expect(await readWordTranslit()).toBe(true);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(localStorage.getItem("ul.wbwTranslit")).toBe("true");
+
+    window.removeEventListener(WORD_TRANSLIT_KEY, handler);
+  });
+});
+
+describe("fetchSurahWordTranslit", () => {
+  it("maps each āyah to its per-word transliterations (words only)", async () => {
+    const body = {
+      verses: [
+        {
+          verse_key: "1:1",
+          words: [
+            { char_type_name: "word", transliteration: { text: "bis'mi" } },
+            { char_type_name: "word", transliteration: { text: "l-lahi" } },
+            { char_type_name: "end", transliteration: { text: null } }, // āyah marker — dropped
+          ],
+        },
+      ],
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+
+    const map = await fetchSurahWordTranslit(1);
+    expect(map.get(1)).toEqual(["bis'mi", "l-lahi"]);
+  });
+
+  it("resolves to an empty map on a failed request", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 500 }));
+    // surah 114 (uncached) so the memo from the previous test doesn't mask this.
+    const map = await fetchSurahWordTranslit(114);
+    expect(map.size).toBe(0);
+  });
+});

--- a/apps/web/src/lib/word-translit.ts
+++ b/apps/web/src/lib/word-translit.ts
@@ -1,0 +1,67 @@
+/**
+ * Word-by-word transliteration (#144): a reader toggle that renders a Latin
+ * transliteration beneath each Arabic word.
+ *
+ * The per-word text is fetched at runtime from quran.com (the same source the
+ * word-by-word popover already uses — display-only, not bundled; see
+ * ATTRIBUTION). The on/off flag persists through the `SettingsStore` port and
+ * broadcasts a window event so the per-āyah word components update live.
+ */
+import { webSettingsStore as store } from "./settings-store";
+
+/** Window event broadcast when the word-transliteration toggle changes. */
+export const WORD_TRANSLIT_KEY = "ul.wbwTranslit";
+
+/** Body class that drives the per-word stacked layout in CSS. */
+export const WORD_TRANSLIT_CLASS = "wbw-translit-on";
+
+export async function readWordTranslit(): Promise<boolean> {
+  return (await store.read()).wordTransliteration ?? false;
+}
+
+export async function writeWordTranslit(on: boolean): Promise<void> {
+  await store.writeWordTransliteration(on);
+  window.dispatchEvent(new CustomEvent(WORD_TRANSLIT_KEY, { detail: on }));
+}
+
+interface QuranComWord {
+  char_type_name?: string;
+  transliteration?: { text: string | null } | null;
+}
+interface QuranComVerse {
+  verse_key?: string;
+  words?: QuranComWord[];
+}
+
+// One fetch per surah, shared across every āyah's word component on the page.
+const cache = new Map<number, Promise<Map<number, string[]>>>();
+
+/**
+ * Per-word transliterations for a whole surah: `āyah → [translit per word]`,
+ * fetched once from quran.com (a surah fits in one page at `per_page=300`). On
+ * any failure it resolves to an empty map so the reader simply shows no row.
+ */
+export function fetchSurahWordTranslit(surah: number): Promise<Map<number, string[]>> {
+  let pending = cache.get(surah);
+  if (!pending) {
+    pending = fetch(
+      `https://api.quran.com/api/v4/verses/by_chapter/${surah}?words=true&word_fields=transliteration&per_page=300`,
+    )
+      .then((r) => (r.ok ? (r.json() as Promise<{ verses?: QuranComVerse[] }>) : { verses: [] }))
+      .then((d) => {
+        const map = new Map<number, string[]>();
+        for (const v of d.verses ?? []) {
+          const aya = Number(v.verse_key?.split(":")[1]);
+          if (!Number.isInteger(aya)) continue;
+          const words = (v.words ?? [])
+            .filter((w) => w.char_type_name === "word")
+            .map((w) => w.transliteration?.text ?? "");
+          map.set(aya, words);
+        }
+        return map;
+      })
+      .catch(() => new Map<number, string[]>());
+    cache.set(surah, pending);
+  }
+  return pending;
+}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -334,6 +334,8 @@ export interface StoredSettings {
   scale: number | null;
   /** Show the per-āyah Latin transliteration line under the Arabic (#150). */
   transliteration: boolean | null;
+  /** Show per-word Latin transliteration beneath each Arabic word (#144). */
+  wordTransliteration: boolean | null;
 }
 
 /**
@@ -352,6 +354,8 @@ export interface SettingsStore {
   writeScale(scale: number): Promise<void>;
   /** Toggle the per-āyah transliteration line (#150). */
   writeTransliteration(on: boolean): Promise<void>;
+  /** Toggle the per-word transliteration row (#144). */
+  writeWordTransliteration(on: boolean): Promise<void>;
 }
 
 /** The reader's prayer-times location and calculation config as persisted. */


### PR DESCRIPTION
## What

Adds an opt-in **Word transliteration** toggle to the reader: a Latin transliteration sits beneath each Arabic word, for non-Arabic readers learning to recite. Closes #144.

Distinct from the verse-level line (#150) and from word-by-word *translation* (whose English gloss is license-blocked, #37) — this is the transliteration layer only.

## Approach

- **Runtime data, not bundled.** The per-word text comes from quran.com — the same display-only source the existing word-by-word popover uses — fetched **once per surah** (`by_chapter?per_page=300` returns a whole surah in one request) and memoised. Consistent with the data-distribution stance and ADR 0011.
- **Behaviour-preserving off-state.** A shared `AyahWords` component renders the *exact* plain `.w` spans the reader has always used when the toggle is off, so audio highlighting (which targets `.w[data-w]`) and peek mode are untouched. When on, each word becomes a stacked Arabic-over-transliteration unit and CSS flows them RTL with wrap. Server-rendered in the off state, so the Arabic stays in the initial HTML.

## Changes

- **core** — `wordTransliteration` on `StoredSettings` + `writeWordTransliteration` on the port.
- **web** — `AyahWords` (surah + juz readers); toggle in the toolbar display panel; `lib/word-translit.ts` (toggle + memoised fetch); CSS stacked layout; `ul.wbwTranslit` added to sync `MANAGED_KEYS` (also added the #150 `ul.transliteration` key, which I'd missed).
- **mobile** — word-by-word flex layout in `AyahView` and the juz reader (additive — off-state path unchanged); toggle in `ReaderControls`; runtime fetch util.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (core 388; web 280 incl. new `AyahWords` + `word-translit` tests), `pnpm build` — all pass.
- `AyahWords` component test proves the DOM: off → plain `.w` spans with `data-w` preserved and no transliteration row; on (mocked fetch) → stacked `.w-unit` with the right per-word text.
- Live data path confirmed: quran.com returns per-word transliteration (e.g. surah 112 → `qul, huwa, l-lahu, aḥadun`).

**Caveat:** the visual CSS layout (RTL stacked flow) is covered at the DOM level but not screenshot-verified in a browser; the off-state is byte-identical to today's reader so there's no regression risk there.

## Acceptance (from #144)

- [x] Word-level transliteration sourced + attributed (quran.com, runtime display-only, per ATTRIBUTION).
- [x] Toggle in reader; aligns under each Arabic word; respects script/font.
- [x] Web + mobile.