### PR TITLE
feat(reader): tap a word to hear it recited (#145)

### DIFF
--- a/apps/mobile/src/audio/useSurahAudio.ts
+++ b/apps/mobile/src/audio/useSurahAudio.ts
@@ -74,6 +74,8 @@ export interface SurahAudio {
   playFrom: (verses: VerseKey[], start: VerseKey, advance: boolean) => void;
   /** Loop the inclusive A→B range `count` times (Infinity = until stopped). */
   playRange: (verses: VerseKey[], from: VerseKey, to: VerseKey, count: number) => void;
+  /** Tap-a-word-to-hear (#145): play just one word of a verse, from its timing segment. */
+  playWord: (verse: VerseKey, wordIndex: number) => void;
   stop: () => void;
 }
 
@@ -390,6 +392,63 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
     [startSession],
   );
 
+  // Tap-a-word-to-hear (#145): seek the verse audio to one word's timing segment
+  // and play just that word, pausing at its segment end. Needs a reciter with
+  // quran.com word timings — a no-op otherwise. The off-by-default toggle gates it.
+  const playWord = useCallback(
+    (verse: VerseKey, wordIndex: number) => {
+      const recitationId = reciter.quranComId;
+      if (!recitationId) return;
+      const token = ++tokenRef.current; // cancels any running session
+      settleRef.current?.();
+      setActiveWord(-1);
+      void (async () => {
+        const key = verseKeyOf(verse);
+        const timing = await fetchTiming(recitationId, key);
+        if (tokenRef.current !== token || !timing) return;
+        const seg = timing.segments.find((s) => s[0] === wordIndex);
+        if (!seg) return;
+        const player = ensurePlayer(timing.url);
+        if (tokenRef.current !== token) return;
+        setPlayingKey(key);
+        const endSec = seg[3] / 1000;
+        try {
+          await player.seekTo(seg[2] / 1000);
+        } catch {
+          /* seek unsupported — falls back to playing from the verse start */
+        }
+        if (tokenRef.current !== token) return;
+        setActiveWord(wordIndex);
+        player.play();
+        // Pause once playback reaches the word's segment end.
+        const poll = setInterval(() => {
+          if (tokenRef.current !== token) {
+            clearInterval(poll);
+            return;
+          }
+          let t: number;
+          try {
+            t = player.currentTime;
+          } catch {
+            return;
+          }
+          if (typeof t === "number" && t >= endSec) {
+            clearInterval(poll);
+            try {
+              player.pause();
+            } catch {
+              /* already paused */
+            }
+            setActiveWord(-1);
+            setPlayingKey(null);
+          }
+        }, POLL_MS);
+        settleRef.current = () => clearInterval(poll);
+      })();
+    },
+    [reciter, ensurePlayer],
+  );
+
   // Tear the player down when the screen leaves so no poll/interval lingers,
   // and clear the notification so it can't outlive the reader.
   useEffect(() => {
@@ -416,6 +475,7 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
     setRate,
     playFrom,
     playRange,
+    playWord,
     stop,
   };
 }

--- a/apps/mobile/src/components/AyahView.tsx
+++ b/apps/mobile/src/components/AyahView.tsx
@@ -27,6 +27,9 @@ interface Props {
   transliteration?: string | null;
   /** Per-word Latin transliteration (#144); when present, words stack over it. */
   translitWords?: string[] | null;
+  /** Tap-a-word-to-hear (#145): render words as tap targets that play that word. */
+  tapToHear?: boolean;
+  onPlayWord?: (aya: number, wordIndex: number) => void;
   activeWord: number;
   playing: boolean;
   scale: number;
@@ -59,6 +62,8 @@ function AyahViewImpl({
   translations,
   transliteration,
   translitWords,
+  tapToHear = false,
+  onPlayWord,
   activeWord,
   playing,
   scale,
@@ -109,17 +114,23 @@ function AyahViewImpl({
         </View>
       </View>
 
-      {translitWords && translitWords.length > 0 && !peek ? (
-        // Word-by-word transliteration (#144): each word stacks over its Latin
-        // reading, flowing right-to-left with wrap. Audio highlight is dropped in
-        // this learning view.
+      {((translitWords && translitWords.length > 0) || tapToHear) && !peek ? (
+        // Word-by-word view (#144 transliteration + #145 tap-to-hear): each word
+        // is a tap target stacked over its Latin reading. A tap plays just that
+        // word when tap-to-hear is on, else it plays from the āyah.
         <View style={styles.wbwRow}>
           {words.map((w, i) => (
-            <Pressable key={i} style={styles.wbwUnit} onPress={() => onPlayFrom(aya)}>
+            <Pressable
+              key={i}
+              style={styles.wbwUnit}
+              onPress={() => (tapToHear && onPlayWord ? onPlayWord(aya, i) : onPlayFrom(aya))}
+            >
               <Text style={[styles.wbwAr, { fontSize: 26 * scale, lineHeight: 40 * scale }]}>
                 {w}
               </Text>
-              <Text style={[styles.wbwTr, { fontSize: 12 * scale }]}>{translitWords[i] ?? ""}</Text>
+              {translitWords?.[i] ? (
+                <Text style={[styles.wbwTr, { fontSize: 12 * scale }]}>{translitWords[i]}</Text>
+              ) : null}
             </Pressable>
           ))}
         </View>

--- a/apps/mobile/src/components/ReaderControls.tsx
+++ b/apps/mobile/src/components/ReaderControls.tsx
@@ -19,6 +19,8 @@ export function ReaderControls({
   onTransliteration,
   wordTransliteration,
   onWordTransliteration,
+  tapToHear,
+  onTapToHear,
   onManage,
 }: {
   mode: ReadingMode;
@@ -29,6 +31,8 @@ export function ReaderControls({
   onTransliteration: (on: boolean) => void;
   wordTransliteration: boolean;
   onWordTransliteration: (on: boolean) => void;
+  tapToHear: boolean;
+  onTapToHear: (on: boolean) => void;
   onManage: () => void;
 }) {
   const { colors } = useTheme();
@@ -84,6 +88,15 @@ export function ReaderControls({
             <Text style={[styles.toggleText, wordTransliteration && styles.toggleTextOn]}>
               Aa Word
             </Text>
+          </Pressable>
+          <Pressable
+            style={[styles.toggle, tapToHear && styles.toggleOn]}
+            onPress={() => onTapToHear(!tapToHear)}
+            accessibilityRole="switch"
+            accessibilityState={{ checked: tapToHear }}
+            accessibilityLabel="Tap a word to hear"
+          >
+            <Text style={[styles.toggleText, tapToHear && styles.toggleTextOn]}>🔊 Word</Text>
           </Pressable>
           <Pressable style={styles.manage} onPress={onManage}>
             <Text style={styles.manageText}>⚙</Text>

--- a/apps/mobile/src/screens/JuzReaderScreen.tsx
+++ b/apps/mobile/src/screens/JuzReaderScreen.tsx
@@ -55,8 +55,15 @@ function juzRange(juz: number): { sura: number; from: number; toExclusive: numbe
 export function JuzReaderScreen({ route }: Props) {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
-  const { editions, readingTranslation, reciterId, scale, transliteration, wordTransliteration } =
-    useSettings();
+  const {
+    editions,
+    readingTranslation,
+    reciterId,
+    scale,
+    transliteration,
+    wordTransliteration,
+    tapToHear,
+  } = useSettings();
   const reciter = RECITERS.find((r) => r.id === reciterId) ?? RECITER;
   const audio = useSurahAudio(reciter);
 
@@ -215,26 +222,35 @@ export function JuzReaderScreen({ route }: Props) {
       {lines.map((l, i) => {
         const key = verseKeyOf(l);
         const playing = audio.playingKey === key;
+        const showWbw = ((wordTransliteration && l.translitWords.length > 0) || tapToHear) && !peek;
         return (
           <View key={key}>
             {l.surahHeader && <Text style={styles.surahHeader}>{l.surahHeader}</Text>}
             <Pressable
               style={[styles.ayah, playing && styles.ayahPlaying]}
-              onPress={peek ? undefined : () => audio.playFrom(verses, l, true)}
+              onPress={peek || showWbw ? undefined : () => audio.playFrom(verses, l, true)}
             >
-              {wordTransliteration && l.translitWords.length > 0 && !peek ? (
+              {showWbw ? (
                 <View style={styles.wbwRow}>
                   {peekWords[i]!.map((w, wi) => (
-                    <View key={wi} style={styles.wbwUnit}>
+                    <Pressable
+                      key={wi}
+                      style={styles.wbwUnit}
+                      onPress={() =>
+                        tapToHear ? audio.playWord(l, wi) : audio.playFrom(verses, l, true)
+                      }
+                    >
                       <Text
                         style={[styles.wbwAr, { fontSize: 24 * scale, lineHeight: 38 * scale }]}
                       >
                         {w}
                       </Text>
-                      <Text style={[styles.wbwTr, { fontSize: 11 * scale }]}>
-                        {l.translitWords[wi] ?? ""}
-                      </Text>
-                    </View>
+                      {l.translitWords[wi] ? (
+                        <Text style={[styles.wbwTr, { fontSize: 11 * scale }]}>
+                          {l.translitWords[wi]}
+                        </Text>
+                      ) : null}
+                    </Pressable>
                   ))}
                   <Text style={styles.marker}>﴿{l.aya}﴾</Text>
                 </View>

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -59,6 +59,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
     scale,
     transliteration,
     wordTransliteration,
+    tapToHear,
     catalogue,
     setEditions,
     setReadingMode,
@@ -66,6 +67,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
     setScale,
     setTransliteration,
     setWordTransliteration,
+    setTapToHear,
   } = settings;
   const { setLastRead, isBookmarked, toggleBookmark } = useLibrary();
 
@@ -297,7 +299,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
   // Stable so the memoized AyahView only re-renders the playing āyah as the
   // recitation moves word to word — an inline arrow would change identity every
   // render and defeat the memo, re-rendering the whole surah on each word.
-  const { playFrom: playAudio, playingKey, activeWord } = audio;
+  const { playFrom: playAudio, playWord, playingKey, activeWord } = audio;
   const playFrom = useCallback(
     (aya: number) => playAudio(verses, { sura: n, aya }, true),
     [playAudio, verses, n],
@@ -305,6 +307,10 @@ export function SurahReaderScreen({ navigation, route }: Props) {
   const playOne = useCallback(
     (aya: number) => playAudio(verses, { sura: n, aya }, false),
     [playAudio, verses, n],
+  );
+  const playWordAt = useCallback(
+    (aya: number, wordIndex: number) => playWord({ sura: n, aya }, wordIndex),
+    [playWord, n],
   );
 
   const renderItem = useCallback(
@@ -317,6 +323,8 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         translations={item.translations}
         transliteration={item.transliteration}
         translitWords={item.translitWords}
+        tapToHear={tapToHear}
+        onPlayWord={playWordAt}
         activeWord={playingKey === item.key ? activeWord : -1}
         playing={playingKey === item.key}
         scale={scale}
@@ -337,6 +345,8 @@ export function SurahReaderScreen({ navigation, route }: Props) {
       scale,
       playFrom,
       playOne,
+      playWordAt,
+      tapToHear,
       peek,
       peekStarts,
       revealed,
@@ -437,6 +447,8 @@ export function SurahReaderScreen({ navigation, route }: Props) {
         onTransliteration={setTransliteration}
         wordTransliteration={wordTransliteration}
         onWordTransliteration={setWordTransliteration}
+        tapToHear={tapToHear}
+        onTapToHear={setTapToHear}
         onManage={() => setManagerOpen(true)}
       />
 
@@ -520,7 +532,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
           data={rows}
           keyExtractor={(r) => r.key}
           renderItem={renderItem}
-          extraData={`${playingKey ?? ""}:${activeWord}:${scale}:${peek}:${revealed}:${peekExtra.size}:${hideTr}:${transliteration}:${translitMap.size}:${wordTransliteration}:${wordTranslitMap.size}`}
+          extraData={`${playingKey ?? ""}:${activeWord}:${scale}:${peek}:${revealed}:${peekExtra.size}:${hideTr}:${transliteration}:${translitMap.size}:${wordTransliteration}:${wordTranslitMap.size}:${tapToHear}`}
           contentContainerStyle={styles.content}
           onViewableItemsChanged={onViewable}
           viewabilityConfig={viewabilityConfig}

--- a/apps/mobile/src/state/SettingsContext.tsx
+++ b/apps/mobile/src/state/SettingsContext.tsx
@@ -33,6 +33,8 @@ interface SettingsValue {
   transliteration: boolean;
   /** Show per-word Latin transliteration beneath each Arabic word (#144). */
   wordTransliteration: boolean;
+  /** Tap an Arabic word to hear just that word recited (#145). */
+  tapToHear: boolean;
   catalogue: Translation[];
   tafsirs: TafsirMeta[];
   setEditions: (ids: string[]) => void;
@@ -44,6 +46,7 @@ interface SettingsValue {
   setScale: (scale: number) => void;
   setTransliteration: (on: boolean) => void;
   setWordTransliteration: (on: boolean) => void;
+  setTapToHear: (on: boolean) => void;
 }
 
 const SettingsContext = createContext<SettingsValue | null>(null);
@@ -60,6 +63,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [scale, setScaleState] = useState<number>(1);
   const [transliteration, setTransliterationState] = useState<boolean>(false);
   const [wordTransliteration, setWordTransliterationState] = useState<boolean>(false);
+  const [tapToHear, setTapToHearState] = useState<boolean>(false);
   const [catalogue, setCatalogue] = useState<Translation[]>([]);
   const [tafsirs, setTafsirs] = useState<TafsirMeta[]>([]);
 
@@ -78,6 +82,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       if (s.scale != null) setScaleState(clampScale(s.scale));
       if (s.transliteration != null) setTransliterationState(s.transliteration);
       if (s.wordTransliteration != null) setWordTransliterationState(s.wordTransliteration);
+      if (s.tapToHear != null) setTapToHearState(s.tapToHear);
     });
     void readTafsirCompare().then(setTafsirCompareState);
     void api
@@ -137,6 +142,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     void store.writeWordTransliteration(on);
   }, []);
 
+  const setTapToHear = useCallback((on: boolean) => {
+    setTapToHearState(on);
+    void store.writeTapToHear(on);
+  }, []);
+
   const value = useMemo<SettingsValue>(
     () => ({
       editions,
@@ -148,6 +158,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       scale,
       transliteration,
       wordTransliteration,
+      tapToHear,
       catalogue,
       tafsirs,
       setEditions,
@@ -159,6 +170,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setScale,
       setTransliteration,
       setWordTransliteration,
+      setTapToHear,
     }),
     [
       editions,
@@ -170,6 +182,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       scale,
       transliteration,
       wordTransliteration,
+      tapToHear,
       catalogue,
       tafsirs,
       setEditions,
@@ -181,6 +194,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setScale,
       setTransliteration,
       setWordTransliteration,
+      setTapToHear,
     ],
   );
 

--- a/apps/mobile/src/state/settings-store.ts
+++ b/apps/mobile/src/state/settings-store.ts
@@ -28,6 +28,7 @@ export const mobileSettingsStore: SettingsStore = {
       scale,
       transliteration,
       wordTransliteration,
+      tapToHear,
     ] = await Promise.all([
       getJSON<string[] | null>(KEYS.editions, null, isStringArray),
       getString(KEYS.readingMode),
@@ -37,6 +38,7 @@ export const mobileSettingsStore: SettingsStore = {
       getJSON<number | null>(KEYS.scale, null, isFiniteNumber),
       getJSON<boolean | null>(KEYS.transliteration, null, isBoolean),
       getJSON<boolean | null>(KEYS.wbwTranslit, null, isBoolean),
+      getJSON<boolean | null>(KEYS.tapToHear, null, isBoolean),
     ]);
     return {
       editions,
@@ -47,6 +49,7 @@ export const mobileSettingsStore: SettingsStore = {
       scale,
       transliteration,
       wordTransliteration,
+      tapToHear,
     };
   },
   writeEditions: (ids) => setJSON(KEYS.editions, ids),
@@ -57,4 +60,5 @@ export const mobileSettingsStore: SettingsStore = {
   writeScale: (scale) => setJSON(KEYS.scale, scale),
   writeTransliteration: (on) => setJSON(KEYS.transliteration, on),
   writeWordTransliteration: (on) => setJSON(KEYS.wbwTranslit, on),
+  writeTapToHear: (on) => setJSON(KEYS.tapToHear, on),
 };

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -16,6 +16,7 @@ export const KEYS = {
   scale: "ul.scale",
   transliteration: "ul.transliteration",
   wbwTranslit: "ul.wbwTranslit",
+  tapToHear: "ul.tapToHear",
   theme: "ul.theme",
   bookmarks: "ul.bookmarks",
   collections: "ul.collections",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -480,6 +480,13 @@ body.wbw-translit-on .ayah-ar {
   margin-top: 0.2em;
   white-space: nowrap;
 }
+/* Tap-a-word-to-hear (#145): show words are tappable while the mode is on. */
+body.tap-hear-on .w {
+  cursor: pointer;
+}
+body.tap-hear-on .w:hover {
+  background: var(--accent-soft);
+}
 
 .surah-search {
   width: 100%;

--- a/apps/web/src/components/ReaderToolbar.tsx
+++ b/apps/web/src/components/ReaderToolbar.tsx
@@ -11,6 +11,7 @@ import { readReciter, readScale, writeReciter, writeScale } from "../lib/reader-
 import { readWordByWord, writeLastRead, writeWordByWord } from "../lib/reader-prefs-store";
 import { readTransliteration, writeTransliteration } from "../lib/transliteration";
 import { WORD_TRANSLIT_CLASS, readWordTranslit, writeWordTranslit } from "../lib/word-translit";
+import { TAP_HEAR_CLASS, readTapToHear, writeTapToHear } from "../lib/tap-to-hear";
 import { TranslationSettings } from "./TranslationSettings";
 import { TafsirPicker } from "./TafsirPicker";
 import { WBW_KEY } from "./WordByWord";
@@ -53,6 +54,7 @@ export function ReaderToolbar({
   const [wbw, setWbw] = useState(false);
   const [translit, setTranslit] = useState(false);
   const [wordTranslit, setWordTranslit] = useState(false);
+  const [tapHear, setTapHear] = useState(false);
   const [managing, setManaging] = useState(false);
   const [catalogue, setCatalogue] = useState<EditionChoice[]>([]);
   const [selected, setSelected] = useState<Set<string>>(() => new Set(DEFAULT_EDITIONS));
@@ -74,6 +76,10 @@ export function ReaderToolbar({
     void readWordTranslit().then((on) => {
       setWordTranslit(on);
       document.body.classList.toggle(WORD_TRANSLIT_CLASS, on);
+    });
+    void readTapToHear().then((on) => {
+      setTapHear(on);
+      document.body.classList.toggle(TAP_HEAR_CLASS, on);
     });
     void readEditions().then((ids) => setSelected(new Set(ids)));
     void fetchCatalogue().then(setCatalogue);
@@ -98,6 +104,13 @@ export function ReaderToolbar({
     setWordTranslit(next);
     document.body.classList.toggle(WORD_TRANSLIT_CLASS, next);
     void writeWordTranslit(next); // persists + broadcasts `ul.wbwTranslit`
+  }
+
+  function toggleTapHear() {
+    const next = !tapHear;
+    setTapHear(next);
+    document.body.classList.toggle(TAP_HEAR_CLASS, next);
+    void writeTapToHear(next); // persists + broadcasts `ul.tapToHear`
   }
 
   function changeScale(delta: number) {
@@ -315,6 +328,35 @@ export function ReaderToolbar({
                 transliteration
               </span>
               {wordTranslit && <Icon name="check" size={15} color={N.gold} />}
+            </button>
+
+            <button
+              type="button"
+              onClick={toggleTapHear}
+              aria-pressed={tapHear}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 10,
+                width: "100%",
+                marginTop: 8,
+                padding: "9px 11px",
+                borderRadius: 10,
+                border: `1px solid ${tapHear ? N.gold : N.border}`,
+                background: tapHear ? N.goldSoft : N.card,
+                color: tapHear ? N.gold : N.fg,
+                cursor: "pointer",
+                fontFamily: N.ui,
+                fontSize: 13.5,
+                fontWeight: 600,
+              }}
+            >
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                <Icon name="headphones" size={15} color={tapHear ? N.gold : N.muted} /> Tap a word
+                to hear
+              </span>
+              {tapHear && <Icon name="check" size={15} color={N.gold} />}
             </button>
 
             {tafsirs.length > 1 && (

--- a/apps/web/src/components/ReadingAudio.test.tsx
+++ b/apps/web/src/components/ReadingAudio.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import type { ReciterPlugin } from "@ummahlibrary/core";
+import { ReadingAudio } from "./ReadingAudio";
+
+const ALAFASY: ReciterPlugin = {
+  kind: "reciter",
+  id: "alafasy",
+  name: "Alafasy",
+  language: "ar",
+  audioUrlTemplate: "https://everyayah.com/data/Alafasy_128kbps/{surah:3}{ayah:3}.mp3",
+  quranComId: 7,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  document.body.className = "";
+  document.body.innerHTML = "";
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.className = "";
+  document.body.innerHTML = "";
+});
+
+describe("ReadingAudio — tap a word to hear (#145)", () => {
+  it("a word tap fetches that verse's timing only when tap-to-hear is on", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          verse: { audio: { url: "Alafasy/mp3/001001.mp3", segments: [[1, 2, 620, 1310]] } },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    render(<ReadingAudio verses={[{ sura: 1, aya: 1 }]} reciters={[ALAFASY]} />);
+
+    // A rendered āyah block with word spans, like the reader produces.
+    const block = document.createElement("div");
+    block.id = "1:1";
+    block.className = "ayah";
+    block.innerHTML = `<p class="ayah-ar"><span class="w" data-w="0">بِسْمِ</span> <span class="w" data-w="1">ٱللَّهِ</span></p>`;
+    document.body.appendChild(block);
+    const word = block.querySelector('.w[data-w="1"]') as HTMLElement;
+
+    // Off: a word tap is ignored (no timing fetch).
+    word.click();
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // On: the tap fetches the verse's word timing.
+    document.body.classList.add("tap-hear-on");
+    word.click();
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/verses/by_key/1:1?audio=7"),
+      ),
+    );
+  });
+});

--- a/apps/web/src/components/ReadingAudio.tsx
+++ b/apps/web/src/components/ReadingAudio.tsx
@@ -277,6 +277,68 @@ export function ReadingAudio({
     );
   }
 
+  /**
+   * Tap-a-word-to-hear (#145): seek the verse audio to one word's timing segment
+   * and play just that word, then pause at its segment end. Reuses the same
+   * quran.com word timings the reciting highlight uses; needs a reciter with
+   * `quranComId` (word timings) — a no-op otherwise.
+   */
+  async function playWord(verseKey: string, wordIndex: number) {
+    const reciter = reciters.find((r) => r.id === reciterId) ?? reciters[0];
+    if (!reciter?.quranComId) return;
+    const token = ++tokenRef.current; // cancels any running recitation
+    repeatRef.current = null;
+    const timing = await fetchTiming(reciter.quranComId, verseKey);
+    if (token !== tokenRef.current) return;
+    const seg = timing?.segments.find((s) => s[0] === wordIndex);
+    if (!timing || !seg) return;
+
+    const audio = (audioRef.current ??= new Audio());
+    audio.onended = null;
+    audio.ontimeupdate = null;
+    audio.pause();
+    clearWord();
+
+    const startSec = seg[2] / 1000;
+    const endSec = seg[3] / 1000;
+    wordRef.current = {
+      block: document.getElementById(verseKey),
+      segments: timing.segments,
+      last: -1,
+    };
+    audio.src = timing.url;
+    audio.playbackRate = rateRef.current;
+
+    const begin = () => {
+      if (token !== tokenRef.current) return;
+      audio.currentTime = startSec;
+      audio.ontimeupdate = () => {
+        const a = audioRef.current;
+        if (!a) return;
+        if (a.currentTime >= endSec) {
+          a.pause();
+          a.ontimeupdate = null;
+          clearWord();
+          setIsPlaying(false);
+        } else {
+          onTimeUpdate();
+        }
+      };
+      audio.onended = () => {
+        clearWord();
+        setIsPlaying(false);
+      };
+      void audio.play().then(
+        () => setIsPlaying(true),
+        () => {},
+      );
+    };
+    // `load()` guarantees a fresh `loadedmetadata` (so the seek lands) even when
+    // the same verse is tapped twice in a row.
+    audio.load();
+    audio.addEventListener("loadedmetadata", begin, { once: true });
+  }
+
   function toggle() {
     const audio = audioRef.current;
     if (isPlaying && audio) {
@@ -307,6 +369,16 @@ export function ReadingAudio({
   useEffect(() => {
     function onClick(event: MouseEvent) {
       const node = event.target as HTMLElement;
+      // Tap-a-word-to-hear (#145): in this mode a word tap plays just that word.
+      if (document.body.classList.contains("tap-hear-on")) {
+        const word = node.closest<HTMLElement>(".w");
+        const block = word?.closest<HTMLElement>(".ayah");
+        if (word && block?.id && word.dataset.w !== undefined) {
+          event.preventDefault();
+          void playWord(block.id, Number(word.dataset.w));
+          return;
+        }
+      }
       const one = node.closest<HTMLElement>("[data-play-one]");
       if (one) {
         event.preventDefault();

--- a/apps/web/src/lib/settings-store.test.ts
+++ b/apps/web/src/lib/settings-store.test.ts
@@ -15,6 +15,7 @@ describe("webSettingsStore", () => {
       scale: null,
       transliteration: null,
       wordTransliteration: null,
+      tapToHear: null,
     });
   });
 
@@ -27,6 +28,7 @@ describe("webSettingsStore", () => {
     await store.writeScale(1.4);
     await store.writeTransliteration(true);
     await store.writeWordTransliteration(true);
+    await store.writeTapToHear(true);
 
     const s = await store.read();
     expect(s.editions).toEqual(["eng-sahih"]);
@@ -37,6 +39,7 @@ describe("webSettingsStore", () => {
     expect(s.scale).toBe(1.4);
     expect(s.transliteration).toBe(true);
     expect(s.wordTransliteration).toBe(true);
+    expect(s.tapToHear).toBe(true);
 
     // editions and scale are JSON; the rest are plain strings (unchanged format)
     expect(localStorage.getItem("ul.editions")).toBe('["eng-sahih"]');

--- a/apps/web/src/lib/settings-store.ts
+++ b/apps/web/src/lib/settings-store.ts
@@ -16,6 +16,7 @@ const TAFSIR_KEY = "ul.tafsir";
 const SCALE_KEY = "ul.scale";
 const TRANSLIT_KEY = "ul.transliteration";
 const WORD_TRANSLIT_KEY = "ul.wbwTranslit";
+const TAP_HEAR_KEY = "ul.tapToHear";
 
 function getJSON<T>(key: string, fallback: T, isValid?: (v: unknown) => boolean): T {
   try {
@@ -58,6 +59,7 @@ export const webSettingsStore: SettingsStore = {
     scale: getJSON<number | null>(SCALE_KEY, null, isFiniteNumber),
     transliteration: getJSON<boolean | null>(TRANSLIT_KEY, null, isBoolean),
     wordTransliteration: getJSON<boolean | null>(WORD_TRANSLIT_KEY, null, isBoolean),
+    tapToHear: getJSON<boolean | null>(TAP_HEAR_KEY, null, isBoolean),
   }),
   writeEditions: async (ids) => setItem(EDITIONS_KEY, JSON.stringify(ids)),
   writeReadingMode: async (mode) => setItem(READING_MODE_KEY, mode),
@@ -67,4 +69,5 @@ export const webSettingsStore: SettingsStore = {
   writeScale: async (scale) => setItem(SCALE_KEY, JSON.stringify(scale)),
   writeTransliteration: async (on) => setItem(TRANSLIT_KEY, JSON.stringify(on)),
   writeWordTransliteration: async (on) => setItem(WORD_TRANSLIT_KEY, JSON.stringify(on)),
+  writeTapToHear: async (on) => setItem(TAP_HEAR_KEY, JSON.stringify(on)),
 };

--- a/apps/web/src/lib/sync/managed-keys.ts
+++ b/apps/web/src/lib/sync/managed-keys.ts
@@ -29,6 +29,7 @@ export const MANAGED_KEYS: readonly string[] = [
   "ul.wbw",
   "ul.transliteration",
   "ul.wbwTranslit",
+  "ul.tapToHear",
   "ul.loop",
   // Last-read position — "continue where you left off" across devices
   "ul.lastRead",

--- a/apps/web/src/lib/tap-to-hear.test.ts
+++ b/apps/web/src/lib/tap-to-hear.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TAP_HEAR_KEY, readTapToHear, writeTapToHear } from "./tap-to-hear";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("tap-to-hear toggle", () => {
+  it("defaults to off and round-trips with a change event", async () => {
+    expect(await readTapToHear()).toBe(false);
+    const handler = vi.fn();
+    window.addEventListener(TAP_HEAR_KEY, handler);
+
+    await writeTapToHear(true);
+    expect(await readTapToHear()).toBe(true);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(localStorage.getItem("ul.tapToHear")).toBe("true");
+
+    window.removeEventListener(TAP_HEAR_KEY, handler);
+  });
+});

--- a/apps/web/src/lib/tap-to-hear.ts
+++ b/apps/web/src/lib/tap-to-hear.ts
@@ -1,0 +1,25 @@
+/**
+ * Tap-a-word-to-hear (#145): a reader toggle that turns each Arabic word into a
+ * tap target — tapping seeks the verse audio to that word's timing segment and
+ * plays just that word. The audio + segments are the same quran.com word timings
+ * the reciting highlight already uses; this only adds the tap seam.
+ *
+ * The flag persists through the `SettingsStore` port and toggles a body class the
+ * audio player reads to decide whether a word tap should play that word.
+ */
+import { webSettingsStore as store } from "./settings-store";
+
+/** Window event broadcast when the tap-to-hear toggle changes. */
+export const TAP_HEAR_KEY = "ul.tapToHear";
+
+/** Body class the audio player checks before treating a word tap as "play word". */
+export const TAP_HEAR_CLASS = "tap-hear-on";
+
+export async function readTapToHear(): Promise<boolean> {
+  return (await store.read()).tapToHear ?? false;
+}
+
+export async function writeTapToHear(on: boolean): Promise<void> {
+  await store.writeTapToHear(on);
+  window.dispatchEvent(new CustomEvent(TAP_HEAR_KEY, { detail: on }));
+}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -336,6 +336,8 @@ export interface StoredSettings {
   transliteration: boolean | null;
   /** Show per-word Latin transliteration beneath each Arabic word (#144). */
   wordTransliteration: boolean | null;
+  /** Tap an Arabic word to hear just that word recited (#145). */
+  tapToHear: boolean | null;
 }
 
 /**
@@ -356,6 +358,8 @@ export interface SettingsStore {
   writeTransliteration(on: boolean): Promise<void>;
   /** Toggle the per-word transliteration row (#144). */
   writeWordTransliteration(on: boolean): Promise<void>;
+  /** Toggle tap-a-word-to-hear word audio (#145). */
+  writeTapToHear(on: boolean): Promise<void>;
 }
 
 /** The reader's prayer-times location and calculation config as persisted. */


### PR DESCRIPTION
## What

Adds an opt-in **Tap a word to hear** toggle. Tapping any Arabic word seeks the verse audio to that word's timing segment and plays just that word — for per-word follow-along. Closes #145.

## Approach

Reuses the **quran.com word timings** the reciting highlight already fetches (`segments: [wordIndex, position, startMs, endMs]`). The segment `wordIndex` is **0-based**, so it maps directly to the word's `data-w` index — tapping word *i* plays `segments.find(s => s[0] === i)`. No new data source.

- **web** — a `playWord` that seeks the `<audio>` to the segment start, plays, and pauses at the segment end (`load()` + `loadedmetadata` so the seek lands even on a repeat tap). A word-tap branch in `ReadingAudio`'s existing document-level click handler, gated by the `tap-hear-on` body class — so it works in **both** the surah and juz readers over the existing `.w` spans, with zero layout change. Toggle in the reader toolbar; `ul.tapToHear` synced.
- **mobile** — `playWord` on `useSurahAudio` (seek to the segment, poll-pause at its end). The per-word units (shared with #144) become tap targets when the toggle is on, in the surah and juz readers; tap plays the word.
- **core** — `tapToHear` on `StoredSettings` + `writeTapToHear`.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (core 388; web 283 incl. new `tap-to-hear` + `ReadingAudio` tests), `pnpm build` — all pass.
- `ReadingAudio` test proves the core web behavior: a word tap fetches that verse's timing **only when tap-to-hear is on** (and is ignored when off).
- Live data path confirmed: quran.com returns word segments (1:1 → `[[0,1,60,610],[1,2,620,1310],…]`), 0-based wordIndex.

**Caveats:** the toggle is **off by default** and the mobile path is additive (the off-state reader is unchanged). The web audio seek is standard `HTMLAudioElement`; the **mobile expo-audio `seekTo`** was not exercised on-device in this environment, so its timing may want a pass on a real device — but it's gated behind the off-by-default toggle and can't crash the reader.

## Acceptance (from #145)

- [x] Word-timing data used (quran.com, runtime), attributed via the existing ATTRIBUTION entry.
- [x] Tap-a-word seeks + plays that word; enables per-word follow-along.
- [x] Web + mobile.