### PR TITLE
feat(mobile): use bundled recitation timings for word highlighting (ADR 0036)

### DIFF
--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -39,6 +39,12 @@ async function getJson<T>(url: string): Promise<T> {
 export const api = {
   listSurahs: () => getJson<{ surahs: Surah[] }>(`${BASE}/surahs`).then((d) => d.surahs),
   getSurah: (n: number) => getJson<{ surah: Surah; ayahs: Ayah[] }>(`${BASE}/surahs/${n}`),
+  /** Bundled word-by-word recitation timings for a reciter+surah (ADR 0036).
+   *  Resolves to null when the reciter/surah isn't covered (caller falls back to live). */
+  getTimings: (reciterId: string, n: number) =>
+    getJson<{ ayahs?: Record<string, [number, number, number][]> }>(
+      `${BASE}/recitations/${reciterId}/surahs/${n}/timings`,
+    ).catch(() => null),
   getTranslation: (n: number, edition: string) =>
     getJson<{ ayahs: TranslatedAyah[] }>(`${BASE}/surahs/${n}/translations/${edition}`).then(
       (d) => d.ayahs,

--- a/apps/mobile/src/audio/useSurahAudio.ts
+++ b/apps/mobile/src/audio/useSurahAudio.ts
@@ -22,6 +22,7 @@ import {
   type VerseKey,
 } from "@ummahlibrary/core";
 import { KEYS, getString, setString } from "../storage";
+import { api } from "../api";
 
 const STALL_MS = 8000;
 const POLL_MS = 60;
@@ -60,6 +61,51 @@ function fetchTiming(recitationId: number, verseKey: string): Promise<Timing | n
     timingCache.set(cacheKey, pending);
   }
   return pending;
+}
+
+// Bundled word timings (ADR 0036): one fetch per (reciter, surah) from our own
+// API, cached for the session. Preferred over the live quran.com timings so
+// highlighting / tap-to-hear work for the covered reciters without a third-party
+// call; null for uncovered reciters/surahs (then we fall back to live).
+const surahTimingCache = new Map<string, Promise<Map<number, Segment[]> | null>>();
+function bundledTimings(reciterId: string, surah: number): Promise<Map<number, Segment[]> | null> {
+  const cacheKey = `${reciterId}:${surah}`;
+  let pending = surahTimingCache.get(cacheKey);
+  if (!pending) {
+    pending = api
+      .getTimings(reciterId, surah)
+      .then((doc) => {
+        if (!doc?.ayahs) return null;
+        const map = new Map<number, Segment[]>();
+        for (const [aya, words] of Object.entries(doc.ayahs)) {
+          map.set(
+            Number(aya),
+            words.map(([w, startMs, endMs]) => [w, w + 1, startMs, endMs] as Segment),
+          );
+        }
+        return map;
+      })
+      .catch(() => null);
+    surahTimingCache.set(cacheKey, pending);
+  }
+  return pending;
+}
+
+/**
+ * Audio URL + word timings for one āyah (ADR 0036). Prefers the bundled
+ * quran-align timings (offline, no quran.com API) — playing the reciter's own
+ * everyayah audio so the timings line up; falls back to the live quran.com timing
+ * for reciters/āyāt the bundle doesn't cover, then to plain audio with no sync.
+ */
+async function getTiming(reciter: ReciterPlugin, verse: VerseKey): Promise<Timing> {
+  const bundled = await bundledTimings(reciter.id, verse.sura);
+  const segs = bundled?.get(verse.aya);
+  if (segs && segs.length) return { url: reciterAudioUrl(reciter, verse), segments: segs };
+  if (reciter.quranComId) {
+    const live = await fetchTiming(reciter.quranComId, verseKeyOf(verse));
+    if (live) return live;
+  }
+  return { url: reciterAudioUrl(reciter, verse), segments: [] };
 }
 
 export interface SurahAudio {
@@ -209,17 +255,10 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
             setBuffering(true);
             setActiveWord(-1);
 
-            let src: string | undefined;
-            let segments: Segment[] | null = null;
-            if (reciter.quranComId) {
-              const timing = await fetchTiming(reciter.quranComId, key);
-              if (tokenRef.current !== token) return;
-              if (timing) {
-                src = timing.url;
-                segments = timing.segments;
-              }
-            }
-            src ??= reciterAudioUrl(reciter, v);
+            const timing = await getTiming(reciter, v);
+            if (tokenRef.current !== token) return;
+            const src = timing.url;
+            const segments: Segment[] | null = timing.segments.length ? timing.segments : null;
 
             const player = ensurePlayer(src);
             if (tokenRef.current !== token) return;
@@ -397,15 +436,13 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
   // quran.com word timings — a no-op otherwise. The off-by-default toggle gates it.
   const playWord = useCallback(
     (verse: VerseKey, wordIndex: number) => {
-      const recitationId = reciter.quranComId;
-      if (!recitationId) return;
       const token = ++tokenRef.current; // cancels any running session
       settleRef.current?.();
       setActiveWord(-1);
       void (async () => {
         const key = verseKeyOf(verse);
-        const timing = await fetchTiming(recitationId, key);
-        if (tokenRef.current !== token || !timing) return;
+        const timing = await getTiming(reciter, verse);
+        if (tokenRef.current !== token) return;
         const seg = timing.segments.find((s) => s[0] === wordIndex);
         if (!seg) return;
         const player = ensurePlayer(timing.url);


### PR DESCRIPTION
## What
Brings the mobile reader to parity with web (#191): word highlighting + tap-to-hear now prefer the **bundled** quran-align timings instead of a live quran.com call.

- `api.getTimings(reciterId, n)` — reads the static `/api/v1/recitations/{id}/surahs/{n}/timings` endpoint (returns null when uncovered).
- `getTiming()` in `useSurahAudio` resolves **bundled → live quran.com → plain audio**, cached per (reciter, surah). Bundled reciters play their everyayah audio so the timings line up.

## Coverage & safety
- 7 covered reciters use bundled timings; **Al-Ghamdi / uncovered āyahs** fall back to the live quran.com timing, then to no-sync audio.
- **Degrades gracefully:** if the timings endpoint isn't reachable yet (e.g. before `ummahlibrary.org` redeploys with the merged route), `getTimings` returns null → live fallback → no breakage. Upgrades to bundled automatically once deployed.

## Verification
`pnpm lint`, `pnpm typecheck`, `pnpm test` (mobile 23, …), `pnpm build` — all green. Runtime word-highlight is best verified on a device/emulator pointed at an API base that serves the timings route.

Same audio-timing approach as the web `ReadingAudio` change in #191 (ADR 0036).