### PR TITLE
ci: pnpm/action-setup v6 (Node 24) + harden flaky home-nav e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,6 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-# Run JS-based actions on the runner's Node 24 (default from 2026-06-16). Covers
-# pnpm/action-setup@v4, which still ships a Node 20 entrypoint; checkout and
-# setup-node below are already on v5 (Node 24 native).
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   verify:
     name: Lint · Typecheck · Test · Build
@@ -24,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -54,7 +48,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/e2e/home-nav.spec.ts
+++ b/e2e/home-nav.spec.ts
@@ -2,6 +2,10 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Home navigation", () => {
   test("opening a surah from the home list lands in the reader", async ({ page }) => {
+    // A cold `next dev` compile of "/" and then /surah/[number] under CI load can
+    // be slow; triple the budget so this navigation doesn't flake near a tight
+    // timeout (it was occasionally exceeding the old 30s waits).
+    test.slow();
     await page.goto("/");
 
     // The surah index row for Al-Fātiḥah ("The Opening"). The home page also shows
@@ -9,12 +13,12 @@ test.describe("Home navigation", () => {
     // when there's no last-read), so match the index row's distinctive "· N ayahs"
     // subtitle — the card reads "· Juzʾ N" instead — to keep the locator unique.
     const opening = page.getByRole("link", { name: /The Opening · \d+ ayahs/ });
-    await expect(opening).toBeVisible();
+    await expect(opening).toBeVisible({ timeout: 30_000 });
     await opening.click();
 
     // We land on the surah-1 reader, with its mode chrome present. Generous
     // timeouts so a cold dev-server compile of /surah/[number] doesn't flake.
-    await expect(page).toHaveURL(/\/surah\/1$/, { timeout: 30_000 });
-    await expect(page.getByRole("button", { name: "Verse" })).toBeVisible({ timeout: 30_000 });
+    await page.waitForURL(/\/surah\/1$/, { timeout: 60_000 });
+    await expect(page.getByRole("button", { name: "Verse" })).toBeVisible({ timeout: 60_000 });
   });
 });


### PR DESCRIPTION
Two small cleanups flagged by the last green run:

- **Node 20 deprecation:** bump `pnpm/action-setup@v4 → @v6` (Node 24-native; drop-in, still reads the `packageManager` field). Removes the deprecation annotation and the temporary `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env workaround. `actions/checkout@v5` / `setup-node@v5` were already Node 24.
- **Flaky `home-nav.spec.ts`:** the home links are real `<a href>`, so navigation isn't the issue — a cold `next dev` compile of `/surah/[number]` under CI load occasionally exceeded the 30s waits. Added `test.slow()` + `waitForURL` + 60s waits for headroom. Verified locally (passes).