### PR TITLE
fix(e2e): harden home-nav for slow client-side navigation (follow-up to #197)

### DIFF
--- a/e2e/home-nav.spec.ts
+++ b/e2e/home-nav.spec.ts
@@ -2,9 +2,8 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Home navigation", () => {
   test("opening a surah from the home list lands in the reader", async ({ page }) => {
-    // A cold `next dev` compile of "/" and then /surah/[number] under CI load can
-    // be slow; triple the budget so this navigation doesn't flake near a tight
-    // timeout (it was occasionally exceeding the old 30s waits).
+    // A cold `next dev` compile of /surah/[number] under CI load can be slow, so
+    // give this navigation a generous budget.
     test.slow();
     await page.goto("/");
 
@@ -16,9 +15,22 @@ test.describe("Home navigation", () => {
     await expect(opening).toBeVisible({ timeout: 30_000 });
     await opening.click();
 
-    // We land on the surah-1 reader, with its mode chrome present. Generous
-    // timeouts so a cold dev-server compile of /surah/[number] doesn't flake.
-    await page.waitForURL(/\/surah\/1$/, { timeout: 60_000 });
+    // Poll the URL (no `load`-event dependency — a client-side nav never fires
+    // one). A cold /surah/[number] compile under CI load can be slow, so allow
+    // 45s. If the first click was swallowed before the App Router hydrated (the
+    // anchor's default nav is prevented but the client nav doesn't fire, leaving
+    // us on "/"), click once more — only after that long wait, so we never
+    // interrupt a slow-but-real navigation (re-clicking mid-nav would livelock it).
+    const surah1 = /\/surah\/1$/;
+    const landed = await expect(page)
+      .toHaveURL(surah1, { timeout: 45_000 })
+      .then(() => true, () => false);
+    if (!landed) {
+      await opening.click().catch(() => {});
+      await expect(page).toHaveURL(surah1, { timeout: 45_000 });
+    }
+
+    // Reader chrome confirms we landed (the cold /surah/[number] compile can be slow).
     await expect(page.getByRole("button", { name: "Verse" })).toBeVisible({ timeout: 60_000 });
   });
 });


### PR DESCRIPTION
#197 mis-diagnosed the home-nav flake (and my `waitForURL` change actually broke it — it waits for a `load` event that a client-side nav never fires).

**Real cause:** the home `<Link>` does a client-side navigation whose cold `/surah/[number]` dev-compile commits slowly — **~25s locally**, occasionally **>30s under CI load** — so the original 30s URL wait timed out (URL stuck at `/` for the whole window).

**Fix:** single click, then **poll the URL** (`toHaveURL`, no `load`-event dependency) with a 45s budget; if it still hasn't navigated after that long wait (a genuinely swallowed pre-hydration click), click **once** more — only after the wait, so a slow-but-real nav is never interrupted (which would livelock it). `test.slow()` gives the overall budget. Verified locally (25.8s).