### PR TITLE
fix(web): disable browser machine-translation app-wide

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -38,6 +38,10 @@ const amiri = Amiri({
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
+  // Disable browser/Google machine translation app-wide: the app already ships
+  // its own scholar-reviewed translations, and auto-translation corrupts the
+  // Arabic Quran text. Renders <meta name="google" content="notranslate">.
+  other: { google: "notranslate" },
   title: { default: "Ummah Library", template: "%s · Ummah Library" },
   description:
     "An open-source Quran reader — read the Quran with translations, recitations, tafsir and Islamic tools.",
@@ -97,7 +101,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${hanken.variable} ${ibmArabic.variable} ${amiri.variable}`}
+      translate="no"
+      className={`${hanken.variable} ${ibmArabic.variable} ${amiri.variable} notranslate`}
       suppressHydrationWarning
     >
       <head>


### PR DESCRIPTION
## What

Disable browser / Google machine translation across the whole web app.

## Why

Chrome/Google "Translate this page" — or a user's auto-translate setting —
rewrites the **Arabic Quran text** into the target language, which corrupts
scripture. The app already ships its own scholar-reviewed translations, so
browser machine translation adds nothing and only does harm.

## How

All in the root layout (`apps/web/src/app/layout.tsx`):

- `<meta name="google" content="notranslate">` via the Metadata `other` field —
  stops Chrome/Edge and the Google Translate widget offering or running
  translation, and suppresses the "Translate this page?" prompt.
- `translate="no"` + the `notranslate` class on `<html>` — covers Firefox and
  Safari; the standard attribute is inherited by the whole document.

## Trade-off

This disables translation for the **entire** app, including the English UI.
Intentional here, since the app provides its own translations.

## Verification

- Web tests: **92 passed** (34 files).
- Typecheck: no new errors from this change (pre-existing stale `.next/types`
  references to removed routes are unrelated).

> Note: this branch is based on a local `main` that is behind `origin/main`; the
> PR diff is just the single layout file.