### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Normalise line endings. Text files are stored LF in the repo and checked out
+# LF on every platform — without this, a Windows checkout with core.autocrlf=true
+# rewrites files to CRLF in the working tree, which breaks byte-exact tests such
+# as the packages/ui generated-CSS drift test (theme-css.test.ts, ADR 0027): the
+# generator emits LF, the checked-out .css became CRLF, so the suite was red on
+# Windows though green in CI. See qa/QA_LOG.md cycle 17.
+* text=auto eol=lf
+
+# Binary assets git must never line-ending-normalise.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.webp  binary
+*.pdf   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.otf   binary
+*.mp3   binary
+*.mp4   binary


### PR DESCRIPTION
## What
Adds a repo-root `.gitattributes` enforcing LF for text files (`* text=auto eol=lf`, plus explicit `binary` markers for images/fonts/audio).

## Why
On Windows with `core.autocrlf=true`, checkout rewrote the LF-committed generated CSS (`packages/ui/src/noor-themes.css`, `noor-tokens.css`) to CRLF. The byte-exact `theme-css.test.ts` drift test then compared CRLF (file) against the LF generator output and failed locally — though it passed in CI (Linux/LF). This makes line endings deterministic across platforms.

## Notes
- The repo index is already all-LF, so there is no renormalization churn — the only change is the new file.
- No `.bat`/`.cmd`/`.ps1` files exist, so nothing needs CRLF.