### PR TITLE
fix(a11y): clear Lighthouse accessibility findings

### DIFF
--- a/apps/web/src/app/hadith/page.tsx
+++ b/apps/web/src/app/hadith/page.tsx
@@ -1,3 +1,4 @@
+import { N } from "@ummahlibrary/ui";
 import { pluginRegistry } from "@ummahlibrary/api";
 import { NoorPageFrame } from "../../components/NoorPageFrame";
 import { HadithBrowser } from "../../components/HadithBrowser";
@@ -23,7 +24,7 @@ export default function HadithPage() {
       <p
         style={{
           fontSize: 12,
-          color: "#5C6273",
+          color: N.faint,
           textAlign: "center",
           marginTop: 32,
           fontFamily: "'Hanken Grotesk', system-ui, sans-serif",

--- a/apps/web/src/components/NoorPageFrame.tsx
+++ b/apps/web/src/components/NoorPageFrame.tsx
@@ -42,7 +42,10 @@ export function NoorPageFrame({ title, sub, glyph, back, actions, maxW = 920, ch
         >
           <div style={{ display: "flex", alignItems: "center", gap: 13, minWidth: 0 }}>
             <button
+              type="button"
               onClick={handleBack}
+              aria-label="Go back"
+              title="Go back"
               style={{
                 width: 40,
                 height: 40,

--- a/apps/web/src/components/ReadingAudio.tsx
+++ b/apps/web/src/components/ReadingAudio.tsx
@@ -633,6 +633,7 @@ export function ReadingAudio({
           {reciters.length > 1 && (
             <select
               className="noor-hide-sm"
+              aria-label="Reciter"
               value={reciterId}
               onChange={(e) => {
                 setReciterId(e.target.value);
@@ -686,6 +687,7 @@ export function ReadingAudio({
         {reciters.length > 1 && (
           <select
             className="audio-reciter"
+            aria-label="Reciter"
             value={reciterId}
             onChange={(e) => {
               setReciterId(e.target.value);

--- a/apps/web/src/components/shell/TabBar.tsx
+++ b/apps/web/src/components/shell/TabBar.tsx
@@ -30,6 +30,7 @@ export function TabBar() {
           <Link
             key={label}
             href={href}
+            aria-label={href === "/settings" ? "More — settings & tools" : undefined}
             style={{
               flex: 1,
               display: "flex",

--- a/packages/ui/src/noor-themes.css
+++ b/packages/ui/src/noor-themes.css
@@ -17,7 +17,7 @@
   --noor-border-soft: #1b2029;
   --noor-fg: #f4f1ea;
   --noor-muted: #9aa0b2;
-  --noor-faint: #5c6273;
+  --noor-faint: #7d8392;
   --noor-gold: #e6b855;
   --noor-gold-hi: #f4d58a;
   --noor-gold-dim: #a98432;

--- a/packages/ui/src/noor-tokens.css
+++ b/packages/ui/src/noor-tokens.css
@@ -13,7 +13,7 @@
   --noor-border-soft: #1b2029;
   --noor-fg: #f4f1ea;
   --noor-muted: #9aa0b2;
-  --noor-faint: #5c6273;
+  --noor-faint: #7d8392;
   --noor-gold: #e6b855;
   --noor-gold-hi: #f4d58a;
   --noor-gold-dim: #a98432;

--- a/packages/ui/src/themes.ts
+++ b/packages/ui/src/themes.ts
@@ -62,7 +62,9 @@ export const noorThemes: Record<ThemeKey, Palette> = {
     borderSoft: "#1b2029",
     fg: "#f4f1ea",
     muted: "#9aa0b2",
-    faint: "#5c6273",
+    // Lightened from #5c6273 to clear WCAG-AA 4.5:1 for small faint labels on the
+    // obsidian backgrounds (was ~2.94:1). #7d8392 → min 4.72:1. (Lighthouse a11y.)
+    faint: "#7d8392",
     accent: "#e6b855",
     accentHi: "#f4d58a",
     accentDim: "#a98432",


### PR DESCRIPTION
## What
Clears the accessibility findings surfaced by a Lighthouse audit across all routes.

- Name the shared back button (`NoorPageFrame`) and both reciter `<select>`s (`ReadingAudio`) so screen readers announce them
- Brighten the obsidian `--noor-faint` token (`#5c6273` → `#7d8392`) to clear WCAG-AA 4.5:1 for small faint labels on the dark backgrounds (was ~2.9:1); regenerate `noor-themes.css` / `noor-tokens.css` from `themes.ts`
- Use the `N.faint` token instead of a hardcoded colour in the hadith footer
- Give the "More" nav tab a descriptive `aria-label`

## Why
These issues lived in shared components, so they hit **23–29 of 29 routes**. Fixing the few shared components lifts accessibility across the whole app.

## Verification
- Home accessibility **96 → 100**; re-audit confirmed `button-name` / `select-name` / `color-contrast` cleared
- Full suite **835/835** green, the `theme-css` drift test holds, web typecheck clean

## Note
The contrast change is the one visual change (slightly brighter faint labels on the dark theme) — the minimal value that just clears AA was chosen; tune `#7d8392` if you'd like. Only the **obsidian** theme was changed (the one Lighthouse audited); the same likely applies to the other dark/light themes and is worth a per-theme pass.