### PR TITLE
feat(core): sunnah-fasting reminders (Mon/Thu + Ayyām al-Bīḍ)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -21,6 +21,7 @@ import { initNotifier } from "./src/notifier";
 import { syncPlanReminder } from "./src/plan-reminders";
 import { syncAdhkarReminder } from "./src/adhkar-reminders";
 import { syncPrayerReminders } from "./src/prayer-reminders";
+import { syncSunnahFastReminder } from "./src/sunnah-fast-reminders";
 import type { RootTabParamList } from "./src/navigation/types";
 
 /** URL routes for the web build and OS deep links (ummahlibrary://). */
@@ -119,6 +120,7 @@ export default function App() {
       void syncPlanReminder();
       void syncAdhkarReminder();
       void syncPrayerReminders();
+      void syncSunnahFastReminder();
     };
     void initNotifier().then(syncAll);
     const sub = AppState.addEventListener("change", (s) => {

--- a/apps/mobile/src/components/SunnahFastReminderToggle.tsx
+++ b/apps/mobile/src/components/SunnahFastReminderToggle.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useState } from "react";
+import { StyleSheet, Switch, Text, View } from "../Type";
+import { Icon, type Palette } from "@ummahlibrary/ui";
+import { type UpcomingSunnahFast, upcomingSunnahFasts } from "@ummahlibrary/core";
+import { useTheme } from "../theme";
+import { FONT } from "../fonts";
+import { expoNotifier } from "../notifier";
+import { readSunnahFastReminderOn, setSunnahFastReminderOn } from "../sunnah-fast-reminders";
+
+const GLYPH: Record<UpcomingSunnahFast["kind"], string> = {
+  "white-day": "🌕",
+  monday: "🌙",
+  thursday: "🌙",
+};
+
+function todayGregorian() {
+  const d = new Date();
+  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+}
+
+function countdownLabel(daysUntil: number): string {
+  if (daysUntil === 0) return "Today";
+  if (daysUntil === 1) return "Tomorrow";
+  return `in ${daysUntil} days`;
+}
+
+function gregorianFull(g: { year: number; month: number; day: number }): string {
+  return new Date(Date.UTC(g.year, g.month - 1, g.day)).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/**
+ * Opt-in reminder for the recommended (Sunnah) fasting days — Mondays &
+ * Thursdays and the white days (Ayyām al-Bīḍ) — with the coming fasts listed.
+ * The reminder fires the evening before; delivery is the OS scheduler. Needs no
+ * location: the dates are pure Hijri/weekday arithmetic.
+ */
+export function SunnahFastReminderToggle({ adjust = 0 }: { adjust?: number }) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const [on, setOn] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    void readSunnahFastReminderOn().then((o) => {
+      setOn(o);
+      setReady(true);
+    });
+  }, []);
+
+  const fasts = useMemo<UpcomingSunnahFast[]>(
+    () => upcomingSunnahFasts(todayGregorian(), 6, adjust),
+    [adjust],
+  );
+  const next = fasts[0];
+
+  async function toggle(nextOn: boolean) {
+    if (nextOn && expoNotifier.permission() !== "granted") await expoNotifier.requestPermission();
+    setOn(nextOn);
+    await setSunnahFastReminderOn(nextOn);
+  }
+
+  if (!ready) return null;
+
+  return (
+    <View>
+      <View style={styles.card}>
+        <View style={styles.row}>
+          <Icon name="bell" size={17} color={on ? colors.accent : colors.muted} sw={1.8} />
+          <View style={styles.text}>
+            <Text style={styles.title}>Sunnah-fast reminders</Text>
+            <Text style={styles.note}>
+              A nudge the evening before Mondays &amp; Thursdays and the white days (13–15).
+            </Text>
+          </View>
+          <Switch
+            value={on}
+            onValueChange={(v) => void toggle(v)}
+            trackColor={{ true: colors.accentSoft, false: colors.border }}
+            thumbColor={on ? colors.accent : colors.faint}
+          />
+        </View>
+        {on && next && (
+          <Text style={styles.nextLine}>
+            Next: {next.name} · {countdownLabel(next.daysUntil)}
+          </Text>
+        )}
+      </View>
+
+      <Text style={styles.sectionLabel}>Upcoming fasts</Text>
+      <View style={styles.list}>
+        {fasts.map((f) => (
+          <View
+            key={`${f.gregorian.year}-${f.gregorian.month}-${f.gregorian.day}`}
+            style={[styles.fastRow, f === next && styles.fastRowNext]}
+          >
+            <View style={styles.badge}>
+              <Text style={styles.badgeGlyph}>{GLYPH[f.kind]}</Text>
+            </View>
+            <View style={styles.flex1}>
+              <Text style={styles.fastName}>{f.name}</Text>
+              <Text style={styles.fastDate}>
+                {gregorianFull(f.gregorian)} · {f.note}
+              </Text>
+            </View>
+            <Text style={styles.countdown}>{countdownLabel(f.daysUntil)}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function makeStyles(c: Palette) {
+  return StyleSheet.create({
+    flex1: { flex: 1, minWidth: 0 },
+    card: {
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 14,
+      padding: 14,
+      backgroundColor: c.bgElev,
+    },
+    row: { flexDirection: "row", alignItems: "center", gap: 12 },
+    text: { flex: 1 },
+    title: { color: c.fg, fontFamily: FONT.semibold, fontSize: 14 },
+    note: { color: c.muted, fontFamily: FONT.regular, fontSize: 12.5, marginTop: 2 },
+    nextLine: { color: c.accent, fontFamily: FONT.semibold, fontSize: 12.5, marginTop: 10 },
+    sectionLabel: {
+      color: c.faint,
+      fontSize: 12,
+      fontWeight: "700",
+      letterSpacing: 1,
+      textTransform: "uppercase",
+      marginTop: 22,
+      marginBottom: 10,
+    },
+    list: { gap: 10 },
+    fastRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+      backgroundColor: c.bgElev,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 12,
+      paddingHorizontal: 14,
+      paddingVertical: 12,
+    },
+    fastRowNext: { borderColor: c.accent },
+    badge: {
+      width: 40,
+      height: 40,
+      borderRadius: 10,
+      backgroundColor: c.accentSoft,
+      borderWidth: 1,
+      borderColor: c.accent,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    badgeGlyph: { fontSize: 18 },
+    fastName: { color: c.fg, fontSize: 15, fontWeight: "700" },
+    fastDate: { color: c.faint, fontSize: 12, marginTop: 1 },
+    countdown: { color: c.accent, fontSize: 13, fontWeight: "700" },
+  });
+}

--- a/apps/mobile/src/reminder-store.ts
+++ b/apps/mobile/src/reminder-store.ts
@@ -16,7 +16,7 @@ import { KEYS, getJSON, getString, isObjectRecord, setJSON, setString } from "./
 export const mobileReminderStore: ReminderStore = {
   read: async (): Promise<ReminderPrefs> => {
     // Object guards: a corrupt/peer-synced null would crash on `plan.on` / `prayers[p]`.
-    const [plan, prayers, adhkar] = await Promise.all([
+    const [plan, prayers, adhkar, sunnahFast] = await Promise.all([
       getJSON<PlanReminderPref>(
         KEYS.planReminder,
         { on: false, time: DEFAULT_PLAN_REMINDER_TIME },
@@ -24,6 +24,7 @@ export const mobileReminderStore: ReminderStore = {
       ),
       getJSON<Partial<Record<PrayerName, boolean>>>(KEYS.prayerReminders, {}, isObjectRecord),
       getString(KEYS.adhkarReminders),
+      getString(KEYS.sunnahFastReminders),
     ]);
     return {
       plan: {
@@ -32,9 +33,11 @@ export const mobileReminderStore: ReminderStore = {
       },
       prayers,
       adhkarOn: adhkar === "on",
+      sunnahFastOn: sunnahFast === "on",
     };
   },
   writePlan: (pref) => setJSON(KEYS.planReminder, pref),
   writePrayers: (prefs) => setJSON(KEYS.prayerReminders, prefs),
   writeAdhkarOn: (on) => setString(KEYS.adhkarReminders, on ? "on" : "off"),
+  writeSunnahFastOn: (on) => setString(KEYS.sunnahFastReminders, on ? "on" : "off"),
 };

--- a/apps/mobile/src/screens/HijriCalendarScreen.tsx
+++ b/apps/mobile/src/screens/HijriCalendarScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { KEYS, getString, setString } from "../storage";
 import { useTheme, type Palette } from "../theme";
 import { weekdayOfGregorian } from "../utils";
+import { SunnahFastReminderToggle } from "../components/SunnahFastReminderToggle";
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
 const ADJUST_OPTIONS = [-2, -1, 0, 1, 2] as const;
@@ -201,6 +202,11 @@ export function HijriCalendarScreen() {
           match; your choice is saved on this device.
         </Text>
       </View>
+
+      <View style={styles.sunnahSection}>
+        <Text style={styles.sectionLabel}>Sunnah fasting</Text>
+        <SunnahFastReminderToggle adjust={adjust} />
+      </View>
     </ScrollView>
   );
 }
@@ -299,6 +305,7 @@ function makeStyles(c: Palette) {
     eventName: { color: c.fg, fontSize: 15, fontWeight: "700" },
     eventDate: { color: c.faint, fontSize: 12, marginTop: 1 },
     eventCountdown: { color: c.accent, fontSize: 13, fontWeight: "700" },
+    sunnahSection: { marginTop: 28 },
     adjustSection: { gap: 10 },
     adjustLabel: { color: c.fg, fontSize: 13, fontWeight: "600" },
     chips: { flexDirection: "row", gap: 8 },

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -52,6 +52,7 @@ export const KEYS = {
   planReminder: "ul.planReminder",
   prayerReminders: "ul.prayerReminders",
   adhkarReminders: "ul.adhkarReminders",
+  sunnahFastReminders: "ul.sunnahFastReminders",
   adhkarTimings: "ul.adhkarTimings",
 } as const;
 

--- a/apps/mobile/src/sunnah-fast-reminders.ts
+++ b/apps/mobile/src/sunnah-fast-reminders.ts
@@ -1,0 +1,26 @@
+/**
+ * Sunnah-fasting reminders — mobile wiring (#139). The on/off pref goes through
+ * the {@link mobileReminderStore}; the scheduling decision is the shared
+ * `syncSunnahFastReminder` in `@ummahlibrary/core`; delivery is the
+ * {@link expoNotifier} (OS-scheduled). Reuses the same orchestration as the web.
+ */
+import { syncSunnahFastReminder as coreSyncSunnahFastReminder } from "@ummahlibrary/core";
+import { expoNotifier } from "./notifier";
+import { mobileReminderStore } from "./reminder-store";
+
+export async function readSunnahFastReminderOn(): Promise<boolean> {
+  return (await mobileReminderStore.read()).sunnahFastOn;
+}
+
+export async function setSunnahFastReminderOn(on: boolean): Promise<void> {
+  await mobileReminderStore.writeSunnahFastOn(on);
+  await syncSunnahFastReminder();
+}
+
+export function syncSunnahFastReminder(): Promise<void> {
+  return coreSyncSunnahFastReminder({
+    notifier: expoNotifier,
+    reminders: mobileReminderStore,
+    now: () => new Date(),
+  });
+}

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 import { NoorPageFrame } from "../../components/NoorPageFrame";
 import { HijriCalendar } from "../../components/HijriCalendar";
+import { SunnahFastReminderToggle } from "../../components/SunnahFastReminderToggle";
 
 export const metadata: Metadata = {
   title: "Hijri calendar",
   description:
-    "The Islamic (Hijri) calendar with Gregorian cross-reference and a per-day adjustment to match your local moon sighting. Computed on Ummah Library — entirely on your device.",
+    "The Islamic (Hijri) calendar with Gregorian cross-reference and a per-day adjustment to match your local moon sighting, plus upcoming Sunnah-fasting days (Mondays, Thursdays and the white days) with optional reminders. Computed on Ummah Library — entirely on your device.",
   alternates: { canonical: "/calendar" },
 };
 
@@ -19,6 +20,9 @@ export default function CalendarPage() {
       maxW={820}
     >
       <HijriCalendar />
+      <div style={{ marginTop: 40 }}>
+        <SunnahFastReminderToggle />
+      </div>
     </NoorPageFrame>
   );
 }

--- a/apps/web/src/components/SunnahFastReminderToggle.tsx
+++ b/apps/web/src/components/SunnahFastReminderToggle.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { type UpcomingSunnahFast, upcomingSunnahFasts } from "@ummahlibrary/core";
+import { N } from "@ummahlibrary/ui";
+import { readHijriAdjust } from "../lib/hijri";
+import { WebNotifier } from "../lib/web-notifier";
+import { remindersEnabled, setRemindersEnabled, syncSunnahFastReminder } from "../lib/sunnah-fast-reminders";
+
+const notifier = new WebNotifier();
+
+const lcard = { background: N.card, border: `1px solid ${N.border}`, borderRadius: 16 } as const;
+const sectionLabel = {
+  fontSize: 12,
+  letterSpacing: 1,
+  textTransform: "uppercase",
+  color: N.faint,
+  fontWeight: 700,
+  fontFamily: N.ui,
+} as const;
+
+function localToday(): { year: number; month: number; day: number } {
+  const d = new Date();
+  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+}
+
+function countdownLabel(daysUntil: number): string {
+  if (daysUntil === 0) return "Today";
+  if (daysUntil === 1) return "Tomorrow";
+  return `in ${daysUntil} days`;
+}
+
+function gregorianFull(g: { year: number; month: number; day: number }): string {
+  return new Date(Date.UTC(g.year, g.month - 1, g.day)).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+const GLYPH: Record<UpcomingSunnahFast["kind"], string> = {
+  "white-day": "🌕",
+  monday: "🌙",
+  thursday: "🌙",
+};
+
+export function SunnahFastReminderToggle() {
+  const [enabled, setEnabled] = useState(false);
+  const [ready, setReady] = useState(false);
+  const [adjust, setAdjust] = useState(0);
+
+  useEffect(() => {
+    const a = readHijriAdjust();
+    setAdjust(a);
+    void remindersEnabled().then((on) => {
+      setEnabled(on);
+      setReady(true);
+    });
+  }, []);
+
+  const fasts = useMemo<UpcomingSunnahFast[]>(
+    () => upcomingSunnahFasts(localToday(), 6, adjust),
+    [adjust],
+  );
+  const next = fasts[0];
+
+  async function toggle() {
+    if (!enabled) {
+      if (notifier.permission() === "default") await notifier.requestPermission();
+      await setRemindersEnabled(true);
+      setEnabled(true);
+      await syncSunnahFastReminder(notifier);
+    } else {
+      await setRemindersEnabled(false);
+      setEnabled(false);
+      await syncSunnahFastReminder(notifier);
+    }
+  }
+
+  if (!ready) return null;
+
+  return (
+    <div>
+      <div style={{ ...sectionLabel, marginBottom: 12 }}>Sunnah fasting</div>
+
+      <div style={{ ...lcard, padding: "16px 18px" }}>
+        <div style={{ display: "flex", gap: 14, alignItems: "flex-start", justifyContent: "space-between" }}>
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 14.5, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>Reminders</div>
+            <p style={{ fontSize: 12.5, color: N.faint, lineHeight: 1.6, marginTop: 4, fontFamily: N.ui }}>
+              A nudge the evening before Mondays &amp; Thursdays and the white days (Ayyām al-Bīḍ,
+              13–15 of each month), so you can make the intention and plan suhoor. Works while Ummah
+              Library is open.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void toggle()}
+            aria-pressed={enabled}
+            style={{
+              flexShrink: 0,
+              padding: "8px 14px",
+              borderRadius: 999,
+              border: `1px solid ${enabled ? N.gold : N.border}`,
+              background: enabled ? N.goldSoft : "transparent",
+              color: enabled ? N.gold : N.muted,
+              fontSize: 13.5,
+              fontWeight: 700,
+              cursor: "pointer",
+              fontFamily: N.ui,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {enabled ? "🔔 On" : "🔕 Off"}
+          </button>
+        </div>
+        {enabled && next && (
+          <p style={{ fontSize: 12.5, color: N.gold, fontWeight: 600, marginTop: 12, fontFamily: N.ui }}>
+            Next: {next.name} · {countdownLabel(next.daysUntil)}
+          </p>
+        )}
+      </div>
+
+      <div style={{ ...sectionLabel, margin: "22px 0 12px" }}>Upcoming fasts</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {fasts.map((f) => (
+          <div
+            key={`${f.gregorian.year}-${f.gregorian.month}-${f.gregorian.day}`}
+            style={{
+              ...lcard,
+              padding: "14px 16px",
+              display: "flex",
+              gap: 14,
+              alignItems: "center",
+              borderColor: f === next ? N.gold : N.border,
+            }}
+          >
+            <div
+              style={{
+                width: 44,
+                height: 44,
+                borderRadius: 11,
+                background: N.goldSoft,
+                border: `1px solid ${N.gold}`,
+                display: "grid",
+                placeItems: "center",
+                flexShrink: 0,
+                fontSize: 20,
+              }}
+            >
+              {GLYPH[f.kind]}
+            </div>
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <div style={{ fontSize: 14.5, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>{f.name}</div>
+              <div style={{ fontSize: 12.5, color: N.faint, marginTop: 1, fontFamily: N.ui }}>
+                {gregorianFull(f.gregorian)} · {f.note}
+              </div>
+            </div>
+            <div
+              style={{
+                fontSize: 12.5,
+                fontWeight: 700,
+                color: N.gold,
+                fontFamily: N.ui,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {countdownLabel(f.daysUntil)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/reminder-store.test.ts
+++ b/apps/web/src/lib/reminder-store.test.ts
@@ -10,20 +10,24 @@ describe("webReminderStore", () => {
       plan: { on: false, time: "20:00" },
       prayers: {},
       adhkarOn: false,
+      sunnahFastOn: false,
     });
   });
 
-  it("round-trips plan, prayer, and adhkar preferences under the existing keys", async () => {
+  it("round-trips plan, prayer, adhkar, and sunnah-fast preferences under the existing keys", async () => {
     await store.writePlan({ on: true, time: "07:30" });
     await store.writePrayers({ fajr: true, isha: false });
     await store.writeAdhkarOn(true);
+    await store.writeSunnahFastOn(true);
 
     const r = await store.read();
     expect(r.plan).toEqual({ on: true, time: "07:30" });
     expect(r.prayers).toEqual({ fajr: true, isha: false });
     expect(r.adhkarOn).toBe(true);
-    // adhkar stays the historical "on"/"off" string
+    expect(r.sunnahFastOn).toBe(true);
+    // adhkar / sunnah-fast stay the historical "on"/"off" string
     expect(localStorage.getItem("ul.adhkarReminders")).toBe("on");
+    expect(localStorage.getItem("ul.sunnahFastReminders")).toBe("on");
   });
 
   it("falls back safely on malformed stored values", async () => {

--- a/apps/web/src/lib/reminder-store.ts
+++ b/apps/web/src/lib/reminder-store.ts
@@ -15,6 +15,7 @@ import { DEFAULT_PLAN_REMINDER_TIME } from "@ummahlibrary/core";
 const PLAN_KEY = "ul.planReminder";
 const PRAYERS_KEY = "ul.prayerReminders";
 const ADHKAR_KEY = "ul.adhkarReminders";
+const SUNNAH_FAST_KEY = "ul.sunnahFastReminders";
 const SEEN_KEY = "ul.adhkarReminderSeen";
 
 export const webReminderStore: ReminderStore = {
@@ -48,7 +49,14 @@ export const webReminderStore: ReminderStore = {
       /* keep default */
     }
 
-    return { plan, prayers, adhkarOn };
+    let sunnahFastOn = false;
+    try {
+      sunnahFastOn = localStorage.getItem(SUNNAH_FAST_KEY) === "on";
+    } catch {
+      /* keep default */
+    }
+
+    return { plan, prayers, adhkarOn, sunnahFastOn };
   },
   writePlan: async (pref) => {
     try {
@@ -67,6 +75,13 @@ export const webReminderStore: ReminderStore = {
   writeAdhkarOn: async (on) => {
     try {
       localStorage.setItem(ADHKAR_KEY, on ? "on" : "off");
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  writeSunnahFastOn: async (on) => {
+    try {
+      localStorage.setItem(SUNNAH_FAST_KEY, on ? "on" : "off");
     } catch {
       /* storage unavailable */
     }

--- a/apps/web/src/lib/sunnah-fast-reminders.ts
+++ b/apps/web/src/lib/sunnah-fast-reminders.ts
@@ -1,0 +1,32 @@
+/**
+ * Sunnah-fasting reminders — web wiring (#139). The on/off preference goes
+ * through the {@link webReminderStore} (`ReminderStore` port); the scheduling
+ * decision is the shared `syncSunnahFastReminder` in `@ummahlibrary/core`.
+ * Delivery is the {@link Notifier} port (fires while a tab is open). Unlike the
+ * adhkar/prayer reminders this needs no location — the fast days are pure
+ * Hijri/weekday arithmetic.
+ */
+import type { Notifier } from "@ummahlibrary/core";
+import { syncSunnahFastReminder as coreSyncSunnahFastReminder } from "@ummahlibrary/core";
+import { webReminderStore } from "./reminder-store";
+
+/** Event dispatched on a preference change so listeners can re-sync. */
+export const SUNNAH_FAST_REMINDERS_KEY = "ul.sunnahFastReminders";
+
+export async function remindersEnabled(): Promise<boolean> {
+  return (await webReminderStore.read()).sunnahFastOn;
+}
+
+export async function setRemindersEnabled(on: boolean): Promise<void> {
+  await webReminderStore.writeSunnahFastOn(on);
+  window.dispatchEvent(new CustomEvent(SUNNAH_FAST_REMINDERS_KEY, { detail: on }));
+}
+
+/** (Re)schedule the next sunnah-fast notification through the shared orchestration. */
+export function syncSunnahFastReminder(notifier: Notifier): Promise<void> {
+  return coreSyncSunnahFastReminder({
+    notifier,
+    reminders: webReminderStore,
+    now: () => new Date(),
+  });
+}

--- a/packages/core/src/hijri.ts
+++ b/packages/core/src/hijri.ts
@@ -117,6 +117,21 @@ export function hijriToGregorian(date: HijriDate, adjustmentDays = 0): Gregorian
   return jdnToGregorian(hijriToJdn(date) - adjustmentDays);
 }
 
+/**
+ * Weekday of a Gregorian civil date, `0`–`6` with `0 = Sunday` (JS `getDay`
+ * convention). Pure integer arithmetic off the Julian Day Number — no `Date`,
+ * no timezone — so `Monday`/`Thursday` tests are exact everywhere.
+ */
+export function gregorianWeekday(date: GregorianDate): number {
+  // JDN 0 is a Monday, so `(jdn + 1) mod 7` puts Sunday at 0.
+  return ((gregorianToJdn(date) + 1) % 7 + 7) % 7;
+}
+
+/** A Gregorian civil date shifted by `days` (may be negative), via the JDN round-trip. */
+export function addGregorianDays(date: GregorianDate, days: number): GregorianDate {
+  return jdnToGregorian(gregorianToJdn(date) + days);
+}
+
 /** The month's metadata (1–12). */
 export function hijriMonth(month: number): HijriMonth {
   return HIJRI_MONTHS[month - 1]!;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export * from "./achievements";
 export * from "./qibla";
 export * from "./hijri";
 export * from "./islamic-events";
+export * from "./sunnah-fasting";
 export * from "./zakat";
 export * from "./adhkar";
 export * from "./duas";

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -435,6 +435,8 @@ export interface ReminderPrefs {
   prayers: Partial<Record<PrayerName, boolean>>;
   /** Morning/evening adhkar reminder on/off. */
   adhkarOn: boolean;
+  /** Sunnah-fasting (Mon/Thu + Ayyām al-Bīḍ) reminder on/off. */
+  sunnahFastOn: boolean;
 }
 
 /**
@@ -449,6 +451,7 @@ export interface ReminderStore {
   writePlan(pref: PlanReminderPref): Promise<void>;
   writePrayers(prefs: Partial<Record<PrayerName, boolean>>): Promise<void>;
   writeAdhkarOn(on: boolean): Promise<void>;
+  writeSunnahFastOn(on: boolean): Promise<void>;
 }
 
 /**

--- a/packages/core/src/reminders.test.ts
+++ b/packages/core/src/reminders.test.ts
@@ -13,11 +13,13 @@ import { type ActivePlan, activatePlan, templateById } from "./reading-plans";
 import {
   DEFAULT_PLAN_REMINDER_TIME,
   PLAN_REMINDER_ID,
+  SUNNAH_FAST_REMINDER_ID,
   adhkarReminderId,
   prayerReminderId,
   syncAdhkarReminder,
   syncPlanReminder,
   syncPrayerReminders,
+  syncSunnahFastReminder,
 } from "./reminders";
 
 function fakeNotifier(permission: NotifyPermission = "granted") {
@@ -41,12 +43,19 @@ function fakeNotifier(permission: NotifyPermission = "granted") {
 }
 
 function fakeReminders(prefs: Partial<ReminderPrefs> = {}): ReminderStore {
-  const state: ReminderPrefs = { plan: { on: false, time: "20:00" }, prayers: {}, adhkarOn: false, ...prefs };
+  const state: ReminderPrefs = {
+    plan: { on: false, time: "20:00" },
+    prayers: {},
+    adhkarOn: false,
+    sunnahFastOn: false,
+    ...prefs,
+  };
   return {
     read: async () => state,
     writePlan: async (p) => void (state.plan = p),
     writePrayers: async (p) => void (state.prayers = p),
     writeAdhkarOn: async (o) => void (state.adhkarOn = o),
+    writeSunnahFastOn: async (o) => void (state.sunnahFastOn = o),
   };
 }
 
@@ -193,6 +202,30 @@ describe("syncPrayerReminders", () => {
   });
 });
 
+describe("syncSunnahFastReminder", () => {
+  it("schedules the next fast's reminder when enabled and granted", async () => {
+    const { notifier, scheduled, cancelled } = fakeNotifier();
+    await syncSunnahFastReminder({ notifier, reminders: fakeReminders({ sunnahFastOn: true }), now });
+    expect(cancelled).toContain(SUNNAH_FAST_REMINDER_ID); // cancels before scheduling (idempotent)
+    const n = scheduled.get(SUNNAH_FAST_REMINDER_ID)!;
+    expect(n.body).toBe("Make your intention tonight and plan suhoor. Tap to open Ummah Library.");
+    expect(n.title).toMatch(/^Sunnah fast tomorrow — /);
+    expect(n.tag).toBe(SUNNAH_FAST_REMINDER_ID);
+    // Fires in the future (the evening before the fast).
+    expect(new Date(n.at!).getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  it("is a no-op when off, or enabled without permission", async () => {
+    const off = fakeNotifier();
+    await syncSunnahFastReminder({ notifier: off.notifier, reminders: fakeReminders({ sunnahFastOn: false }), now });
+    expect(off.scheduled.size).toBe(0);
+
+    const denied = fakeNotifier("denied");
+    await syncSunnahFastReminder({ notifier: denied.notifier, reminders: fakeReminders({ sunnahFastOn: true }), now });
+    expect(denied.scheduled.size).toBe(0);
+  });
+});
+
 describe("reminder ids and constants", () => {
   it("pins the stable ids and the default plan time", () => {
     expect(DEFAULT_PLAN_REMINDER_TIME).toBe("20:00");
@@ -200,6 +233,7 @@ describe("reminder ids and constants", () => {
     expect(adhkarReminderId("morning")).toBe("adhkar:morning");
     expect(adhkarReminderId("evening")).toBe("adhkar:evening");
     expect(prayerReminderId("fajr")).toBe("prayer:fajr");
+    expect(SUNNAH_FAST_REMINDER_ID).toBe("sunnah-fast:next");
   });
 });
 

--- a/packages/core/src/reminders.ts
+++ b/packages/core/src/reminders.ts
@@ -16,9 +16,12 @@ import type { Notifier, PlanStore, PrayerTimingsProvider, ReminderStore } from "
 import { nextAdhkarReminder } from "./adhkar";
 import { OBLIGATORY_PRAYERS, PRAYER_LABELS, type PrayerName, prayerReminders } from "./prayer";
 import { nextDailyReminder, planReminderContent } from "./reading-plans";
+import { nextSunnahFastReminder } from "./sunnah-fasting";
 
 export const DEFAULT_PLAN_REMINDER_TIME = "20:00";
 export const PLAN_REMINDER_ID = "plan:daily";
+/** Stable id for the single next-sunnah-fast reminder (rescheduling replaces it). */
+export const SUNNAH_FAST_REMINDER_ID = "sunnah-fast:next";
 
 const ADHKAR_OCCASION_LIST: readonly AdhkarOccasion[] = ["morning", "evening"];
 const ADHKAR_LABEL: Record<AdhkarOccasion, string> = { morning: "morning", evening: "evening" };
@@ -128,4 +131,30 @@ export async function syncPrayerReminders(
       tag: prayerReminderId(reminder.prayer),
     });
   }
+}
+
+/**
+ * (Re)schedule the next Sunnah-fast reminder (#139) — the evening before the
+ * next recommended fast (Monday/Thursday or a white day). Idempotent: cancels the
+ * single id, then schedules the next occurrence. A no-op when off or without
+ * permission. Needs no location or timings — the dates are pure Hijri/weekday
+ * arithmetic; v1 uses the tabular calendar (no sighting adjustment).
+ */
+export async function syncSunnahFastReminder(deps: ReminderSyncDeps): Promise<void> {
+  const { notifier, reminders, now } = deps;
+  await notifier.cancel(SUNNAH_FAST_REMINDER_ID);
+
+  const { sunnahFastOn } = await reminders.read();
+  if (!sunnahFastOn || notifier.permission() !== "granted") return;
+
+  const next = nextSunnahFastReminder(now());
+  if (!next) return;
+
+  await notifier.schedule({
+    id: SUNNAH_FAST_REMINDER_ID,
+    title: `Sunnah fast tomorrow — ${next.fast.name} 🌙`,
+    body: "Make your intention tonight and plan suhoor. Tap to open Ummah Library.",
+    at: next.at.toISOString(),
+    tag: SUNNAH_FAST_REMINDER_ID,
+  });
 }

--- a/packages/core/src/sunnah-fasting.test.ts
+++ b/packages/core/src/sunnah-fasting.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { GregorianDate } from "./hijri";
+import { addGregorianDays, gregorianToHijri, gregorianWeekday, hijriToGregorian } from "./hijri";
+import { nextSunnahFastReminder, upcomingSunnahFasts } from "./sunnah-fasting";
+
+/** Independent oracle: the platform's own UTC weekday for a civil date. */
+function utcWeekday(g: GregorianDate): number {
+  return new Date(Date.UTC(g.year, g.month - 1, g.day)).getUTCDay();
+}
+
+describe("gregorianWeekday", () => {
+  it("matches known anchors", () => {
+    expect(gregorianWeekday({ year: 2000, month: 1, day: 1 })).toBe(6); // Saturday
+    expect(gregorianWeekday({ year: 2026, month: 7, day: 2 })).toBe(4); // Thursday
+    expect(gregorianWeekday({ year: 2026, month: 1, day: 1 })).toBe(4); // Thursday
+  });
+
+  it("agrees with the platform UTC weekday across a range", () => {
+    let g: GregorianDate = { year: 2025, month: 1, day: 1 };
+    for (let i = 0; i < 800; i++) {
+      expect(gregorianWeekday(g)).toBe(utcWeekday(g));
+      g = addGregorianDays(g, 1);
+    }
+  });
+});
+
+describe("addGregorianDays", () => {
+  it("crosses month and year boundaries", () => {
+    expect(addGregorianDays({ year: 2026, month: 1, day: 1 }, -1)).toEqual({ year: 2025, month: 12, day: 31 });
+    expect(addGregorianDays({ year: 2026, month: 2, day: 28 }, 1)).toEqual({ year: 2026, month: 3, day: 1 }); // 2026 not leap
+    expect(addGregorianDays({ year: 2026, month: 7, day: 2 }, 7)).toEqual({ year: 2026, month: 7, day: 9 });
+  });
+});
+
+describe("upcomingSunnahFasts", () => {
+  const today: GregorianDate = { year: 2026, month: 7, day: 2 }; // a Thursday
+
+  it("returns fasts sorted soonest-first, all upcoming, with unique dates", () => {
+    const fasts = upcomingSunnahFasts(today, 8);
+    expect(fasts.length).toBeLessThanOrEqual(8);
+    expect(fasts.length).toBeGreaterThan(0);
+    for (let i = 1; i < fasts.length; i++) {
+      expect(fasts[i]!.daysUntil).toBeGreaterThanOrEqual(fasts[i - 1]!.daysUntil);
+    }
+    expect(fasts.every((f) => f.daysUntil >= 0)).toBe(true);
+    const keys = fasts.map((f) => `${f.gregorian.year}-${f.gregorian.month}-${f.gregorian.day}`);
+    expect(new Set(keys).size).toBe(keys.length); // no duplicate dates
+  });
+
+  it("labels each fast consistently with its actual date", () => {
+    for (const f of upcomingSunnahFasts(today, 12)) {
+      if (f.kind === "monday") expect(gregorianWeekday(f.gregorian)).toBe(1);
+      if (f.kind === "thursday") expect(gregorianWeekday(f.gregorian)).toBe(4);
+      if (f.kind === "white-day") {
+        expect([13, 14, 15]).toContain(f.hijri.day);
+        // The stored Hijri date resolves back to the stored Gregorian one.
+        expect(hijriToGregorian(f.hijri)).toEqual(f.gregorian);
+      }
+    }
+  });
+
+  it("surfaces today's Thursday and the coming Monday", () => {
+    const fasts = upcomingSunnahFasts(today, 8);
+    expect(fasts.some((f) => f.kind === "thursday" && f.daysUntil === 0)).toBe(true);
+    expect(fasts.some((f) => f.kind === "monday" && f.daysUntil === 4)).toBe(true); // Mon 2026-07-06
+  });
+
+  it("lists a white day that is also a weekly day once, as the white day", () => {
+    const keyOf = (g: GregorianDate) => `${g.year}-${g.month}-${g.day}`;
+    // A white day is where the calendar *places* the 13th–15th (via hijriToGregorian);
+    // find a real one that also falls on a Monday/Thursday, matching the resolver.
+    let probe: GregorianDate = { year: 2026, month: 1, day: 1 };
+    let hit: GregorianDate | null = null;
+    for (let i = 0; i < 400 && !hit; i++) {
+      const h = gregorianToHijri(probe);
+      const isWhite = [13, 14, 15].some((d) => keyOf(hijriToGregorian({ ...h, day: d })) === keyOf(probe));
+      const wd = gregorianWeekday(probe);
+      if (isWhite && (wd === 1 || wd === 4)) hit = probe;
+      probe = addGregorianDays(probe, 1);
+    }
+    expect(hit).not.toBeNull();
+
+    const from = addGregorianDays(hit!, -3);
+    const coinciding = upcomingSunnahFasts(from, 30).filter((f) => keyOf(f.gregorian) === keyOf(hit!));
+    expect(coinciding).toHaveLength(1); // collapsed to a single entry
+    expect(coinciding[0]!.kind).toBe("white-day"); // …and it's the white day, not the weekly one
+  });
+
+  it("honours count and the sighting adjustment", () => {
+    expect(upcomingSunnahFasts(today, 3)).toHaveLength(3);
+    // A white day's Gregorian date is resolved with the same adjustment threaded through.
+    const white = upcomingSunnahFasts(today, 12, 1).find((f) => f.kind === "white-day")!;
+    expect(white.gregorian).toEqual(hijriToGregorian(white.hijri, 1));
+  });
+});
+
+describe("nextSunnahFastReminder", () => {
+  it("fires at 20:00 the evening before the next fast, in the future", () => {
+    const now = new Date(2026, 6, 2, 10, 0, 0); // Thu 2026-07-02, 10:00 local
+    const res = nextSunnahFastReminder(now)!;
+    expect(res).not.toBeNull();
+    expect(res.at.getHours()).toBe(20);
+    expect(res.at.getMinutes()).toBe(0);
+    expect(res.at.getTime()).toBeGreaterThan(now.getTime());
+    // `at` is exactly the day before the fast, locally.
+    const eve = addGregorianDays(res.fast.gregorian, -1);
+    expect(res.at.getFullYear()).toBe(eve.year);
+    expect(res.at.getMonth()).toBe(eve.month - 1);
+    expect(res.at.getDate()).toBe(eve.day);
+  });
+
+  it("skips a fast whose evening-before has already passed (never reminds for today)", () => {
+    // 22:00 on a Thursday: today's fast is over, and its eve (yesterday) is long gone.
+    const now = new Date(2026, 6, 2, 22, 0, 0);
+    const res = nextSunnahFastReminder(now)!;
+    expect(res.fast.daysUntil).toBeGreaterThanOrEqual(1);
+    expect(res.at.getTime()).toBeGreaterThan(now.getTime());
+  });
+});

--- a/packages/core/src/sunnah-fasting.ts
+++ b/packages/core/src/sunnah-fasting.ts
@@ -1,0 +1,154 @@
+/**
+ * Sunnah (recommended) fasting days — the weekly Mondays & Thursdays and the
+ * white days (Ayyām al-Bīḍ, 13–15 of each Hijri month) — resolved to their
+ * upcoming Gregorian occurrences with a day countdown, plus the decision of when
+ * to remind about the next one.
+ *
+ * Like the rest of `core` this is deterministic and clock-injected: the resolver
+ * takes "today" as a {@link GregorianDate} and the reminder helper takes `now`
+ * as a `Date` (see `hifz.ts`), so there is no I/O and no hidden `Date.now()`.
+ * These are factual calendar markers (no interpretive content); the tabular
+ * Hijri calendar can sit ±1 day from a local sighting, so every function threads
+ * the same `adjustmentDays` offset the rest of the calendar uses (see `hijri.ts`).
+ */
+
+import type { GregorianDate, HijriDate } from "./hijri";
+import { addGregorianDays, gregorianToHijri, gregorianWeekday, hijriToGregorian } from "./hijri";
+
+/** Which kind of recommended fast a day is. */
+export type SunnahFastKind = "monday" | "thursday" | "white-day";
+
+/** A recommended fast resolved to its next Gregorian occurrence. */
+export interface UpcomingSunnahFast {
+  kind: SunnahFastKind;
+  /** Short label shown to the reader, e.g. `"Monday fast"`. */
+  name: string;
+  /** One-line description. */
+  note: string;
+  /** The Hijri date it falls on. */
+  hijri: HijriDate;
+  /** Its Gregorian civil date. */
+  gregorian: GregorianDate;
+  /** Whole days from `today` to the fast (0 = today, 1 = tomorrow). */
+  daysUntil: number;
+}
+
+const MONDAY = 1;
+const THURSDAY = 4;
+/** The white days — Ayyām al-Bīḍ — are the 13th, 14th and 15th of every Hijri month. */
+const WHITE_DAYS = [13, 14, 15] as const;
+
+/**
+ * Proleptic Gregorian day number (a Julian Day Number) for a civil date — pure
+ * integer arithmetic, no `Date`. Mirrors the conversion in `hijri.ts`/
+ * `islamic-events.ts` so day differences are exact regardless of timezone.
+ */
+function dayNumber({ year, month, day }: GregorianDate): number {
+  const a = Math.floor((14 - month) / 12);
+  const y = year + 4800 - a;
+  const m = month + 12 * a - 3;
+  return (
+    day +
+    Math.floor((153 * m + 2) / 5) +
+    365 * y +
+    Math.floor(y / 4) -
+    Math.floor(y / 100) +
+    Math.floor(y / 400) -
+    32045
+  );
+}
+
+const dateKey = (g: GregorianDate): string => `${g.year}-${g.month}-${g.day}`;
+
+/** The next `count` Gregorian dates (soonest first) whose weekday is `weekday`, from `today`. */
+function nextWeekdays(today: GregorianDate, weekday: number, count: number): GregorianDate[] {
+  const offset = (weekday - gregorianWeekday(today) + 7) % 7;
+  return Array.from({ length: count }, (_, i) => addGregorianDays(today, offset + i * 7));
+}
+
+/**
+ * The next `count` recommended fasts at or after `today`, soonest first, each
+ * with the Gregorian date it next falls on and the days until then. A day that is
+ * both a white day and a Monday/Thursday is listed once, as the white day (its
+ * three-day observance takes precedence in the label).
+ */
+export function upcomingSunnahFasts(
+  today: GregorianDate,
+  count = 8,
+  adjustmentDays = 0,
+): UpcomingSunnahFast[] {
+  const todayNum = dayNumber(today);
+  const todayHijri = gregorianToHijri(today, adjustmentDays);
+
+  // White days first so they win the de-dupe when they coincide with a Mon/Thu.
+  const byDate = new Map<string, UpcomingSunnahFast>();
+  const add = (fast: UpcomingSunnahFast): void => {
+    if (fast.daysUntil >= 0 && !byDate.has(dateKey(fast.gregorian))) {
+      byDate.set(dateKey(fast.gregorian), fast);
+    }
+  };
+
+  // Ayyām al-Bīḍ for this Hijri month and the next two (enough to fill `count`).
+  for (let k = 0; k < 3; k++) {
+    let year = todayHijri.year;
+    let month = todayHijri.month + k;
+    if (month > 12) {
+      month -= 12;
+      year += 1;
+    }
+    for (const day of WHITE_DAYS) {
+      const gregorian = hijriToGregorian({ year, month, day }, adjustmentDays);
+      add({
+        kind: "white-day",
+        name: "White Day (Ayyām al-Bīḍ)",
+        note: "The 13th–15th of the Hijri month",
+        hijri: { year, month, day },
+        gregorian,
+        daysUntil: dayNumber(gregorian) - todayNum,
+      });
+    }
+  }
+
+  // Weekly Mondays & Thursdays.
+  const weekly: Array<[SunnahFastKind, number, string]> = [
+    ["monday", MONDAY, "Monday fast"],
+    ["thursday", THURSDAY, "Thursday fast"],
+  ];
+  for (const [kind, weekday, name] of weekly) {
+    for (const gregorian of nextWeekdays(today, weekday, count)) {
+      add({
+        kind,
+        name,
+        note: "A recommended weekly fast",
+        hijri: gregorianToHijri(gregorian, adjustmentDays),
+        gregorian,
+        daysUntil: dayNumber(gregorian) - todayNum,
+      });
+    }
+  }
+
+  return [...byDate.values()].sort((a, b) => a.daysUntil - b.daysUntil).slice(0, Math.max(0, count));
+}
+
+/**
+ * The next recommended fast to remind about and the instant to fire it — the
+ * evening before at 20:00 local, so the reader has time to make the intention
+ * and plan suhoor. Skips a fast whose evening-before has already passed (e.g. a
+ * fast that is today), rolling forward to the next one. Pure: `now` is injected.
+ */
+export function nextSunnahFastReminder(
+  now: Date,
+  adjustmentDays = 0,
+): { fast: UpcomingSunnahFast; at: Date } | null {
+  const today: GregorianDate = {
+    year: now.getFullYear(),
+    month: now.getMonth() + 1,
+    day: now.getDate(),
+  };
+  for (const fast of upcomingSunnahFasts(today, 8, adjustmentDays)) {
+    const eve = addGregorianDays(fast.gregorian, -1);
+    const at = new Date(eve.year, eve.month - 1, eve.day, 20, 0, 0, 0);
+    if (at.getTime() > now.getTime()) return { fast, at };
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #139.

## What
Opt-in reminders and an upcoming-fasts list for the recommended (Sunnah) fasting days — **Mondays & Thursdays** and the **white days (Ayyām al-Bīḍ, 13–15 of each Hijri month)** — surfaced on the Hijri calendar in both web and mobile.

The reminder fires the **evening before** a fast (~20:00 local) so the reader has time to make the intention (niyyah) and plan suhoor.

## How it's built (follows the existing pattern)
- **Core (pure, tested):** `sunnah-fasting.ts` — `upcomingSunnahFasts` resolves the next fasts (de-duped by date, white-day precedence when one lands on a Mon/Thu) and `nextSunnahFastReminder` picks the evening-before instant. The clock is injected and the sighting `adjustmentDays` is threaded through, like `islamic-events.ts`. Two small pure calendar primitives added to `hijri.ts` (`gregorianWeekday`, `addGregorianDays`).
- **Reminder stack:** new `sunnahFastOn` pref + `writeSunnahFastOn` on the `ReminderStore` port; `syncSunnahFastReminder` orchestration mirroring the adhkar/prayer families (cancel-by-id, no-op without permission). No location needed — the dates are pure arithmetic.
- **Adapters:** `ul.sunnahFastReminders` key in the web (localStorage) and mobile (AsyncStorage) stores.
- **Apps:** thin `sunnah-fast-reminders` wrappers, a `SunnahFastReminderToggle` (toggle + upcoming list) on the Hijri calendar (web) and calendar screen (mobile), and launch/foreground sync in mobile `App.tsx`.

No new data, no network, no scholar review (Tier 1 factual dates). No ADR — it follows the existing reminder pattern without adding an architectural boundary.

## Verification
- 439 core tests pass, including new `sunnah-fasting` cases (weekday anchors, next Mon/Thu, white-day resolution + precedence, adjustment, reminder timing) and `syncSunnahFastReminder` cases.
- `tsc --noEmit` clean for core, web, and mobile; web production build succeeds; web/mobile store-adapter tests updated and green.
- Visually confirmed on `/calendar`: today shows as the next fast, "Monday fast · in 4 days" follows, styled cohesively with the calendar.