### PR TITLE
feat(core): hifz analytics & heatmap

### DIFF
--- a/apps/mobile/src/hifz.ts
+++ b/apps/mobile/src/hifz.ts
@@ -4,51 +4,16 @@
  * same local-first SM-2 state identically (ADR 0006). The SM-2 engine itself
  * lives in `@ummahlibrary/core`; this module only derives view-model summaries.
  */
-import { type HifzCard, type VerseKey, isDue } from "@ummahlibrary/core";
-
-interface Record {
-  ref: VerseKey;
-  card: HifzCard;
-}
-
-/** 0 = new / never reviewed · 1 = solidly known (interval ≥ 30 days). */
-export function cardStrength(card: HifzCard): number {
-  if (card.lastReviewed === null) return 0;
-  return Math.min(1, card.intervalDays / 30);
-}
-
-export interface SurahProgress {
-  surahNumber: number;
-  trackedCount: number;
-  dueCount: number;
-  avgStrength: number; // 0–1
-  nextDue: string | null; // earliest due ISO timestamp among tracked cards
-}
-
-/** Aggregate per-ayah records into per-surah summaries. */
-export function surahProgressMap(records: Record[], now: Date): Map<number, SurahProgress> {
-  const map = new Map<number, SurahProgress>();
-  for (const r of records) {
-    const sura = r.ref.sura;
-    const p = map.get(sura) ?? {
-      surahNumber: sura,
-      trackedCount: 0,
-      dueCount: 0,
-      avgStrength: 0,
-      nextDue: null,
-    };
-    p.trackedCount++;
-    p.avgStrength += cardStrength(r.card);
-    if (isDue(r.card, now)) p.dueCount++;
-    if (!p.nextDue || r.card.due < p.nextDue) p.nextDue = r.card.due;
-    map.set(sura, p);
-  }
-  for (const [sura, p] of map) {
-    p.avgStrength = p.trackedCount > 0 ? p.avgStrength / p.trackedCount : 0;
-    map.set(sura, p);
-  }
-  return map;
-}
+// Strength + per-surah progress derivations are pure logic; they live in core
+// (shared with the web reader) and are re-exported here so existing imports keep
+// their path. `surahProgressMap(records, now)` — pass `allRecords()`.
+export {
+  cardStrength,
+  surahProgressMap,
+  weakestSurahs,
+  type SurahProgress,
+  type HifzAyahRecord,
+} from "@ummahlibrary/core";
 
 /** Render a card's next-due timestamp relative to now. */
 export function relativeDue(nextDue: string | null, now: Date): string {

--- a/apps/mobile/src/screens/HifzDashboardScreen.tsx
+++ b/apps/mobile/src/screens/HifzDashboardScreen.tsx
@@ -2,7 +2,14 @@ import { useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from "../Type";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { TOTAL_AYAHS, type Surah } from "@ummahlibrary/core";
+import {
+  TOTAL_AYAHS,
+  type HeatmapDay,
+  type Surah,
+  activityHeatmap,
+  hifzStreaks,
+  weakestSurahs,
+} from "@ummahlibrary/core";
 import { Khatam } from "@ummahlibrary/ui";
 import { api } from "../api";
 import { useTheme, type Palette } from "../theme";
@@ -24,9 +31,15 @@ export function HifzDashboardScreen({ navigation }: Props) {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
   const insets = useSafeAreaInsets();
-  const { ready, allRecords, trackedCount, dueRecords, streak } = useLibrary();
+  const { ready, allRecords, trackedCount, dueRecords, streak, reviewLog } = useLibrary();
 
   const [surahs, setSurahs] = useState<Surah[] | null>(null);
+
+  const levelColors = useMemo(() => {
+    const a = colors.accent;
+    const hex = /^#[0-9a-fA-F]{6}$/.test(a);
+    return [colors.border, hex ? `${a}3D` : a, hex ? `${a}7A` : a, hex ? `${a}B8` : a, a];
+  }, [colors]);
 
   useEffect(() => {
     let active = true;
@@ -57,6 +70,30 @@ export function HifzDashboardScreen({ navigation }: Props) {
     return items;
     // trackedCount changes whenever the hifz store mutates — recompute then.
   }, [surahs, trackedCount]);
+
+  // Weakest surahs (lowest strength first) to guide focus.
+  const weak = useMemo<QueueItem[]>(() => {
+    if (!surahs) return [];
+    const byNum = new Map(surahs.map((s) => [s.number, s]));
+    return weakestSurahs(surahProgressMap(allRecords(), now).values(), 5)
+      .map((p) => {
+        const meta = byNum.get(p.surahNumber);
+        return meta
+          ? { ...p, transliteration: meta.transliteration, name: meta.name, ayahCount: meta.ayahCount }
+          : null;
+      })
+      .filter((x): x is QueueItem => x !== null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [surahs, trackedCount]);
+
+  // Review-activity heatmap + longest streak from the forward-looking log.
+  const heatmap = useMemo<HeatmapDay[]>(() => activityHeatmap(reviewLog, now), [reviewLog]);
+  const longestStreak = useMemo(() => hifzStreaks(reviewLog, now).longest, [reviewLog]);
+  const weeks = useMemo(() => {
+    const out: HeatmapDay[][] = [];
+    for (let i = 0; i < heatmap.length; i += 7) out.push(heatmap.slice(i, i + 7));
+    return out;
+  }, [heatmap]);
 
   const memorizedPct =
     trackedCount === 0 ? "0%" : `${Math.round((trackedCount / TOTAL_AYAHS) * 100)}%`;
@@ -137,6 +174,61 @@ export function HifzDashboardScreen({ navigation }: Props) {
                 </View>
               ))}
             </View>
+          )}
+
+          {/* Review activity heatmap */}
+          <Text style={styles.sectionLabel}>Review activity</Text>
+          <View style={styles.heatCard}>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+              <View style={styles.heatGrid}>
+                {weeks.map((week, wi) => (
+                  <View key={wi} style={styles.heatCol}>
+                    {week.map((d) => (
+                      <View key={d.date} style={[styles.heatCell, { backgroundColor: levelColors[d.level] }]} />
+                    ))}
+                  </View>
+                ))}
+              </View>
+            </ScrollView>
+            <View style={styles.heatFooter}>
+              <Text style={styles.heatCaption}>
+                Longest streak: {longestStreak} day{longestStreak === 1 ? "" : "s"}
+              </Text>
+              <View style={styles.legendRow}>
+                <Text style={styles.legendText}>Less</Text>
+                {[0, 1, 2, 3, 4].map((l) => (
+                  <View key={l} style={[styles.heatCell, { backgroundColor: levelColors[l] }]} />
+                ))}
+                <Text style={styles.legendText}>More</Text>
+              </View>
+            </View>
+          </View>
+
+          {/* Needs attention — weakest surahs */}
+          {weak.length > 0 && (
+            <>
+              <Text style={styles.sectionLabel}>Needs attention</Text>
+              <View style={{ gap: 10 }}>
+                {weak.map((item) => (
+                  <View key={item.surahNumber} style={styles.queueRow}>
+                    <AyahBadge n={item.surahNumber} size={38} />
+                    <View style={{ flex: 1, minWidth: 0 }}>
+                      <Text style={styles.queueName}>{item.transliteration}</Text>
+                      <View style={styles.strengthRow}>
+                        <View style={styles.strengthTrack}>
+                          <View
+                            style={[styles.strengthFill, { width: `${Math.round(item.avgStrength * 100)}%` }]}
+                          />
+                        </View>
+                        <Text style={styles.queueMeta}>
+                          {item.trackedCount}/{item.ayahCount} · {Math.round(item.avgStrength * 100)}%
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                ))}
+              </View>
+            </>
           )}
         </>
       )}
@@ -226,6 +318,27 @@ function makeStyles(c: Palette) {
     },
     strengthFill: { height: "100%", borderRadius: 2, backgroundColor: c.accent },
     queueMeta: { color: c.faint, fontSize: 12 },
+    heatCard: {
+      backgroundColor: c.bgElev,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 14,
+      padding: 14,
+      gap: 12,
+    },
+    heatGrid: { flexDirection: "row", gap: 3 },
+    heatCol: { flexDirection: "column", gap: 3 },
+    heatCell: { width: 11, height: 11, borderRadius: 2 },
+    heatFooter: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      flexWrap: "wrap",
+      gap: 8,
+    },
+    heatCaption: { color: c.muted, fontSize: 12.5 },
+    legendRow: { flexDirection: "row", alignItems: "center", gap: 5 },
+    legendText: { color: c.faint, fontSize: 11.5 },
     dueBadge: {
       color: c.accent,
       fontSize: 12.5,

--- a/apps/mobile/src/screens/HifzReviewScreen.tsx
+++ b/apps/mobile/src/screens/HifzReviewScreen.tsx
@@ -34,7 +34,7 @@ const RATINGS: { rating: ReviewRating; label: string; color: keyof Palette }[] =
 export function HifzReviewScreen({ navigation }: Props) {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
-  const { ready, dueRecords, trackedCount, setHifzCard, touchStreak } = useLibrary();
+  const { ready, dueRecords, trackedCount, setHifzCard, touchStreak, recordReview } = useLibrary();
 
   const [queue, setQueue] = useState<HifzRecord[] | null>(null);
   const [index, setIndex] = useState(0);
@@ -68,6 +68,7 @@ export function HifzReviewScreen({ navigation }: Props) {
   function rate(rating: ReviewRating) {
     if (!current) return;
     setHifzCard(current.ref, reviewByRating(current.card, rating, new Date()));
+    recordReview(); // every rating counts toward today's heatmap cell
     if (!streakTouched.current) {
       touchStreak();
       streakTouched.current = true;

--- a/apps/mobile/src/state/LibraryContext.tsx
+++ b/apps/mobile/src/state/LibraryContext.tsx
@@ -15,10 +15,12 @@ import {
 } from "react";
 import {
   type Collection,
+  type HifzActivityLog,
   type HifzCard,
   type VerseKey,
   compareVerseKeys,
   isDue,
+  logReview,
 } from "@ummahlibrary/core";
 import { KEYS, getJSON, isObjectRecord, setJSON } from "../storage";
 import { mobileLibraryStore as library } from "./library-store";
@@ -54,6 +56,9 @@ interface LibraryValue {
   /** Daily review streak. `touchStreak` records a review completed today. */
   streak: StreakData;
   touchStreak: () => void;
+  /** Per-day review-activity log (heatmap source). `recordReview` counts one review today. */
+  reviewLog: HifzActivityLog;
+  recordReview: () => void;
   /** Ayah-level bookmark collections + per-ayah notes (separate from `bookmarks`). */
   collections: Collection[];
   notes: Record<string, string>;
@@ -73,13 +78,14 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
   const [lastRead, setLastReadState] = useState<number | null>(null);
   const [hifz, setHifz] = useState<HifzStore>({});
   const [streak, setStreak] = useState<StreakData>(EMPTY_STREAK);
+  const [reviewLog, setReviewLog] = useState<HifzActivityLog>({});
   const [collections, setCollections] = useState<Collection[]>([]);
   const [notes, setNotes] = useState<Record<string, string>>({});
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
     void (async () => {
-      const [bm, lr, hz, st, cols, nts] = await Promise.all([
+      const [bm, lr, hz, st, log, cols, nts] = await Promise.all([
         library.readBookmarks(),
         getJSON<{ surah: number } | null>(KEYS.lastRead, null, isObjectRecord),
         getJSON<HifzStore>(KEYS.hifz, {}, isObjectRecord),
@@ -91,6 +97,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
             typeof (v as StreakData).count === "number" &&
             typeof (v as StreakData).lastDate === "string",
         ),
+        getJSON<HifzActivityLog>(KEYS.hifzReviewLog, {}, isObjectRecord),
         library.readCollections(),
         library.readNotes(),
       ]);
@@ -98,6 +105,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
       setLastReadState(lr?.surah ?? null);
       setHifz(hz);
       setStreak(st);
+      setReviewLog(log);
       setCollections(cols);
       setNotes(nts);
       setReady(true);
@@ -124,6 +132,14 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
     setStreak((prev) => {
       const next = advanceStreak(prev, new Date());
       if (next !== prev) void setJSON(KEYS.hifzStreak, next);
+      return next;
+    });
+  }, []);
+
+  const recordReview = useCallback(() => {
+    setReviewLog((prev) => {
+      const next = logReview(prev, new Date());
+      void setJSON(KEYS.hifzReviewLog, next);
       return next;
     });
   }, []);
@@ -183,6 +199,8 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
       trackedCount: Object.keys(hifz).length,
       streak,
       touchStreak,
+      reviewLog,
+      recordReview,
       collections,
       notes,
       updateCollections,
@@ -194,6 +212,8 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
       lastRead,
       hifz,
       streak,
+      reviewLog,
+      recordReview,
       collections,
       notes,
       toggleBookmark,

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -31,6 +31,7 @@ export const KEYS = {
   khatma: "ul.khatma",
   hifz: "ul.hifz",
   hifzStreak: "ul.hifz.streak",
+  hifzReviewLog: "ul.hifz.reviewLog",
   lastRead: "ul.lastRead",
   asmaLearned: "ul.asmaLearned",
   tasbih: "ul.tasbih",

--- a/apps/web/src/components/HifzDashboard.tsx
+++ b/apps/web/src/components/HifzDashboard.tsx
@@ -2,10 +2,17 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { TOTAL_AYAHS } from "@ummahlibrary/core";
+import {
+  TOTAL_AYAHS,
+  type HeatmapDay,
+  activityHeatmap,
+  hifzStreaks,
+  weakestSurahs,
+} from "@ummahlibrary/core";
 import { N, Khatam, Btn } from "@ummahlibrary/ui";
 import { allRecords, dueRecords, surahProgressMap, type SurahProgress } from "../lib/hifz-store";
 import { getStreak } from "../lib/hifz-streak";
+import { readReviewLog } from "../lib/hifz-review-log-store";
 
 export interface SurahMeta {
   number: number;
@@ -37,6 +44,43 @@ function StrengthBar({ value }: { value: number }) {
   );
 }
 
+/** Gold ramp for a heatmap cell's intensity level (0 = empty). */
+function levelColor(level: number): string {
+  switch (level) {
+    case 1:
+      return `color-mix(in srgb, ${N.gold} 24%, transparent)`;
+    case 2:
+      return `color-mix(in srgb, ${N.gold} 48%, transparent)`;
+    case 3:
+      return `color-mix(in srgb, ${N.gold} 72%, transparent)`;
+    case 4:
+      return N.gold;
+    default:
+      return N.borderSoft;
+  }
+}
+
+/** GitHub-style activity grid: columns are weeks (Sunday-first), coloured by level. */
+function HeatmapGrid({ days }: { days: HeatmapDay[] }) {
+  const weeks: HeatmapDay[][] = [];
+  for (let i = 0; i < days.length; i += 7) weeks.push(days.slice(i, i + 7));
+  return (
+    <div style={{ display: "flex", gap: 3, overflowX: "auto", paddingBottom: 4 }}>
+      {weeks.map((week, wi) => (
+        <div key={wi} style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+          {week.map((d) => (
+            <div
+              key={d.date}
+              title={`${d.date} · ${d.count} review${d.count === 1 ? "" : "s"}`}
+              style={{ width: 11, height: 11, borderRadius: 2, background: levelColor(d.level) }}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function StatCard({ value, label }: { value: string; label: string }) {
   return (
     <div
@@ -61,6 +105,9 @@ export function HifzDashboard({ surahs }: { surahs: SurahMeta[] }) {
   const [dueCount, setDueCount] = useState(0);
   const [streak, setStreak] = useState(0);
   const [queue, setQueue] = useState<QueueItem[]>([]);
+  const [heatmap, setHeatmap] = useState<HeatmapDay[]>([]);
+  const [longestStreak, setLongestStreak] = useState(0);
+  const [weak, setWeak] = useState<QueueItem[]>([]);
 
   useEffect(() => {
     try {
@@ -68,21 +115,36 @@ export function HifzDashboard({ surahs }: { surahs: SurahMeta[] }) {
       const all = allRecords();
       const due = dueRecords(now);
       const streakData = getStreak();
-      const progressMap = surahProgressMap(now);
+      const progressMap = surahProgressMap(all, now);
       const surahByNum = new Map(surahs.map((s) => [s.number, s]));
+      const withMeta = (p: SurahProgress): QueueItem | null => {
+        const meta = surahByNum.get(p.surahNumber);
+        return meta
+          ? { ...p, name: meta.name, transliteration: meta.transliteration, ayahCount: meta.ayahCount }
+          : null;
+      };
 
       setTotalTracked(all.length);
       setDueCount(due.length);
       setStreak(streakData.count);
 
-      const items: QueueItem[] = [];
-      for (const [surahNum, progress] of progressMap) {
-        const meta = surahByNum.get(surahNum);
-        if (!meta) continue;
-        items.push({ ...progress, name: meta.name, transliteration: meta.transliteration, ayahCount: meta.ayahCount });
-      }
-      items.sort((a, b) => b.dueCount - a.dueCount || a.surahNumber - b.surahNumber);
+      const items = [...progressMap.values()]
+        .map(withMeta)
+        .filter((x): x is QueueItem => x !== null)
+        .sort((a, b) => b.dueCount - a.dueCount || a.surahNumber - b.surahNumber);
       setQueue(items);
+
+      // Weakest surahs (lowest strength first) to guide focus.
+      setWeak(
+        weakestSurahs(progressMap.values(), 5)
+          .map(withMeta)
+          .filter((x): x is QueueItem => x !== null),
+      );
+
+      // Review-activity heatmap + longest streak from the forward-looking log.
+      const log = readReviewLog();
+      setHeatmap(activityHeatmap(log, now));
+      setLongestStreak(hifzStreaks(log, now).longest);
     } finally {
       setReady(true);
     }
@@ -260,6 +322,104 @@ export function HifzDashboard({ surahs }: { surahs: SurahMeta[] }) {
           ))}
         </div>
       </div>
+
+      {/* Review activity heatmap + longest streak */}
+      <div>
+        <div
+          style={{
+            fontSize: 12,
+            letterSpacing: 1,
+            textTransform: "uppercase",
+            color: N.faint,
+            fontWeight: 700,
+            fontFamily: N.ui,
+            marginBottom: 10,
+          }}
+        >
+          Review activity
+        </div>
+        <div style={{ background: N.card, border: `1px solid ${N.border}`, borderRadius: 14, padding: "16px 18px" }}>
+          <HeatmapGrid days={heatmap} />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              flexWrap: "wrap",
+              gap: 10,
+              marginTop: 12,
+            }}
+          >
+            <span style={{ fontSize: 12.5, color: N.faint, fontFamily: N.ui }}>
+              Longest streak:{" "}
+              <strong style={{ color: N.gold }}>
+                {longestStreak} day{longestStreak === 1 ? "" : "s"}
+              </strong>
+            </span>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 11.5, color: N.faint, fontFamily: N.ui }}>
+              Less
+              {[0, 1, 2, 3, 4].map((l) => (
+                <span key={l} style={{ width: 11, height: 11, borderRadius: 2, background: levelColor(l) }} />
+              ))}
+              More
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Needs attention — weakest surahs */}
+      {weak.length > 0 && (
+        <div>
+          <div
+            style={{
+              fontSize: 12,
+              letterSpacing: 1,
+              textTransform: "uppercase",
+              color: N.faint,
+              fontWeight: 700,
+              fontFamily: N.ui,
+              marginBottom: 10,
+            }}
+          >
+            Needs attention
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            {weak.map((item) => (
+              <Link key={item.surahNumber} href={`/surah/${item.surahNumber}`} style={{ textDecoration: "none" }}>
+                <div
+                  style={{
+                    background: N.card,
+                    border: `1px solid ${N.borderSoft}`,
+                    borderRadius: 14,
+                    padding: "14px 18px",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 14,
+                  }}
+                >
+                  <div style={{ width: 38, height: 38, position: "relative", display: "grid", placeItems: "center", flexShrink: 0 }}>
+                    <Khatam size={38} color={N.goldDim} sw={1.2} />
+                    <span style={{ position: "absolute", fontSize: 11.5, fontWeight: 700, color: N.gold, fontFamily: N.ui }}>
+                      {item.surahNumber}
+                    </span>
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 15, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>
+                      {item.transliteration}
+                    </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 6 }}>
+                      <StrengthBar value={item.avgStrength} />
+                      <span style={{ fontSize: 12, color: N.faint, fontFamily: N.ui, whiteSpace: "nowrap" }}>
+                        {item.trackedCount} / {item.ayahCount} āyāt · {Math.round(item.avgStrength * 100)}% strength
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/HifzReview.tsx
+++ b/apps/web/src/components/HifzReview.tsx
@@ -6,6 +6,7 @@ import { type ReviewRating, reviewByRating } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
 import { type HifzRecord, allRecords, dueRecords, setCard } from "../lib/hifz-store";
 import { touchStreak } from "../lib/hifz-streak";
+import { recordReview } from "../lib/hifz-review-log-store";
 
 interface SurahArabic {
   ayahs: { aya: number; text: string }[];
@@ -67,6 +68,7 @@ export function HifzReview({
   function rate(rating: ReviewRating) {
     if (!current) return;
     setCard(current.ref, reviewByRating(current.card, rating, new Date()));
+    recordReview(); // every rating counts toward today's heatmap cell
     if (!streakTouched.current) {
       touchStreak();
       streakTouched.current = true;

--- a/apps/web/src/components/ProfileView.tsx
+++ b/apps/web/src/components/ProfileView.tsx
@@ -84,7 +84,7 @@ export function ProfileView() {
         const next: Stats = {
           hifzStreak,
           memorized: allRecords().length,
-          surahsStarted: surahProgressMap(new Date()).size,
+          surahsStarted: surahProgressMap(allRecords(), new Date()).size,
           prayerStreak: prayer,
           names: countLearned(),
           saved: totalSavedAyahs(collections),

--- a/apps/web/src/lib/hifz-review-log-store.ts
+++ b/apps/web/src/lib/hifz-review-log-store.ts
@@ -1,0 +1,34 @@
+/**
+ * Web persistence for the hifz review-activity log (ADR 0024), under
+ * `ul.hifz.reviewLog`: a `YYYY-MM-DD` → review-count map that powers the
+ * dashboard heatmap and streaks. Sync; the `*-store` file is the sanctioned
+ * `localStorage` home. The pure log/heatmap/streak logic lives in
+ * `@ummahlibrary/core` (`hifz-analytics`). Like the hifz cards themselves this
+ * key is held back from cross-device sync pending element-level merge.
+ */
+import { type HifzActivityLog, logReview } from "@ummahlibrary/core";
+
+const KEY = "ul.hifz.reviewLog";
+
+export function readReviewLog(): HifzActivityLog {
+  try {
+    const v = JSON.parse(localStorage.getItem(KEY) ?? "{}") as unknown;
+    // A corrupt/peer-synced null/array/scalar would break the heatmap consumers.
+    return v !== null && typeof v === "object" && !Array.isArray(v) ? (v as HifzActivityLog) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function writeReviewLog(log: HifzActivityLog): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(log));
+  } catch {
+    /* storage unavailable — ignore */
+  }
+}
+
+/** Record one completed review at `now`, persisting the updated log. */
+export function recordReview(now = new Date()): void {
+  writeReviewLog(logReview(readReviewLog(), now));
+}

--- a/apps/web/src/lib/hifz-store.test.ts
+++ b/apps/web/src/lib/hifz-store.test.ts
@@ -68,7 +68,7 @@ describe("hifz store", () => {
     // Surah 1: a single due card.
     setCard({ sura: 1, aya: 1 }, card("2000-06-01T00:00:00.000Z"));
 
-    const map = surahProgressMap(now);
+    const map = surahProgressMap(allRecords(), now);
 
     const s2 = map.get(2)!;
     expect(s2.trackedCount).toBe(2);

--- a/apps/web/src/lib/hifz-store.ts
+++ b/apps/web/src/lib/hifz-store.ts
@@ -2,44 +2,10 @@
 
 import { type HifzCard, type VerseKey, compareVerseKeys, isDue } from "@ummahlibrary/core";
 
-/** 0 = new/never reviewed · 1 = solidly known (interval ≥ 30 days). */
-export function cardStrength(card: HifzCard): number {
-  if (card.lastReviewed === null) return 0;
-  return Math.min(1, card.intervalDays / 30);
-}
-
-export interface SurahProgress {
-  surahNumber: number;
-  trackedCount: number;
-  dueCount: number;
-  avgStrength: number; // 0–1
-  nextDue: string | null; // earliest due ISO timestamp among tracked cards
-}
-
-/** Aggregate per-ayah records into per-surah summaries. */
-export function surahProgressMap(now: Date): Map<number, SurahProgress> {
-  const map = new Map<number, SurahProgress>();
-  for (const r of allRecords()) {
-    const sura = r.ref.sura;
-    const p = map.get(sura) ?? {
-      surahNumber: sura,
-      trackedCount: 0,
-      dueCount: 0,
-      avgStrength: 0,
-      nextDue: null,
-    };
-    p.trackedCount++;
-    p.avgStrength += cardStrength(r.card);
-    if (isDue(r.card, now)) p.dueCount++;
-    if (!p.nextDue || r.card.due < p.nextDue) p.nextDue = r.card.due;
-    map.set(sura, p);
-  }
-  for (const [sura, p] of map) {
-    p.avgStrength = p.trackedCount > 0 ? p.avgStrength / p.trackedCount : 0;
-    map.set(sura, p);
-  }
-  return map;
-}
+// Strength + per-surah progress derivations are pure logic; they live in core
+// (shared with mobile) and are re-exported here so existing web imports keep
+// their path. `surahProgressMap(records, now)` — pass `allRecords()`.
+export { cardStrength, surahProgressMap, weakestSurahs, type SurahProgress } from "@ummahlibrary/core";
 
 const KEY = "ul.hifz";
 

--- a/apps/web/src/lib/sync/managed-keys.ts
+++ b/apps/web/src/lib/sync/managed-keys.ts
@@ -6,7 +6,7 @@
  *
  * Deliberately EXCLUDED, pending v2 element-level merge (two devices edit different
  * entries concurrently, which whole-value LWW would clobber): `ul.collections`,
- * `ul.ayahNotes`, `ul.hifz`(+`.streak`), the prayer/qada/haid/ramadan logs, the
+ * `ul.ayahNotes`, `ul.hifz`(+`.streak`, `.reviewLog`), the prayer/qada/haid/ramadan logs, the
  * reading-goal logs and active plan, the tasbih/adhkar counters, `ul.asmaLearned`,
  * `ul.badges`, and `ul.searchHistory`. Also excluded: the sync sidecar itself
  * (`ul.sync.*` — it must never sync), device-local flags (`ul.onboarded`), and the

--- a/packages/core/src/hifz-analytics.test.ts
+++ b/packages/core/src/hifz-analytics.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { HifzCard } from "./hifz";
+import {
+  type HifzActivityLog,
+  activityHeatmap,
+  cardStrength,
+  hifzStreaks,
+  logReview,
+  surahProgressMap,
+  weakestSurahs,
+} from "./hifz-analytics";
+
+const card = (opts: Partial<HifzCard> = {}): HifzCard => ({
+  repetitions: 1,
+  easeFactor: 2.5,
+  intervalDays: 1,
+  due: "2030-01-01T00:00:00.000Z",
+  lastReviewed: null,
+  ...opts,
+});
+
+describe("cardStrength", () => {
+  it("is 0 when never reviewed, proportional to interval, capped at 1", () => {
+    expect(cardStrength(card())).toBe(0);
+    expect(cardStrength(card({ lastReviewed: "2026-06-01T00:00:00.000Z", intervalDays: 15 }))).toBe(0.5);
+    expect(cardStrength(card({ lastReviewed: "2026-06-01T00:00:00.000Z", intervalDays: 60 }))).toBe(1);
+  });
+});
+
+describe("surahProgressMap + weakestSurahs", () => {
+  const now = new Date("2026-06-14T00:00:00.000Z");
+  const records = [
+    // Surah 2: one strong+due (strength 1), one fresh not-due (strength 0) → avg 0.5.
+    { ref: { sura: 2, aya: 1 }, card: card({ due: "2000-01-01T00:00:00.000Z", lastReviewed: "2026-06-01T00:00:00.000Z", intervalDays: 30 }) },
+    { ref: { sura: 2, aya: 2 }, card: card({ due: "2099-01-01T00:00:00.000Z" }) },
+    // Surah 1: a single due, fresh card → avg 0.
+    { ref: { sura: 1, aya: 1 }, card: card({ due: "2000-06-01T00:00:00.000Z" }) },
+    // Surah 3: one strong card → avg 1.
+    { ref: { sura: 3, aya: 5 }, card: card({ due: "2099-01-01T00:00:00.000Z", lastReviewed: "2026-06-01T00:00:00.000Z", intervalDays: 40 }) },
+  ];
+
+  it("aggregates tracked/due/strength/earliest-due per surah", () => {
+    const map = surahProgressMap(records, now);
+    const s2 = map.get(2)!;
+    expect(s2.trackedCount).toBe(2);
+    expect(s2.dueCount).toBe(1);
+    expect(s2.avgStrength).toBe(0.5);
+    expect(s2.nextDue).toBe("2000-01-01T00:00:00.000Z");
+    expect(map.get(1)!.avgStrength).toBe(0);
+    expect(map.get(3)!.avgStrength).toBe(1);
+  });
+
+  it("ranks the weakest surahs first, tie-broken by surah number", () => {
+    const weak = weakestSurahs(surahProgressMap(records, now).values(), 2);
+    expect(weak.map((p) => p.surahNumber)).toEqual([1, 2]); // 0, then 0.5 (before 1.0)
+  });
+});
+
+describe("logReview", () => {
+  it("increments today's UTC day count without mutating the input", () => {
+    const log: HifzActivityLog = { "2026-06-13": 2 };
+    const next = logReview(log, new Date("2026-06-14T09:30:00.000Z"));
+    expect(next["2026-06-14"]).toBe(1);
+    expect(logReview(next, new Date("2026-06-14T21:00:00.000Z"))["2026-06-14"]).toBe(2);
+    expect(log).toEqual({ "2026-06-13": 2 }); // original untouched
+  });
+});
+
+describe("activityHeatmap", () => {
+  const today = new Date("2026-06-17T12:00:00.000Z"); // a Wednesday
+
+  it("is a Sunday-aligned rectangle ending in the week of `today`", () => {
+    const days = activityHeatmap({}, today, 26);
+    expect(days).toHaveLength(26 * 7);
+    expect(new Date(`${days[0]!.date}T00:00:00.000Z`).getUTCDay()).toBe(0); // starts on a Sunday
+    // `today` sits in the final week; days after it are still emitted (level 0).
+    expect(days.some((d) => d.date === "2026-06-17")).toBe(true);
+    expect(days[days.length - 1]!.date).toBe("2026-06-20"); // Saturday of the current week
+  });
+
+  it("buckets counts into levels 0–4", () => {
+    const log: HifzActivityLog = { "2026-06-17": 1, "2026-06-16": 3, "2026-06-15": 6, "2026-06-14": 9 };
+    const byDate = new Map(activityHeatmap(log, today, 26).map((d) => [d.date, d]));
+    expect(byDate.get("2026-06-18")!.level).toBe(0); // future/empty
+    expect(byDate.get("2026-06-17")!.level).toBe(1);
+    expect(byDate.get("2026-06-16")!.level).toBe(2);
+    expect(byDate.get("2026-06-15")!.level).toBe(3);
+    expect(byDate.get("2026-06-14")!.level).toBe(4);
+  });
+});
+
+describe("hifzStreaks", () => {
+  it("counts the current run and the longest run", () => {
+    const log: HifzActivityLog = {
+      // current run: 15, 16, 17 (today) = 3
+      "2026-06-17": 1,
+      "2026-06-16": 2,
+      "2026-06-15": 1,
+      // gap on the 14th
+      // earlier run of 4: 10, 11, 12, 13
+      "2026-06-13": 1,
+      "2026-06-12": 1,
+      "2026-06-11": 1,
+      "2026-06-10": 1,
+    };
+    const today = new Date("2026-06-17T12:00:00.000Z");
+    expect(hifzStreaks(log, today)).toEqual({ current: 3, longest: 4 });
+  });
+
+  it("keeps the current streak alive on a not-yet-reviewed today (grace via yesterday)", () => {
+    const log: HifzActivityLog = { "2026-06-16": 1, "2026-06-15": 1 };
+    expect(hifzStreaks(log, new Date("2026-06-17T08:00:00.000Z")).current).toBe(2);
+  });
+
+  it("is zero when there is no recent activity", () => {
+    expect(hifzStreaks({ "2026-01-01": 1 }, new Date("2026-06-17T00:00:00.000Z")).current).toBe(0);
+    expect(hifzStreaks({}, new Date("2026-06-17T00:00:00.000Z"))).toEqual({ current: 0, longest: 0 });
+  });
+});

--- a/packages/core/src/hifz-analytics.ts
+++ b/packages/core/src/hifz-analytics.ts
@@ -1,0 +1,178 @@
+/**
+ * Hifz analytics — pure derivations over the SM-2 state and a lightweight review
+ * log: per-surah strength (strong vs. weak), a calendar activity heatmap, and
+ * review streaks. No I/O and no clock of its own — `now`/`today` are injected
+ * (see `hifz.ts`) — so every function is deterministic and unit-tested. Persistence
+ * (the card store and the review log) lives in the app adapters; this file only
+ * turns that data into view-model summaries, shared by web and mobile.
+ */
+import type { VerseKey } from "./entities";
+import { type HifzCard, isDue } from "./hifz";
+
+/** One tracked ayah and its SM-2 card (the app record shape). */
+export interface HifzAyahRecord {
+  ref: VerseKey;
+  card: HifzCard;
+}
+
+/** 0 = new / never reviewed · 1 = solidly known (interval ≥ 30 days). */
+export function cardStrength(card: HifzCard): number {
+  if (card.lastReviewed === null) return 0;
+  return Math.min(1, card.intervalDays / 30);
+}
+
+/** Per-surah memorization summary aggregated from its tracked ayah cards. */
+export interface SurahProgress {
+  surahNumber: number;
+  trackedCount: number;
+  dueCount: number;
+  avgStrength: number; // 0–1
+  nextDue: string | null; // earliest due ISO timestamp among tracked cards
+}
+
+/** Aggregate per-ayah records into per-surah summaries. */
+export function surahProgressMap(
+  records: readonly HifzAyahRecord[],
+  now: Date,
+): Map<number, SurahProgress> {
+  const map = new Map<number, SurahProgress>();
+  for (const r of records) {
+    const sura = r.ref.sura;
+    const p = map.get(sura) ?? {
+      surahNumber: sura,
+      trackedCount: 0,
+      dueCount: 0,
+      avgStrength: 0,
+      nextDue: null,
+    };
+    p.trackedCount++;
+    p.avgStrength += cardStrength(r.card);
+    if (isDue(r.card, now)) p.dueCount++;
+    if (!p.nextDue || r.card.due < p.nextDue) p.nextDue = r.card.due;
+    map.set(sura, p);
+  }
+  for (const [sura, p] of map) {
+    p.avgStrength = p.trackedCount > 0 ? p.avgStrength / p.trackedCount : 0;
+    map.set(sura, p);
+  }
+  return map;
+}
+
+/**
+ * The tracked surahs most in need of work, weakest first (lowest average
+ * strength, ties broken by surah order). Only surahs with tracked ayāt.
+ */
+export function weakestSurahs(
+  progress: Iterable<SurahProgress>,
+  count: number,
+): SurahProgress[] {
+  return [...progress]
+    .filter((p) => p.trackedCount > 0)
+    .sort((a, b) => a.avgStrength - b.avgStrength || a.surahNumber - b.surahNumber)
+    .slice(0, Math.max(0, count));
+}
+
+// ── Review activity log ──────────────────────────────────────────────────────
+
+/** Number of reviews completed per day, keyed by `YYYY-MM-DD` (UTC). */
+export type HifzActivityLog = Record<string, number>;
+
+/** UTC `YYYY-MM-DD` for an instant (matches the streak store's day key). */
+export function activityDateKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function addUtcDays(d: Date, days: number): Date {
+  const next = new Date(d.getTime());
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+/** Record one completed review on `now`, returning a new log (input unchanged). */
+export function logReview(log: HifzActivityLog, now: Date): HifzActivityLog {
+  const key = activityDateKey(now);
+  return { ...log, [key]: (log[key] ?? 0) + 1 };
+}
+
+/** One day in the heatmap grid. `level` buckets `count` into 0–4 for shading. */
+export interface HeatmapDay {
+  date: string; // YYYY-MM-DD
+  count: number;
+  level: 0 | 1 | 2 | 3 | 4;
+}
+
+function intensity(count: number): HeatmapDay["level"] {
+  if (count <= 0) return 0;
+  if (count === 1) return 1;
+  if (count <= 3) return 2;
+  if (count <= 6) return 3;
+  return 4;
+}
+
+/**
+ * A week-aligned activity grid ending on `today`: `weeks` columns of 7 days
+ * (Sunday-first), oldest day first. The final column holds the current week, so
+ * days after `today` sit at the end as empty (level 0) cells. Chunk into groups
+ * of 7 for a columns-as-weeks render.
+ */
+export function activityHeatmap(
+  log: HifzActivityLog,
+  today: Date,
+  weeks = 26,
+): HeatmapDay[] {
+  const cols = Math.max(1, weeks);
+  // Sunday of the current week, then back to the first column's Sunday.
+  const todayWeekday = today.getUTCDay(); // 0 = Sunday
+  const start = addUtcDays(today, -todayWeekday - (cols - 1) * 7);
+
+  const days: HeatmapDay[] = [];
+  for (let i = 0; i < cols * 7; i++) {
+    const date = activityDateKey(addUtcDays(start, i));
+    const count = log[date] ?? 0;
+    days.push({ date, count, level: intensity(count) });
+  }
+  return days;
+}
+
+// ── Streaks ──────────────────────────────────────────────────────────────────
+
+/** Consecutive-day review streaks derived from the activity log. */
+export interface HifzStreaks {
+  /** Days in a row ending today (a not-yet-reviewed today still counts if yesterday was active). */
+  current: number;
+  /** The longest run of consecutive active days ever recorded. */
+  longest: number;
+}
+
+function runEndingAt(log: HifzActivityLog, anchor: Date): number {
+  let count = 0;
+  let cursor = anchor;
+  while ((log[activityDateKey(cursor)] ?? 0) > 0) {
+    count++;
+    cursor = addUtcDays(cursor, -1);
+  }
+  return count;
+}
+
+export function hifzStreaks(log: HifzActivityLog, today: Date): HifzStreaks {
+  // Current: count from today; if today is blank, allow the run ending yesterday
+  // so an as-yet-unreviewed day doesn't drop the streak to zero mid-day.
+  const current =
+    (log[activityDateKey(today)] ?? 0) > 0
+      ? runEndingAt(log, today)
+      : runEndingAt(log, addUtcDays(today, -1));
+
+  // Longest: scan the active days in date order for the longest consecutive run.
+  const active = Object.keys(log)
+    .filter((k) => (log[k] ?? 0) > 0)
+    .sort();
+  let longest = 0;
+  let run = 0;
+  let prev: string | null = null;
+  for (const key of active) {
+    run = prev !== null && key === activityDateKey(addUtcDays(new Date(`${prev}T00:00:00.000Z`), 1)) ? run + 1 : 1;
+    if (run > longest) longest = run;
+    prev = key;
+  }
+  return { current, longest };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@
 
 export * from "./quran-structure";
 export * from "./hifz";
+export * from "./hifz-analytics";
 export * from "./plugins";
 export * from "./languages";
 export * from "./translations";


### PR DESCRIPTION
Closes #135.

## What
Surfaces the SM-2 review data on the hifz dashboard (web + mobile): a **calendar heatmap** of review activity, **streaks**, and a **weakest-surahs** focus list — Tarteel's headline analytics, built entirely from local data.

## How
- **Core `hifz-analytics.ts` (new, pure, tested):** `activityHeatmap`, `hifzStreaks`, `logReview`, `weakestSurahs`. Also **centralizes** the previously-duplicated `cardStrength` / `surahProgressMap` (the web `lib/hifz-store.ts` and mobile `src/hifz.ts` now re-export from core — a boundary cleanup).
- **Review log:** a forward-looking per-day count (`ul.hifz.reviewLog`) persisted on web (localStorage) and mobile (AsyncStorage via `LibraryContext`), appended on every review rating. Held back from cross-device sync like the other hifz keys (element-merge pending).
- **Dashboards:** a GitHub-style activity heatmap with a longest-streak caption + legend, and a "Needs attention" list ranking the weakest surahs by strength. Existing stats/queue unchanged; the top-line day-streak stays the current-streak headline.

No new architectural boundary → no ADR.

## Verification
- 448 core tests (new `hifz-analytics` suite + regressions) and 227 web/mobile app tests pass; refactor keeps the existing hifz/store tests green.
- `tsc --noEmit` clean for core, web, mobile; web production build succeeds.
- Visually confirmed on `/hifz` with seeded data: heatmap renders with a "Longest streak" caption and the weakest surahs ranked correctly.