### PR TITLE
feat(core): per-event Islamic-event reminders

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -22,6 +22,7 @@ import { syncPlanReminder } from "./src/plan-reminders";
 import { syncAdhkarReminder } from "./src/adhkar-reminders";
 import { syncPrayerReminders } from "./src/prayer-reminders";
 import { syncSunnahFastReminder } from "./src/sunnah-fast-reminders";
+import { syncIslamicEventReminders } from "./src/islamic-event-reminders";
 import type { RootTabParamList } from "./src/navigation/types";
 
 /** URL routes for the web build and OS deep links (ummahlibrary://). */
@@ -121,6 +122,7 @@ export default function App() {
       void syncAdhkarReminder();
       void syncPrayerReminders();
       void syncSunnahFastReminder();
+      void syncIslamicEventReminders();
     };
     void initNotifier().then(syncAll);
     const sub = AppState.addEventListener("change", (s) => {

--- a/apps/mobile/src/islamic-event-reminders.ts
+++ b/apps/mobile/src/islamic-event-reminders.ts
@@ -1,0 +1,31 @@
+/**
+ * Islamic-event reminders — mobile wiring (#143). Per-event on/off toggles go
+ * through the {@link mobileReminderStore}; the scheduling decision is the shared
+ * `syncIslamicEventReminders` in `@ummahlibrary/core`; delivery is the
+ * {@link expoNotifier} (OS-scheduled). Reuses the same orchestration as the web.
+ */
+import { syncIslamicEventReminders as coreSyncIslamicEventReminders } from "@ummahlibrary/core";
+import { expoNotifier } from "./notifier";
+import { mobileReminderStore } from "./reminder-store";
+
+export async function readEventReminders(): Promise<Record<string, boolean>> {
+  return (await mobileReminderStore.read()).islamicEvents;
+}
+
+/** Toggle one event's reminder, persisting the updated map (off = removed) and re-syncing. */
+export async function setEventReminder(eventId: string, on: boolean): Promise<Record<string, boolean>> {
+  const prefs = { ...(await readEventReminders()) };
+  if (on) prefs[eventId] = true;
+  else delete prefs[eventId];
+  await mobileReminderStore.writeIslamicEvents(prefs);
+  await syncIslamicEventReminders();
+  return prefs;
+}
+
+export function syncIslamicEventReminders(): Promise<void> {
+  return coreSyncIslamicEventReminders({
+    notifier: expoNotifier,
+    reminders: mobileReminderStore,
+    now: () => new Date(),
+  });
+}

--- a/apps/mobile/src/reminder-store.ts
+++ b/apps/mobile/src/reminder-store.ts
@@ -16,7 +16,7 @@ import { KEYS, getJSON, getString, isObjectRecord, setJSON, setString } from "./
 export const mobileReminderStore: ReminderStore = {
   read: async (): Promise<ReminderPrefs> => {
     // Object guards: a corrupt/peer-synced null would crash on `plan.on` / `prayers[p]`.
-    const [plan, prayers, adhkar, sunnahFast] = await Promise.all([
+    const [plan, prayers, adhkar, sunnahFast, islamicEvents] = await Promise.all([
       getJSON<PlanReminderPref>(
         KEYS.planReminder,
         { on: false, time: DEFAULT_PLAN_REMINDER_TIME },
@@ -25,6 +25,7 @@ export const mobileReminderStore: ReminderStore = {
       getJSON<Partial<Record<PrayerName, boolean>>>(KEYS.prayerReminders, {}, isObjectRecord),
       getString(KEYS.adhkarReminders),
       getString(KEYS.sunnahFastReminders),
+      getJSON<Record<string, boolean>>(KEYS.islamicEventReminders, {}, isObjectRecord),
     ]);
     return {
       plan: {
@@ -34,10 +35,12 @@ export const mobileReminderStore: ReminderStore = {
       prayers,
       adhkarOn: adhkar === "on",
       sunnahFastOn: sunnahFast === "on",
+      islamicEvents,
     };
   },
   writePlan: (pref) => setJSON(KEYS.planReminder, pref),
   writePrayers: (prefs) => setJSON(KEYS.prayerReminders, prefs),
   writeAdhkarOn: (on) => setString(KEYS.adhkarReminders, on ? "on" : "off"),
   writeSunnahFastOn: (on) => setString(KEYS.sunnahFastReminders, on ? "on" : "off"),
+  writeIslamicEvents: (prefs) => setJSON(KEYS.islamicEventReminders, prefs),
 };

--- a/apps/mobile/src/screens/HijriCalendarScreen.tsx
+++ b/apps/mobile/src/screens/HijriCalendarScreen.tsx
@@ -9,10 +9,13 @@ import {
   hijriToGregorian,
   islamicEventsForMonth,
 } from "@ummahlibrary/core";
+import { Icon } from "@ummahlibrary/ui";
 import { KEYS, getString, setString } from "../storage";
 import { useTheme, type Palette } from "../theme";
 import { weekdayOfGregorian } from "../utils";
 import { SunnahFastReminderToggle } from "../components/SunnahFastReminderToggle";
+import { expoNotifier } from "../notifier";
+import { readEventReminders, setEventReminder } from "../islamic-event-reminders";
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
 const ADJUST_OPTIONS = [-2, -1, 0, 1, 2] as const;
@@ -46,6 +49,7 @@ export function HijriCalendarScreen() {
   const [adjust, setAdjust] = useState(0);
   const [today, setToday] = useState<HijriDate | null>(null);
   const [view, setView] = useState<{ year: number; month: number } | null>(null);
+  const [reminders, setReminders] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     void getString(KEYS.hijriAdjust).then((raw) => {
@@ -56,7 +60,14 @@ export function HijriCalendarScreen() {
       setToday(t);
       setView({ year: t.year, month: t.month });
     });
+    void readEventReminders().then(setReminders);
   }, []);
+
+  async function toggleReminder(eventId: string) {
+    const on = !reminders[eventId];
+    if (on && expoNotifier.permission() !== "granted") await expoNotifier.requestPermission();
+    setReminders(await setEventReminder(eventId, on));
+  }
 
   function changeAdjust(next: number) {
     setAdjust(next);
@@ -174,6 +185,14 @@ export function HijriCalendarScreen() {
                   <Text style={styles.eventDate}>{gregorianFull(m.gregorian)} · {m.event.note}</Text>
                 </View>
                 {up && <Text style={styles.eventCountdown}>{countdownLabel(m.daysUntil)}</Text>}
+                <Pressable
+                  onPress={() => void toggleReminder(m.event.id)}
+                  hitSlop={8}
+                  accessibilityLabel={`${reminders[m.event.id] ? "Turn off" : "Turn on"} reminder for ${m.event.name}`}
+                  style={[styles.bellBtn, reminders[m.event.id] && styles.bellBtnOn]}
+                >
+                  <Icon name="bell" size={16} color={reminders[m.event.id] ? colors.accent : colors.faint} sw={1.8} />
+                </Pressable>
               </View>
             );
           })}
@@ -305,6 +324,16 @@ function makeStyles(c: Palette) {
     eventName: { color: c.fg, fontSize: 15, fontWeight: "700" },
     eventDate: { color: c.faint, fontSize: 12, marginTop: 1 },
     eventCountdown: { color: c.accent, fontSize: 13, fontWeight: "700" },
+    bellBtn: {
+      width: 34,
+      height: 34,
+      borderRadius: 9,
+      alignItems: "center",
+      justifyContent: "center",
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    bellBtnOn: { borderColor: c.accent, backgroundColor: c.accentSoft },
     sunnahSection: { marginTop: 28 },
     adjustSection: { gap: 10 },
     adjustLabel: { color: c.fg, fontSize: 13, fontWeight: "600" },

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -54,6 +54,7 @@ export const KEYS = {
   prayerReminders: "ul.prayerReminders",
   adhkarReminders: "ul.adhkarReminders",
   sunnahFastReminders: "ul.sunnahFastReminders",
+  islamicEventReminders: "ul.islamicEventReminders",
   adhkarTimings: "ul.adhkarTimings",
 } as const;
 

--- a/apps/web/src/components/HijriCalendar.tsx
+++ b/apps/web/src/components/HijriCalendar.tsx
@@ -11,7 +11,11 @@ import {
   islamicEventsForMonth,
 } from "@ummahlibrary/core";
 import { readHijriAdjust, writeHijriAdjust } from "../lib/hijri";
-import { N } from "@ummahlibrary/ui";
+import { N, Icon } from "@ummahlibrary/ui";
+import { WebNotifier } from "../lib/web-notifier";
+import { readEventReminders, setEventReminder, syncIslamicEventReminders } from "../lib/islamic-event-reminders";
+
+const notifier = new WebNotifier();
 
 const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 const lcard = { background: N.card, border: `1px solid ${N.border}`, borderRadius: 16 } as const;
@@ -64,6 +68,7 @@ export function HijriCalendar() {
   const [adjust, setAdjust] = useState(0);
   const [todayHijri, setTodayHijri] = useState<HijriDate | null>(null);
   const [view, setView] = useState<{ year: number; month: number } | null>(null);
+  const [reminders, setReminders] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     const a = readHijriAdjust();
@@ -71,7 +76,15 @@ export function HijriCalendar() {
     const t = gregorianToHijri(localToday(), a);
     setTodayHijri(t);
     setView({ year: t.year, month: t.month });
+    void readEventReminders().then(setReminders);
   }, []);
+
+  async function toggleReminder(eventId: string) {
+    const turningOn = !reminders[eventId];
+    if (turningOn && notifier.permission() === "default") await notifier.requestPermission();
+    setReminders(await setEventReminder(eventId, turningOn));
+    await syncIslamicEventReminders(notifier);
+  }
 
   function changeAdjust(next: number) {
     setAdjust(next);
@@ -336,6 +349,26 @@ export function HijriCalendar() {
                         {countdownLabel(m.daysUntil)}
                       </div>
                     )}
+                    <button
+                      type="button"
+                      onClick={() => void toggleReminder(m.event.id)}
+                      aria-pressed={!!reminders[m.event.id]}
+                      aria-label={`${reminders[m.event.id] ? "Turn off" : "Turn on"} reminder for ${m.event.name}`}
+                      title="Remind me the evening before"
+                      style={{
+                        flexShrink: 0,
+                        width: 34,
+                        height: 34,
+                        borderRadius: 9,
+                        display: "grid",
+                        placeItems: "center",
+                        cursor: "pointer",
+                        border: `1px solid ${reminders[m.event.id] ? N.gold : N.border}`,
+                        background: reminders[m.event.id] ? N.goldSoft : "transparent",
+                      }}
+                    >
+                      <Icon name="bell" size={16} color={reminders[m.event.id] ? N.gold : N.faint} />
+                    </button>
                   </div>
                 );
               })}

--- a/apps/web/src/lib/islamic-event-reminders.ts
+++ b/apps/web/src/lib/islamic-event-reminders.ts
@@ -1,0 +1,36 @@
+/**
+ * Islamic-event reminders — web wiring (#143). Per-event on/off toggles go
+ * through the {@link webReminderStore} (`ReminderStore` port); the scheduling
+ * decision is the shared `syncIslamicEventReminders` in `@ummahlibrary/core`.
+ * Delivery is the {@link Notifier} port (fires while a tab is open). No location
+ * needed — the dates are pure tabular-Hijri arithmetic.
+ */
+import type { Notifier } from "@ummahlibrary/core";
+import { syncIslamicEventReminders as coreSyncIslamicEventReminders } from "@ummahlibrary/core";
+import { webReminderStore } from "./reminder-store";
+
+/** Event dispatched on a preference change so listeners can re-sync. */
+export const EVENT_REMINDERS_KEY = "ul.islamicEventReminders";
+
+export async function readEventReminders(): Promise<Record<string, boolean>> {
+  return (await webReminderStore.read()).islamicEvents;
+}
+
+/** Toggle one event's reminder, persisting the updated map (off = removed). */
+export async function setEventReminder(eventId: string, on: boolean): Promise<Record<string, boolean>> {
+  const prefs = { ...(await readEventReminders()) };
+  if (on) prefs[eventId] = true;
+  else delete prefs[eventId];
+  await webReminderStore.writeIslamicEvents(prefs);
+  window.dispatchEvent(new CustomEvent(EVENT_REMINDERS_KEY, { detail: prefs }));
+  return prefs;
+}
+
+/** (Re)schedule the enabled event reminders through the shared orchestration. */
+export function syncIslamicEventReminders(notifier: Notifier): Promise<void> {
+  return coreSyncIslamicEventReminders({
+    notifier,
+    reminders: webReminderStore,
+    now: () => new Date(),
+  });
+}

--- a/apps/web/src/lib/reminder-store.test.ts
+++ b/apps/web/src/lib/reminder-store.test.ts
@@ -11,20 +11,23 @@ describe("webReminderStore", () => {
       prayers: {},
       adhkarOn: false,
       sunnahFastOn: false,
+      islamicEvents: {},
     });
   });
 
-  it("round-trips plan, prayer, adhkar, and sunnah-fast preferences under the existing keys", async () => {
+  it("round-trips plan, prayer, adhkar, sunnah-fast, and event preferences under the existing keys", async () => {
     await store.writePlan({ on: true, time: "07:30" });
     await store.writePrayers({ fajr: true, isha: false });
     await store.writeAdhkarOn(true);
     await store.writeSunnahFastOn(true);
+    await store.writeIslamicEvents({ "eid-al-fitr": true, arafah: false });
 
     const r = await store.read();
     expect(r.plan).toEqual({ on: true, time: "07:30" });
     expect(r.prayers).toEqual({ fajr: true, isha: false });
     expect(r.adhkarOn).toBe(true);
     expect(r.sunnahFastOn).toBe(true);
+    expect(r.islamicEvents).toEqual({ "eid-al-fitr": true, arafah: false });
     // adhkar / sunnah-fast stay the historical "on"/"off" string
     expect(localStorage.getItem("ul.adhkarReminders")).toBe("on");
     expect(localStorage.getItem("ul.sunnahFastReminders")).toBe("on");

--- a/apps/web/src/lib/reminder-store.ts
+++ b/apps/web/src/lib/reminder-store.ts
@@ -16,6 +16,7 @@ const PLAN_KEY = "ul.planReminder";
 const PRAYERS_KEY = "ul.prayerReminders";
 const ADHKAR_KEY = "ul.adhkarReminders";
 const SUNNAH_FAST_KEY = "ul.sunnahFastReminders";
+const ISLAMIC_EVENTS_KEY = "ul.islamicEventReminders";
 const SEEN_KEY = "ul.adhkarReminderSeen";
 
 export const webReminderStore: ReminderStore = {
@@ -56,7 +57,16 @@ export const webReminderStore: ReminderStore = {
       /* keep default */
     }
 
-    return { plan, prayers, adhkarOn, sunnahFastOn };
+    let islamicEvents: Record<string, boolean> = {};
+    try {
+      const raw = localStorage.getItem(ISLAMIC_EVENTS_KEY);
+      const v = raw ? (JSON.parse(raw) as unknown) : null;
+      islamicEvents = v !== null && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, boolean>) : {};
+    } catch {
+      /* keep default */
+    }
+
+    return { plan, prayers, adhkarOn, sunnahFastOn, islamicEvents };
   },
   writePlan: async (pref) => {
     try {
@@ -82,6 +92,13 @@ export const webReminderStore: ReminderStore = {
   writeSunnahFastOn: async (on) => {
     try {
       localStorage.setItem(SUNNAH_FAST_KEY, on ? "on" : "off");
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  writeIslamicEvents: async (prefs) => {
+    try {
+      localStorage.setItem(ISLAMIC_EVENTS_KEY, JSON.stringify(prefs));
     } catch {
       /* storage unavailable */
     }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -437,6 +437,8 @@ export interface ReminderPrefs {
   adhkarOn: boolean;
   /** Sunnah-fasting (Mon/Thu + Ayyām al-Bīḍ) reminder on/off. */
   sunnahFastOn: boolean;
+  /** Per-Islamic-event reminder toggles, keyed by event id. */
+  islamicEvents: Record<string, boolean>;
 }
 
 /**
@@ -452,6 +454,7 @@ export interface ReminderStore {
   writePrayers(prefs: Partial<Record<PrayerName, boolean>>): Promise<void>;
   writeAdhkarOn(on: boolean): Promise<void>;
   writeSunnahFastOn(on: boolean): Promise<void>;
+  writeIslamicEvents(prefs: Record<string, boolean>): Promise<void>;
 }
 
 /**

--- a/packages/core/src/reminders.test.ts
+++ b/packages/core/src/reminders.test.ts
@@ -8,6 +8,7 @@ import type {
   ReminderPrefs,
   ReminderStore,
 } from "./ports";
+import { ISLAMIC_EVENTS } from "./islamic-events";
 import type { PrayerTimings } from "./prayer";
 import { type ActivePlan, activatePlan, templateById } from "./reading-plans";
 import {
@@ -15,8 +16,10 @@ import {
   PLAN_REMINDER_ID,
   SUNNAH_FAST_REMINDER_ID,
   adhkarReminderId,
+  islamicEventReminderId,
   prayerReminderId,
   syncAdhkarReminder,
+  syncIslamicEventReminders,
   syncPlanReminder,
   syncPrayerReminders,
   syncSunnahFastReminder,
@@ -48,6 +51,7 @@ function fakeReminders(prefs: Partial<ReminderPrefs> = {}): ReminderStore {
     prayers: {},
     adhkarOn: false,
     sunnahFastOn: false,
+    islamicEvents: {},
     ...prefs,
   };
   return {
@@ -56,6 +60,7 @@ function fakeReminders(prefs: Partial<ReminderPrefs> = {}): ReminderStore {
     writePrayers: async (p) => void (state.prayers = p),
     writeAdhkarOn: async (o) => void (state.adhkarOn = o),
     writeSunnahFastOn: async (o) => void (state.sunnahFastOn = o),
+    writeIslamicEvents: async (p) => void (state.islamicEvents = p),
   };
 }
 
@@ -226,6 +231,36 @@ describe("syncSunnahFastReminder", () => {
   });
 });
 
+describe("syncIslamicEventReminders", () => {
+  it("schedules the evening-before reminder for each enabled event, ahead of now", async () => {
+    // Enable every event; those whose next occurrence is >1 day out schedule.
+    const all = Object.fromEntries(ISLAMIC_EVENTS.map((e) => [e.id, true]));
+    const { notifier, scheduled, cancelled } = fakeNotifier();
+    await syncIslamicEventReminders({ notifier, reminders: fakeReminders({ islamicEvents: all }), now });
+
+    // Clears every known event id first (idempotent), then schedules.
+    expect(cancelled).toContain(islamicEventReminderId("eid-al-fitr"));
+    expect(scheduled.size).toBeGreaterThan(0);
+    for (const [id, n] of scheduled) {
+      expect(id.startsWith("event:")).toBe(true);
+      expect(n.tag).toBe(id);
+      expect(n.title).toMatch(/^Tomorrow: /);
+      expect(new Date(n.at!).getTime()).toBeGreaterThan(NOW.getTime());
+    }
+  });
+
+  it("is a no-op when none are enabled, or enabled without permission", async () => {
+    const none = fakeNotifier();
+    await syncIslamicEventReminders({ notifier: none.notifier, reminders: fakeReminders({ islamicEvents: {} }), now });
+    expect(none.scheduled.size).toBe(0);
+
+    const denied = fakeNotifier("denied");
+    const all = Object.fromEntries(ISLAMIC_EVENTS.map((e) => [e.id, true]));
+    await syncIslamicEventReminders({ notifier: denied.notifier, reminders: fakeReminders({ islamicEvents: all }), now });
+    expect(denied.scheduled.size).toBe(0);
+  });
+});
+
 describe("reminder ids and constants", () => {
   it("pins the stable ids and the default plan time", () => {
     expect(DEFAULT_PLAN_REMINDER_TIME).toBe("20:00");
@@ -234,6 +269,7 @@ describe("reminder ids and constants", () => {
     expect(adhkarReminderId("evening")).toBe("adhkar:evening");
     expect(prayerReminderId("fajr")).toBe("prayer:fajr");
     expect(SUNNAH_FAST_REMINDER_ID).toBe("sunnah-fast:next");
+    expect(islamicEventReminderId("eid-al-adha")).toBe("event:eid-al-adha");
   });
 });
 

--- a/packages/core/src/reminders.ts
+++ b/packages/core/src/reminders.ts
@@ -14,6 +14,8 @@
 import type { AdhkarOccasion } from "./entities";
 import type { Notifier, PlanStore, PrayerTimingsProvider, ReminderStore } from "./ports";
 import { nextAdhkarReminder } from "./adhkar";
+import { addGregorianDays } from "./hijri";
+import { ISLAMIC_EVENTS, upcomingIslamicEvents } from "./islamic-events";
 import { OBLIGATORY_PRAYERS, PRAYER_LABELS, type PrayerName, prayerReminders } from "./prayer";
 import { nextDailyReminder, planReminderContent } from "./reading-plans";
 import { nextSunnahFastReminder } from "./sunnah-fasting";
@@ -22,6 +24,8 @@ export const DEFAULT_PLAN_REMINDER_TIME = "20:00";
 export const PLAN_REMINDER_ID = "plan:daily";
 /** Stable id for the single next-sunnah-fast reminder (rescheduling replaces it). */
 export const SUNNAH_FAST_REMINDER_ID = "sunnah-fast:next";
+/** Stable notification id for an Islamic-event reminder (rescheduling replaces it). */
+export const islamicEventReminderId = (eventId: string): string => `event:${eventId}`;
 
 const ADHKAR_OCCASION_LIST: readonly AdhkarOccasion[] = ["morning", "evening"];
 const ADHKAR_LABEL: Record<AdhkarOccasion, string> = { morning: "morning", evening: "evening" };
@@ -157,4 +161,43 @@ export async function syncSunnahFastReminder(deps: ReminderSyncDeps): Promise<vo
     at: next.at.toISOString(),
     tag: SUNNAH_FAST_REMINDER_ID,
   });
+}
+
+/**
+ * (Re)schedule reminders for the Islamic (Hijri) events the reader has toggled on
+ * (#143) — one notification the evening before each enabled event's next
+ * occurrence. Idempotent: clears every known event id first, then schedules the
+ * enabled ones still ahead of `now`. A no-op without permission or with none
+ * enabled. Needs no location; v1 uses the tabular calendar (no sighting offset).
+ */
+export async function syncIslamicEventReminders(deps: ReminderSyncDeps): Promise<void> {
+  const { notifier, reminders, now } = deps;
+  for (const event of ISLAMIC_EVENTS) await notifier.cancel(islamicEventReminderId(event.id));
+
+  const { islamicEvents } = await reminders.read();
+  if (notifier.permission() !== "granted") return;
+
+  const enabled = ISLAMIC_EVENTS.filter((e) => islamicEvents[e.id]);
+  if (enabled.length === 0) return;
+
+  const n = now();
+  const today = { year: n.getFullYear(), month: n.getMonth() + 1, day: n.getDate() };
+  const upcomingById = new Map(upcomingIslamicEvents(today).map((u) => [u.event.id, u]));
+
+  for (const event of enabled) {
+    const next = upcomingById.get(event.id);
+    if (!next) continue;
+    // Fire the evening before at 20:00 local; skip if that has already passed
+    // (e.g. the event is today) — it will re-arm for next year on a later sync.
+    const eve = addGregorianDays(next.gregorian, -1);
+    const at = new Date(eve.year, eve.month - 1, eve.day, 20, 0, 0, 0);
+    if (at.getTime() <= n.getTime()) continue;
+    await notifier.schedule({
+      id: islamicEventReminderId(event.id),
+      title: `Tomorrow: ${event.name}`,
+      body: "An Islamic observance is tomorrow. Tap to open Ummah Library.",
+      at: at.toISOString(),
+      tag: islamicEventReminderId(event.id),
+    });
+  }
 }


### PR DESCRIPTION
Closes #143.

## Why
The Islamic-events calendar layer already shipped (core event table + resolver + tests, events shown with a next-event countdown on web and mobile), but issue #143's acceptance also required a **per-event reminder toggle** — which was never implemented. This adds it, completing the issue.

## What
Each observance in the calendar's "Observances this month" panel gets a **bell toggle**. When on, a notification is scheduled the **evening before** that event's next occurrence.

## How (reuses the existing reminder stack)
- **Core:** `ReminderPrefs.islamicEvents` (per-event on/off map) + `ReminderStore.writeIslamicEvents`; `islamicEventReminderId` + `syncIslamicEventReminders` in `reminders.ts` (cancel-by-id per event, no-op without permission, evening-before via `upcomingIslamicEvents` + `addGregorianDays`). No location needed — pure tabular-Hijri dates.
- **Adapters:** `ul.islamicEventReminders` (JSON map) on web (localStorage) + mobile (AsyncStorage). Held back from sync like the other notification prefs.
- **Apps:** thin `islamic-event-reminders` wrappers; a bell toggle per observance row in `HijriCalendar.tsx` (web) and `HijriCalendarScreen.tsx` (mobile); launch/foreground sync in mobile `App.tsx`.

No new architectural boundary → no ADR.

## Verification
- 460 core + adapter tests pass, incl. new `syncIslamicEventReminders` cases (schedules enabled events ahead of now; no-op when none enabled or without permission) and updated store round-trips.
- `tsc --noEmit` clean for core, web, mobile; web production build succeeds.
- Visually confirmed on `/calendar`: each observance has a bell toggle, and an enabled event (ʿĀshūrāʾ) renders in the gold "on" state.