### PR TITLE
fix(web,mobile): let the prayer tracker's history grid log past days

### DIFF
--- a/apps/mobile/src/screens/PrayerTrackerScreen.tsx
+++ b/apps/mobile/src/screens/PrayerTrackerScreen.tsx
@@ -91,12 +91,16 @@ export function PrayerTrackerScreen() {
     });
   }
 
-  function cycle(prayer: (typeof OBLIGATORY_PRAYERS)[number]) {
+  function cycleDate(date: string, prayer: (typeof OBLIGATORY_PRAYERS)[number]) {
     setLog((prev) => {
-      const next = setPrayerStatus(prev, today, prayer, nextPrayerStatus(statusFor(prev[today], prayer)));
+      const next = setPrayerStatus(prev, date, prayer, nextPrayerStatus(statusFor(prev[date], prayer)));
       void prayerStore.write(next);
       return next;
     });
+  }
+
+  function cycle(prayer: (typeof OBLIGATORY_PRAYERS)[number]) {
+    cycleDate(today, prayer);
   }
 
   const todayLog = log[today];
@@ -173,8 +177,13 @@ export function PrayerTrackerScreen() {
               const st = d.statuses[pi] ?? "none";
               const dayPaused = isDatePaused(haid, d.date);
               return (
-                <View
+                <Pressable
                   key={d.date}
+                  disabled={dayPaused}
+                  onPress={() => cycleDate(d.date, p)}
+                  accessibilityLabel={`${PRAYER_LABELS[p]}: ${
+                    dayPaused ? "Paused" : STATUS_LABEL[st]
+                  } — tap to change`}
                   style={[
                     styles.cell,
                     dayPaused

--- a/apps/web/src/components/PrayerTracker.test.tsx
+++ b/apps/web/src/components/PrayerTracker.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { addDays, type PrayerDayLog } from "@ummahlibrary/core";
 import { PrayerTracker } from "./PrayerTracker";
 
@@ -49,5 +49,21 @@ describe("PrayerTracker × ḥayḍ pause", () => {
   it("shows a Paused legend for the history grid", async () => {
     render(<PrayerTracker />);
     expect(await screen.findByText("Paused")).toBeInTheDocument();
+  });
+});
+
+describe("PrayerTracker × history grid", () => {
+  it("lets you tap a past day in the grid to log a prayer, not just today", async () => {
+    render(<PrayerTracker />);
+
+    // The grid runs oldest → newest over 7 days; index 5 is yesterday.
+    const fajrCells = await screen.findAllByRole("button", { name: /^Fajr ·/ });
+    expect(fajrCells).toHaveLength(7);
+    const yesterdayCell = fajrCells[5]!;
+    expect(yesterdayCell.getAttribute("aria-label")).toMatch(/Not yet — tap to change$/);
+
+    fireEvent.click(yesterdayCell);
+
+    expect(await screen.findByLabelText(/^Fajr ·.*On time — tap to change$/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/PrayerTracker.tsx
+++ b/apps/web/src/components/PrayerTracker.tsx
@@ -204,16 +204,24 @@ export function PrayerTracker() {
                 const st = d.statuses[pi] ?? "none";
                 const dayPaused = isDatePaused(haid, d.date);
                 return (
-                  <div
+                  <button
                     key={d.date}
+                    type="button"
+                    disabled={dayPaused}
+                    onClick={() => void cyclePrayer(d.date, p).then(setLog)}
+                    aria-label={`${PRAYER_LABELS[p]} · ${weekdayInitial(d.date)}: ${
+                      dayPaused ? "Paused" : statusLabel(st)
+                    } — tap to change`}
                     title={`${PRAYER_LABELS[p]} · ${weekdayInitial(d.date)}: ${
                       dayPaused ? "Paused" : statusLabel(st)
                     }`}
                     style={{
+                      display: "block",
                       aspectRatio: "1",
                       width: "100%",
                       maxWidth: 30,
                       margin: "0 auto",
+                      padding: 0,
                       borderRadius: 7,
                       background: dayPaused || st === "none" ? "transparent" : statusColor(st),
                       border: dayPaused
@@ -221,6 +229,8 @@ export function PrayerTracker() {
                         : st === "none"
                           ? `1px solid ${N.border}`
                           : "none",
+                      cursor: dayPaused ? "default" : "pointer",
+                      fontFamily: N.ui,
                     }}
                   />
                 );


### PR DESCRIPTION
The 7-day grid on the Prayer Tracker only ever displayed history; the
five-prayer tap-to-log control was wired to today only, so a missed
or late prayer from an earlier day in the visible week couldn't be
recorded. The underlying log already accepted any date — this was a
UI gap, not a data-model one. Each grid cell now cycles that day's
prayer status the same way today's row does; paused (ḥayḍ) days stay
non-interactive.