### PR TITLE
docs(design): add blog design prototype snapshot

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,4 @@ packages/data/datasets
 # Vendored design-reference snapshots — kept verbatim, not reformatted
 docs/design/noor-prototype
 docs/design/noor-prototype-mobile
+docs/design/noor-prototype-blog

--- a/docs/design/noor-prototype-blog/blog/blogdata.js
+++ b/docs/design/noor-prototype-blog/blog/blogdata.js
@@ -1,0 +1,386 @@
+/* Ummah Library — engineering blog series content.
+   Plain data (no JSX) so it can be shared between the index and article views.
+   Body is a list of typed blocks the ArticleBody renderer in blogscreens.jsx
+   maps over. Paragraph text can be a plain string or an array of
+   (string | {ar, translit}) parts for inline Arabic-term treatment. */
+
+// Series is just a name a post can belong to — null/absent is valid (a
+// standalone post). Today all 12 share one series; nothing here assumes a
+// fixed member count or a single series forever.
+const SERIES_ENGINEERING = "The Ummah Library engineering series";
+
+const ARTICLES = [
+  {
+    slug: "anatomy-of-an-open-source-quran-platform",
+    order: 1,
+    date: "2026-07-13",
+    series: SERIES_ENGINEERING,
+    title: "Anatomy of an Open-Source Quran Platform",
+    description: "A tour of the whole system: how the monorepo is organized, what talks to what, and why the pieces are split the way they are.",
+    tags: ["architecture", "typescript", "monorepo", "open-source", "software-design"],
+    body: [
+      { type: "p", text: "Ummah Library started as a single Next.js app. It is now a monorepo of nine packages, three shipped apps and a domain core that none of them are allowed to bypass. This post is the map — the one we wished existed before we opened the codebase for the first time." },
+      { type: "h2", text: "The shape of the repo" },
+      { type: "p", text: "Everything lives under one root: a domain package with no framework dependencies, a set of adapters that implement its ports, and three consumer apps — web, mobile and a browser extension — that compose those adapters differently for their platform." },
+      { type: "ul", items: [
+        "packages/domain — entities, use-cases, ports. Zero framework imports.",
+        "packages/adapters-* — one package per external concern: storage, audio, search, licensing.",
+        "apps/web, apps/mobile, apps/extension — thin shells that wire adapters into the domain.",
+      ] },
+      { type: "h3", text: "Why a monorepo at all" },
+      { type: "p", text: "Three apps sharing one domain only works if changing the domain is a single, atomic commit. Split repos would mean versioning the core and waiting for three consumers to update — which, in practice, means the domain drifts three ways within a year." },
+      { type: "diagram", caption: "apps → adapters → domain, dependencies pointing inward" },
+      { type: "p", text: "The rest of this series works through that inward-pointing rule in detail — starting with the single lint rule, next post, that keeps it from becoming a suggestion." },
+    ],
+  },
+  {
+    slug: "the-one-rule-that-protects-everything",
+    order: 2,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "The One Rule That Protects Everything",
+    description: "One ESLint rule keeps the domain layer honest — and why hexagonal architecture lives or dies on enforcement, not good intentions.",
+    tags: ["architecture", "hexagonal-architecture", "eslint", "typescript", "software-design"],
+    body: [
+      { type: "p", text: "Hexagonal architecture diagrams are easy to draw and easy to violate. The domain sits in the middle, ports define what it needs, adapters supply it — and then, eighteen months later, someone imports a browser API into a use-case because it was faster than adding a port. The diagram survives in the docs; the boundary doesn't survive in the code." },
+      { type: "p", text: "We stopped trusting the diagram and started trusting a linter." },
+      { type: "h2", text: "The rule" },
+      { type: "p", text: "One ESLint rule — `no-restricted-imports` scoped by path — says the domain package may not import from adapters, apps, or any package tagged `platform`. That's the entire enforcement mechanism. No architecture-fitness test suite, no custom static analysis. One rule, checked on every commit and in CI." },
+      { type: "code", lang: "js", code: `// .eslintrc.cjs — enforced in packages/domain only
+module.exports = {
+  rules: {
+    "no-restricted-imports": ["error", {
+      patterns: [
+        { group: ["**/adapters-*/**"], message: "Domain may not import adapters. Add a port instead." },
+        { group: ["**/apps/**"], message: "Domain may not depend on an app shell." },
+      ],
+    }],
+  },
+};` },
+      { type: "h3", text: "Why one rule is enough" },
+      { type: "ul", items: [
+        "It fails loudly, at commit time, in a language every contributor already reads.",
+        "It has no exceptions list to maintain — the boundary is binary, not negotiable.",
+        "It costs nothing to onboard a new contributor onto: the error message says what to do.",
+      ] },
+      { type: "p", text: "The other side of the rule is a checklist for adding a new capability without breaking it:" },
+      { type: "ol", items: [
+        "Define the port as an interface in the domain — the shape the domain needs, not what a library offers.",
+        "Implement the port in a new or existing adapters-* package.",
+        "Wire the concrete adapter at the app's composition root, never inside a use-case.",
+      ] },
+      { type: "quote", text: "The dependency rule is the overriding rule that makes this architecture work... source code dependencies can only point inwards.", cite: "Internal ADR-0003, quoting Robert C. Martin's Clean Architecture" },
+      { type: "table", head: ["Layer", "May import", "May not import"], rows: [
+        ["domain", "domain", "adapters-*, apps/*"],
+        ["adapters-*", "domain, external libs", "apps/*"],
+        ["apps/*", "domain, adapters-*", "— (composition root)"],
+      ] },
+      { type: "p", text: [
+        "It's the same discipline as keeping the ", { ar: "قِبْلَة", translit: "qibla" }, " direction as a single computed value rather than letting every screen calculate its own bearing: one authority, everywhere else depends on it.",
+      ] },
+      { type: "hr" },
+      { type: "p", text: "The next post pushes the same rule one layer deeper: not just what the domain can import, but what it's allowed to know about time." },
+    ],
+  },
+  {
+    slug: "a-pure-core-keeping-the-clock-out-of-your-domain",
+    order: 3,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "A Pure Core: Keeping the Clock Out of Your Domain",
+    description: "Why the domain never calls Date.now(), and how injecting time makes prayer calculations and streaks deterministic and testable.",
+    tags: ["architecture", "testing", "typescript", "determinism", "software-design"],
+    body: [
+      { type: "p", text: "Prayer times, fasting streaks and reading-plan pacing all depend on \"now.\" That makes them the easiest place in the codebase to write a flaky test — unless \"now\" is a value the domain receives, not a global it reaches for." },
+      { type: "h2", text: "The Clock port" },
+      { type: "p", text: "Every use-case that needs the current time takes a `Clock` port as an argument. In production it's backed by `Date.now()`; in tests it's a fixed instant." },
+      { type: "code", lang: "ts", code: `interface Clock {
+  now(): Date;
+}
+
+function nextPrayer(times: PrayerTime[], clock: Clock): PrayerTime {
+  const now = clock.now();
+  return times.find((t) => t.at > now) ?? times[0];
+}` },
+      { type: "p", text: "This looks like ceremony for a one-line function. It stops looking like ceremony the first time a test needs to assert what happens at 11:58pm on the last day of Ramaḍān." },
+      { type: "h3", text: "What it buys you" },
+      { type: "ul", items: [
+        "Tests run at any time of day, in any timezone, with no flakiness.",
+        "Bug reports include the exact instant, so a fix can be verified against the same input.",
+        "Streak and pacing logic can be simulated forward — useful for previewing a reading plan before committing to it.",
+      ] },
+      { type: "p", text: "The same pattern extends to anything else non-deterministic — random IDs, locale, geolocation. If a use-case's output can change between two runs with identical arguments, something impure is hiding inside it." },
+    ],
+  },
+  {
+    slug: "when-not-to-add-a-port",
+    order: 4,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "When Not to Add a Port",
+    description: "Ports and adapters are cheap to draw and expensive to maintain. A rule of thumb for when a port is worth it — and when it's just ceremony.",
+    tags: ["architecture", "hexagonal-architecture", "software-design", "abstraction", "typescript"],
+    body: [
+      { type: "p", text: "Once a codebase has one port, it's tempting to reach for a port every time. Need to format a number? Port. Need to check if a string is empty? Port. This is how hexagonal architecture earns its reputation for ceremony." },
+      { type: "h2", text: "The question that actually matters" },
+      { type: "p", text: "Before adding a port, we ask one thing: could this dependency plausibly need a second implementation? Not \"is it technically external\" — `Intl.NumberFormat` is external and never gets a port. Not \"is it a library\" — `date-fns` helpers are pure functions and stay unwrapped." },
+      { type: "ul", items: [
+        "A second, real implementation is plausible → add a port. (Storage: IndexedDB today, a native SQLite adapter tomorrow.)",
+        "It's a pure function with no I/O and one obvious implementation → import it directly, even in the domain.",
+        "It's a platform capability the domain merely needs the *result* of → pass the result in, don't wrap the API.",
+      ] },
+      { type: "p", text: "That third case is the one people miss. The domain doesn't need a `GeolocationPort` — it needs a latitude and longitude. Passing the coordinates in as arguments is simpler than wrapping the Geolocation API in an interface the domain never directly touches anyway." },
+      { type: "h3", text: "A smell to watch for" },
+      { type: "p", text: "If an adapter interface has exactly one implementation eighteen months after it shipped, and no plan for a second, it's not a seam — it's indirection. We've deleted three such ports so far, each time replacing a `SomethingPort.doThing()` call with the plain function it wrapped." },
+    ],
+  },
+  {
+    slug: "no-account-no-server-no-tracking-local-first-software-people-own",
+    order: 5,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "No Account, No Server, No Tracking: Local-First Software People Own",
+    description: "Why Ummah Library has no login and no backend, and what that constraint forces onto the architecture.",
+    tags: ["local-first", "architecture", "typescript", "software-design", "privacy"],
+    body: [
+      { type: "p", text: "There is no sign-up screen in Ummah Library, and there is no backend to sign up to. Bookmarks, ḥifẓ progress and reading streaks live entirely on-device. This wasn't a growth decision — it was a values decision that then had to become an architectural one." },
+      { type: "h2", text: "What \"no server\" actually constrains" },
+      { type: "ul", items: [
+        "Persistence must work fully offline, from first launch — so storage is a first-class port, not a cache in front of an API.",
+        "Anything that looks like sync between devices has to happen without a server that can read the payload (see the next post).",
+        "There is nothing to A/B test server-side, no analytics pipeline to reason about, and no account-deletion flow — because there's no account.",
+      ] },
+      { type: "p", text: "The trade-off is real: no server-side backup means a wiped device is a wiped library unless the user exports their own data. We chose to make export/import a first-run-quality feature rather than compromise on the no-account premise." },
+      { type: "h3", text: "Local-first, not offline-first" },
+      { type: "p", text: "Offline-first usually still assumes a server exists somewhere and the app degrades gracefully without it. Local-first flips the default: the device is the source of truth, and anything server-shaped is optional, additive, and — as the next post covers — blind to the data it carries." },
+    ],
+  },
+  {
+    slug: "encrypting-data-you-can-never-read",
+    order: 6,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "Encrypting Data You Can Never Read",
+    description: "Bookmarks and progress sync between devices without a server that can read them — the design behind zero-knowledge sync.",
+    tags: ["distributed-systems", "cryptography", "local-first", "architecture", "typescript"],
+    body: [
+      { type: "p", text: "Sync was the one feature that seemed to require breaking the no-server premise. It doesn't — it just requires the server to be a courier for ciphertext it can't open." },
+      { type: "h2", text: "The shape of it" },
+      { type: "p", text: "A device-local key, derived from a passphrase the user never sends anywhere, encrypts the sync payload before it leaves the device. The relay stores and forwards opaque blobs keyed by an anonymous sync-group ID. It has no way to associate a blob with a person, and no way to read its contents." },
+      { type: "code", lang: "ts", code: `async function encryptPayload(data: SyncPayload, key: CryptoKey) {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const cipher = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(JSON.stringify(data)),
+  );
+  return { iv, cipher };
+}` },
+      { type: "h3", text: "What the relay is trusted with" },
+      { type: "table", head: ["Can the relay...", "Answer"], rows: [
+        ["Read bookmark or progress content?", "No — AES-GCM ciphertext only"],
+        ["Link a blob to an email or account?", "No — no accounts exist"],
+        ["Know how many devices are in a sync group?", "Yes — blob count, not content"],
+        ["Cause data loss if it disappears?", "No — local data is authoritative"],
+      ] },
+      { type: "p", text: "This is a smaller guarantee than end-to-end encrypted messaging makes, and we're careful not to oversell it — metadata like blob timing is still visible to the relay. But it means the one server Ummah Library does operate can be run, in principle, by anyone, without becoming a custodian of anyone's reading habits." },
+    ],
+  },
+  {
+    slug: "delete-the-database",
+    order: 7,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "Delete the Database",
+    description: "How static generation replaced a database for Qur'ān and hadith text, and what got faster (and harder) as a result.",
+    tags: ["architecture", "nextjs", "static-site-generation", "performance", "software-design"],
+    body: [
+      { type: "p", text: "The Qur'ān text, translations and hadith corpus don't change at runtime. Querying them from a database on every request was solving a problem we didn't have." },
+      { type: "h2", text: "What moved to build time" },
+      { type: "ul", items: [
+        "Every surah, ayah, translation and tafsīr entry is generated to a static JSON asset at build time.",
+        "Search indexes (see the post on Arabic search) are pre-built and shipped as static files, not queried live.",
+        "The only runtime writes are user-local: bookmarks, progress, settings — none of which ever touch a server database.",
+      ] },
+      { type: "p", text: "The result is a content layer with no database to provision, back up, migrate or take down for maintenance. A new translation ships as a pull request that adds a data file and a rebuild — reviewable the same way a code change is." },
+      { type: "h3", text: "What got harder" },
+      { type: "p", text: "Anything that used to be \"just a query\" is now a build step. Adding a cross-cutting field to every ayah means regenerating the whole corpus, not writing one migration. We accepted that trade because the corpus changes rarely and the read path — which every user hits, constantly — gets to be a CDN cache hit instead of a database round trip." },
+    ],
+  },
+  {
+    slug: "one-domain-three-apps",
+    order: 8,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "One Domain, Three Apps",
+    description: "The same domain core powers the web app, the mobile app and the browser extension. Here's how the boundary makes that possible.",
+    tags: ["architecture", "react-native", "design-systems", "monorepo", "typescript"],
+    body: [
+      { type: "p", text: "Web, mobile and the browser extension ship the same reading progress, the same prayer-time logic and the same ḥifẓ review algorithm — implemented once, in `packages/domain`, and consumed three times." },
+      { type: "h2", text: "What's shared and what isn't" },
+      { type: "table", head: ["Layer", "Web", "Mobile", "Extension"], rows: [
+        ["Domain use-cases", "shared", "shared", "shared"],
+        ["Storage adapter", "IndexedDB", "SQLite (React Native)", "extension storage API"],
+        ["UI components", "web kit", "React Native kit", "web kit, constrained"],
+        ["Design tokens", "shared", "shared", "shared"],
+      ] },
+      { type: "p", text: "The design tokens travelling unchanged across all three is what makes the interfaces feel like one product rather than three skins. The components don't — a card on web isn't a React Native card — but they render from the same colour, spacing and type tokens." },
+      { type: "h3", text: "The test that keeps this honest" },
+      { type: "p", text: "Each app's composition root is a small file whose only job is instantiating adapters and handing them to domain use-cases. If that file starts containing business logic, it's a sign a use-case leaked out of the domain — the same violation the ESLint rule from post two exists to catch." },
+    ],
+  },
+  {
+    slug: "plug-it-in-a-content-system-with-three-delivery-modes",
+    order: 9,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "Plug It In: A Content System with Three Delivery Modes",
+    description: "Tafsīr, translations and audio all flow through one plugin interface, whether they ship in the bundle, fetch over the network, or load from disk.",
+    tags: ["architecture", "plugin-systems", "typescript", "software-design", "extensibility"],
+    body: [
+      { type: "p", text: "A translation might be small enough to bundle. A tafsīr might be too large to bundle but fine to fetch on demand. An audio reciter's files are large enough that they need to be downloaded once and read from disk after that. Three very different delivery mechanisms — one `ContentProvider` interface." },
+      { type: "code", lang: "ts", code: `interface ContentProvider<T> {
+  readonly id: string;
+  readonly mode: "bundled" | "remote" | "on-device";
+  load(ref: ContentRef): Promise<T>;
+}` },
+      { type: "h2", text: "Why one interface, not three" },
+      { type: "p", text: "A reading screen that wants a translation shouldn't need to know or care which of the three a given translation uses — that decision belongs to whoever registers the provider, and it can change later without touching the screen." },
+      { type: "ol", items: [
+        "A new translation ships bundled at first, for immediate availability.",
+        "Once it's popular enough to matter for bundle size, its provider is swapped to \"remote\" — same interface, same call sites.",
+        "No reading-screen code changes for that migration.",
+      ] },
+      { type: "h3", text: "The trade-off" },
+      { type: "p", text: "A uniform interface across three delivery modes means the interface has to be the lowest common denominator — async, and content-ref based rather than assuming synchronous, in-memory access. Every provider pays a small `await` tax even the bundled ones don't strictly need, in exchange for every call site staying identical regardless of where the content actually lives." },
+    ],
+  },
+  {
+    slug: "searching-arabic-in-the-browser",
+    order: 10,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "Searching Arabic in the Browser",
+    description: "Fast, diacritic-insensitive Arabic search, entirely client-side — the indexing and normalization tricks that make it work.",
+    tags: ["search", "unicode", "typescript", "local-first", "algorithms"],
+    body: [
+      { type: "p", text: [
+        "Search has to work with no server, which rules out anything that depends on a hosted index. It also has to handle the fact that most people typing a query don't include ",
+        { ar: "تَشْكِيل", translit: "tashkeel" },
+        " — the diacritic marks — even though the corpus stores them.",
+      ] },
+      { type: "h2", text: "Normalize before you index" },
+      { type: "p", text: "Every ayah is indexed twice: once with full diacritics, once with them stripped to bare consonantal skeleton. A query is normalized the same way before matching, so \"رحمن\" finds \"رَحْمَٰن\" without the user ever needing to type a single tashkeel mark." },
+      { type: "code", lang: "ts", code: `const DIACRITICS = /[\\u064B-\\u065F\\u0670]/g;
+
+function normalizeArabic(text: string): string {
+  return text
+    .normalize("NFKD")
+    .replace(DIACRITICS, "")
+    .replace(/[إأآا]/g, "ا") // fold alif variants
+    .replace(/ى/g, "ي");     // fold alif maqsura
+}` },
+      { type: "h3", text: "Keeping it client-side" },
+      { type: "ul", items: [
+        "The normalized index is pre-built at content-generation time and shipped as a static asset, not computed on first search.",
+        "Matching runs against an in-memory inverted index — no network round trip, no server to keep warm.",
+        "Highlighting re-maps normalized match offsets back onto the original, fully-diacritized text so results still look like the Qur'ān, not the search index.",
+      ] },
+      { type: "p", text: "The offset re-mapping is the fiddly part: stripping diacritics shortens the string, so a naive highlight would land on the wrong character. The index stores a position map alongside the normalized text specifically so highlighting can survive the round trip." },
+    ],
+  },
+  {
+    slug: "provenance-as-architecture-when-a-licence-decides-your-system-design",
+    order: 11,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "Provenance as Architecture: When a Licence Decides Your System Design",
+    description: "Mixed-licence source texts forced a system boundary most apps never have to draw. How licensing became an architectural constraint.",
+    tags: ["architecture", "open-source", "licensing", "data-engineering", "software-design"],
+    body: [
+      { type: "p", text: "The Qur'ān text itself is unambiguous. The translations, tafsīr and hadith gradings around it are not — each comes from a publisher with its own licence, some permissive, some requiring attribution, a small number requiring the content never be bundled with software under a different licence." },
+      { type: "h2", text: "The constraint became a boundary" },
+      { type: "p", text: "Rather than track licence terms in a spreadsheet and hope every contributor reads it, provenance became a field on the content model itself — every text asset carries its source, licence and permitted distribution modes, checked in CI before anything ships." },
+      { type: "table", head: ["Field", "Example", "Enforced by"], rows: [
+        ["source", "\"Sahih International\"", "schema validation"],
+        ["licence", "\"CC-BY-NC-4.0\"", "build-time licence gate"],
+        ["distribution", "\"bundle\" | \"remote-only\"", "ContentProvider mode (see post 9)"],
+      ] },
+      { type: "blockquote", text: "No text asset may reach the `bundled` distribution mode unless its licence field is on the pre-approved allow-list. This check may not be bypassed by configuration.", cite: "Internal ADR-0011" },
+      { type: "h3", text: "Why this is architecture, not paperwork" },
+      { type: "p", text: "A licence that forbids bundling isn't a legal footnote — it's the reason some translations use the \"remote\" delivery mode from the plugin-system post rather than the \"bundled\" one, even though bundling would be simpler and faster. The system's shape follows from what the content is legally allowed to do, which made provenance a first-class part of the domain model instead of an afterthought in a README." },
+    ],
+  },
+  {
+    slug: "your-first-contribution-to-ummah-library",
+    order: 12,
+    date: null,
+    series: SERIES_ENGINEERING,
+    title: "Your First Contribution to Ummah Library",
+    description: "A practical, step-by-step guide to setting up the monorepo, finding a good first issue, and opening your first pull request.",
+    tags: ["open-source", "contributing", "typescript", "monorepo", "software-design"],
+    body: [
+      { type: "p", text: "This is the last post in the series, and the most practical one: how to go from cloning the repo to an opened, reviewable pull request." },
+      { type: "h2", text: "Set up the monorepo" },
+      { type: "code", lang: "bash", code: `git clone https://github.com/ummah-library/ummah-library.git
+cd ummah-library
+pnpm install
+pnpm dev --filter=web` },
+      { type: "p", text: "That last command starts the web app with hot reload against the shared domain package — a change in `packages/domain` is reflected without a rebuild step." },
+      { type: "h2", text: "Find something worth working on" },
+      { type: "ul", items: [
+        "Issues labelled `good-first-issue` are scoped to a single package and don't require touching the domain boundary.",
+        "Issues labelled `content` are usually translation, tafsīr or hadith data additions — no TypeScript required.",
+        "If nothing labelled fits, open a discussion before a PR — it's cheaper to align on approach before writing code than after.",
+      ] },
+      { type: "h2", text: "Before you open the PR" },
+      { type: "ol", items: [
+        "`pnpm lint` — this is where the boundary rule from post two will catch a misplaced import.",
+        "`pnpm test` — domain tests should need no mocks beyond the `Clock` port from post three.",
+        "`pnpm typecheck` — the monorepo is strict-mode TypeScript throughout.",
+      ] },
+      { type: "p", text: "None of this is gatekeeping for its own sake — every check exists because it once caught a real regression, and we'd rather a contributor's CI run catch it locally than a maintainer catch it in review." },
+    ],
+  },
+];
+
+Object.assign(window, { ARTICLES });
+
+// ── Synthetic test data — for stress-testing pagination, grid density and
+// filters at counts far beyond the real 12-article series. Gated behind the
+// Tweaks panel's "Extra test posts" slider (default 0); never shown otherwise.
+// Clearly self-identifies as placeholder content in its own description.
+const TEST_SERIES = [SERIES_ENGINEERING, "Community Spotlights", "Release Notes", null];
+const TEST_TAG_POOL = [
+  "performance", "refactoring", "ci-cd", "accessibility", "i18n", "react",
+  "testing", "postgres", "caching", "observability", "api-design", "security",
+  "onboarding", "documentation", "tooling", "graphql", "webassembly",
+];
+function generateTestArticles(count) {
+  const out = [];
+  for (let i = 0; i < count; i++) {
+    const n = i + 1;
+    const series = TEST_SERIES[i % TEST_SERIES.length];
+    const tagCount = 3 + (i % 3);
+    const tags = [];
+    for (let j = 0; j < tagCount; j++) tags.push(TEST_TAG_POOL[(i * 5 + j) % TEST_TAG_POOL.length]);
+    const d = new Date("2026-01-05T00:00:00");
+    d.setDate(d.getDate() + i * 4);
+    out.push({
+      slug: `test-post-${n}`,
+      order: 1000 + n,
+      date: d.toISOString().slice(0, 10),
+      series,
+      title: `Test Post ${n}: Sample Entry for Layout Stress-Testing`,
+      description: "Synthetic entry generated to stress-test the index grid, pagination and filters at higher post counts — not real editorial content.",
+      tags: [...new Set(tags)],
+      body: [
+        { type: "p", text: "This is placeholder test content, generated only to stress-test the index grid, pagination and filter UI at higher post counts. It is not part of the real 12-article engineering series." },
+        { type: "h2", text: "Why this exists" },
+        { type: "p", text: "Use the Tweaks panel's \"Extra test posts\" slider to add or remove entries like this one, and confirm the grid, pagination and series/tag filters all hold up at scale." },
+      ],
+    });
+  }
+  return out;
+}
+Object.assign(window, { generateTestArticles });

--- a/docs/design/noor-prototype-blog/blog/blogkit.jsx
+++ b/docs/design/noor-prototype-blog/blog/blogkit.jsx
@@ -1,0 +1,437 @@
+/* Ummah Library — engineering blog kit. Editorial companion to the Noor app
+   design: slim header, article index cards, and a full prose component set
+   for the article body. Reuses N tokens, Btn, Icon, Logo, Khatam from the app
+   kit — no new hardcoded colours. */
+
+const { useState: useStateBlog } = React;
+
+const card = { background: "var(--ul-card)", border: "1px solid var(--ul-border)", borderRadius: 16 };
+
+// Editorial reading face — serif for long-form body copy, kept distinct from
+// the app's all-Hanken-Grotesk UI chrome (headings/labels stay sans, matching
+// the Medium-style contrast between headline sans and body serif).
+const serif = "'Source Serif 4', Georgia, serif";
+
+// ── Slim editorial header — no sidebar, no tool nav ───────────────────────────
+function BlogHeader({ page = "blog", onNavigate, theme, onToggleTheme }) {
+  const mode = THEME_MODE[theme] || "dark";
+  return (
+    <header style={{ position: "sticky", top: 0, zIndex: 20, background: N.bg, borderBottom: `1px solid ${N.borderSoft}` }}>
+      <div style={{ maxWidth: 1040, margin: "0 auto", height: 64, display: "flex", alignItems: "center", gap: 28, padding: "0 28px" }}>
+        <Logo scale={0.92} onClick={() => onNavigate && onNavigate("index")} />
+        <div style={{ flex: 1 }} />
+        <nav style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <button className="ul-press ul-link" onClick={() => onNavigate && onNavigate("index")}
+            style={{ background: "none", border: "none", cursor: "pointer", fontFamily: N.ui, fontSize: 14, fontWeight: 700, padding: "8px 12px", borderRadius: 8, color: page === "blog" ? N.gold : N.muted }}>
+            Blog
+          </button>
+          <a href="#" onClick={(e) => e.preventDefault()} className="ul-link"
+            style={{ fontSize: 14, fontWeight: 600, padding: "8px 12px", borderRadius: 8, color: N.muted, textDecoration: "none" }}>
+            Open the app
+          </a>
+        </nav>
+        <a href="#" onClick={(e) => e.preventDefault()} title="RSS feed" className="ul-press ul-link"
+          style={{ width: 36, height: 36, borderRadius: 10, background: N.card, border: `1px solid ${N.border}`, display: "grid", placeItems: "center", color: N.muted }}>
+          <RssIcon size={15} color={N.muted} />
+        </a>
+        <button className="ul-press ul-link" onClick={onToggleTheme} title="Toggle theme"
+          style={{ width: 36, height: 36, borderRadius: 10, background: N.card, border: `1px solid ${N.border}`, display: "grid", placeItems: "center", cursor: "pointer" }}>
+          <Icon name={mode === "dark" ? "moon" : "sun"} size={16} color={N.muted} />
+        </button>
+      </div>
+    </header>
+  );
+}
+
+// ── Shared small pieces ────────────────────────────────────────────────────────
+// A small RSS glyph — not in the app's icon set (app has no feed), drawn as a
+// simple dot + two concentric arcs, matching the line-icon weight/style.
+function RssIcon({ size = 16, color = "currentColor" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+      <circle cx="5.5" cy="18.5" r="1.8" fill={color} stroke="none" />
+      <path d="M4 11a9 9 0 0 1 9 9" />
+      <path d="M4 4.5A15.5 15.5 0 0 1 19.5 20" />
+    </svg>
+  );
+}
+
+// Series is optional — renders nothing when the post has none (a standalone
+// post is a first-class case, not a fallback).
+function SeriesBadge({ series, size = "md" }) {
+  if (!series) return null;
+  const fs = size === "sm" ? 11.5 : 12.5;
+  return (
+    <span style={{ display: "inline-block", whiteSpace: "nowrap", fontSize: fs, fontWeight: 700, letterSpacing: 0.2, color: N.gold, background: N.goldSoft, border: `1px solid ${N.gold}`, borderRadius: 999, padding: size === "sm" ? "4px 10px" : "5px 12px" }}>
+      {series}
+    </span>
+  );
+}
+
+const dateFmt = new Intl.DateTimeFormat("en", { month: "short", day: "numeric", year: "numeric" });
+function PublishDate({ date, style }) {
+  if (!date) return null;
+  const d = typeof date === "string" ? new Date(date + "T00:00:00") : date;
+  return <time dateTime={typeof date === "string" ? date : d.toISOString().slice(0, 10)} style={{ fontSize: 13, color: N.faint, whiteSpace: "nowrap", ...style }}>{dateFmt.format(d)}</time>;
+}
+
+function TagPill({ children }) {
+  return (
+    <span style={{ fontSize: 12, fontWeight: 600, color: N.muted, background: N.card, border: `1px solid ${N.border}`, borderRadius: 999, padding: "5px 11px", whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+// ── Reading time ───────────────────────────────────────────────────────────────
+// Estimated from the article's actual body word count (~200 wpm) — a
+// computed fact, not a fabricated figure. Medium/dev.to/Substack all surface
+// this as a lightweight signal of commitment before a reader clicks in.
+function textWords(t) {
+  if (!t) return 0;
+  if (typeof t === "string") return t.split(/\s+/).filter(Boolean).length;
+  return t.reduce((n, part) => n + (typeof part === "string" ? part.split(/\s+/).filter(Boolean).length : 1), 0);
+}
+function readMinutes(blocks) {
+  let n = 0;
+  blocks.forEach((b) => {
+    if (b.type === "p" || b.type === "h2" || b.type === "h3") n += textWords(b.text);
+    else if (b.type === "ul" || b.type === "ol") n += b.items.reduce((s, it) => s + textWords(it), 0);
+    else if (b.type === "quote") n += textWords(b.text);
+    else if (b.type === "table") n += b.head.reduce((s, h) => s + textWords(h), 0) + b.rows.reduce((s, r) => s + r.reduce((s2, c) => s2 + textWords(c), 0), 0);
+  });
+  return Math.max(1, Math.round(n / 200));
+}
+
+// One small, muted meta line: publish date · reading time. Either half is
+// optional — an unpublished-in-demo post with no date just shows the minutes.
+function PostMeta({ date, mins, style }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 13, color: N.faint, ...style }}>
+      {date && <PublishDate date={date} />}
+      {date && mins ? <span aria-hidden="true">·</span> : null}
+      {mins ? <span>{mins} min read</span> : null}
+    </div>
+  );
+}
+
+// ── Index: article card ───────────────────────────────────────────────────────
+function ArticleCard({ article, onOpen }) {
+  const mins = readMinutes(article.body);
+  return (
+    <article onClick={() => onOpen(article.slug)} className="ul-press ul-link"
+      style={{ ...card, padding: 24, display: "flex", flexDirection: "column", gap: 12, cursor: "pointer" }}>
+      {article.series && <SeriesBadge series={article.series} size="sm" />}
+      <div>
+        <h3 style={{ margin: 0, fontSize: 19, fontWeight: 800, letterSpacing: -0.3, lineHeight: 1.32, color: N.fg }}>{article.title}</h3>
+        <p style={{ margin: "9px 0 0", fontSize: 14.5, lineHeight: 1.6, color: N.muted }}>{article.description}</p>
+      </div>
+      <div style={{ flex: 1 }} />
+      <PostMeta date={article.date} mins={mins} />
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {article.tags.slice(0, 5).map((t) => <TagPill key={t}>{t}</TagPill>)}
+      </div>
+    </article>
+  );
+}
+
+// ── Filtering — pill row for series, dropdown for tags (tags can grow large) ──
+function FilterBar({ series, activeSeries, onSeries, tags, activeTag, onTag }) {
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 10, marginBottom: 28 }}>
+      {series.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          <button onClick={() => onSeries(null)} className="ul-press ul-link" style={{ fontSize: 12.5, fontWeight: 600, color: !activeSeries ? N.ink : N.muted, background: !activeSeries ? N.gold : N.card, border: `1px solid ${!activeSeries ? N.gold : N.border}`, borderRadius: 999, padding: "6px 13px", cursor: "pointer", fontFamily: N.ui }}>All</button>
+          {series.map((s) => (
+            <button key={s} onClick={() => onSeries(s)} className="ul-press ul-link" style={{ fontSize: 12.5, fontWeight: 600, color: activeSeries === s ? N.ink : N.muted, background: activeSeries === s ? N.gold : N.card, border: `1px solid ${activeSeries === s ? N.gold : N.border}`, borderRadius: 999, padding: "6px 13px", cursor: "pointer", fontFamily: N.ui, whiteSpace: "nowrap" }}>{s}</button>
+          ))}
+        </div>
+      )}
+      {tags.length > 0 && (
+        <select value={activeTag || ""} onChange={(e) => onTag(e.target.value || null)}
+          style={{ fontSize: 12.5, fontWeight: 600, color: N.fg, background: N.card, border: `1px solid ${N.border}`, borderRadius: 10, padding: "7px 12px", fontFamily: N.ui, cursor: "pointer", marginLeft: "auto" }}>
+          <option value="">All tags</option>
+          {tags.map((t) => <option key={t} value={t}>{t}</option>)}
+        </select>
+      )}
+    </div>
+  );
+}
+
+function LoadMoreButton({ onClick, remaining, pageSize }) {
+  return (
+    <div style={{ display: "flex", justifyContent: "center", marginTop: 32 }}>
+      <Btn variant="ghost" onClick={onClick}>Load {Math.min(remaining, pageSize)} more</Btn>
+    </div>
+  );
+}
+
+// ── Prose components ──────────────────────────────────────────────────────────
+const proseWidth = 680;
+
+// Renders a paragraph's `text`, which may be a plain string or an array of
+// (string | {ar, translit}) parts — the latter render as an inline Arabic term.
+function ArTerm({ ar, translit }) {
+  return (
+    <bdi className="ul-ar" style={{ fontWeight: 600, color: N.fg, margin: "0 2px" }}>
+      {ar}
+      <span style={{ fontFamily: N.ui, fontStyle: "italic", color: N.muted, fontWeight: 400, marginLeft: 5 }}>({translit})</span>
+    </bdi>
+  );
+}
+function proseText(text) {
+  if (typeof text === "string") return text;
+  return text.map((part, i) => (typeof part === "string" ? <React.Fragment key={i}>{part}</React.Fragment> : <ArTerm key={i} ar={part.ar} translit={part.translit} />));
+}
+
+function ProseP({ children }) {
+  return <p style={{ fontSize: 19, lineHeight: 1.75, color: N.fg, margin: "0 0 26px", fontFamily: serif, textWrap: "pretty" }}>{children}</p>;
+}
+function ProseH2({ children, id }) {
+  return <h2 id={id} style={{ fontSize: 26, fontWeight: 800, letterSpacing: -0.4, color: N.fg, fontFamily: N.ui, margin: "52px 0 18px", scrollMarginTop: 84 }}>{children}</h2>;
+}
+function ProseH3({ children }) {
+  return <h3 style={{ fontSize: 20, fontWeight: 700, letterSpacing: -0.2, color: N.fg, fontFamily: N.ui, margin: "38px 0 14px" }}>{children}</h3>;
+}
+function ProseUL({ items }) {
+  return (
+    <ul style={{ margin: "0 0 26px", padding: "0 0 0 24px", display: "flex", flexDirection: "column", gap: 12, fontFamily: serif }}>
+      {items.map((it, i) => <li key={i} style={{ fontSize: 18, lineHeight: 1.65, color: N.fg, textWrap: "pretty" }}>{it}</li>)}
+    </ul>
+  );
+}
+function ProseOL({ items }) {
+  return (
+    <ol style={{ margin: "0 0 26px", padding: "0 0 0 24px", display: "flex", flexDirection: "column", gap: 12, fontFamily: serif }}>
+      {items.map((it, i) => <li key={i} style={{ fontSize: 18, lineHeight: 1.65, color: N.fg, textWrap: "pretty" }}>{it}</li>)}
+    </ol>
+  );
+}
+function InlineCode({ children }) {
+  return <code style={{ fontFamily: "ui-monospace, Menlo, monospace", fontSize: "0.82em", color: N.gold, background: N.goldSoft, borderRadius: 5, padding: "2px 6px" }}>{children}</code>;
+}
+function ProseQuote({ text, cite }) {
+  return (
+    <blockquote style={{ margin: "0 0 26px", padding: "20px 24px", background: N.bg2, borderLeft: `3px solid ${N.gold}`, borderRadius: "0 10px 10px 0" }}>
+      <p style={{ margin: 0, fontSize: 18.5, lineHeight: 1.65, color: N.muted, fontFamily: serif, fontStyle: "italic" }}>“{text}”</p>
+      {cite && <div style={{ marginTop: 12, fontSize: 12.5, fontWeight: 700, letterSpacing: 0.6, textTransform: "uppercase", color: N.faint, fontFamily: N.ui }}>{cite}</div>}
+    </blockquote>
+  );
+}
+function ProseHR() {
+  return <hr style={{ border: "none", borderTop: `1px solid ${N.borderSoft}`, margin: "36px 0" }} />;
+}
+function ProseTable({ head, rows }) {
+  return (
+    <div style={{ margin: "0 0 24px", ...card, overflow: "hidden" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14.5 }}>
+        <thead>
+          <tr style={{ background: N.bg2 }}>
+            {head.map((h) => <th key={h} style={{ textAlign: "left", padding: "11px 16px", fontSize: 11.5, fontWeight: 700, letterSpacing: 0.8, textTransform: "uppercase", color: N.faint, borderBottom: `1px solid ${N.border}` }}>{h}</th>)}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              {r.map((c, j) => <td key={j} style={{ padding: "12px 16px", color: j === 0 ? N.fg : N.muted, fontWeight: j === 0 ? 700 : 400, borderTop: `1px solid ${N.borderSoft}`, fontFamily: j === 0 ? "ui-monospace, Menlo, monospace" : N.ui }}>{c}</td>)}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// Bordered diagram frame — chrome only; a Mermaid diagram would render inside.
+function DiagramFrame({ caption }) {
+  return (
+    <div style={{ margin: "0 0 24px", ...card, padding: 20 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
+        <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: 1.2, textTransform: "uppercase", color: N.faint }}>Diagram</span>
+        <Icon name="grid" size={15} color={N.faint} />
+      </div>
+      <div style={{
+        height: 180, borderRadius: 10, border: `1px dashed ${N.border}`,
+        background: `repeating-linear-gradient(135deg, ${N.bg2} 0px, ${N.bg2} 10px, transparent 10px, transparent 20px)`,
+        display: "grid", placeItems: "center", textAlign: "center", padding: 16,
+      }}>
+        <span style={{ fontFamily: "ui-monospace, Menlo, monospace", fontSize: 12.5, color: N.faint }}>[ mermaid diagram — {caption} ]</span>
+      </div>
+    </div>
+  );
+}
+
+// Simple regex-based highlighter — keywords/strings/comments only, coloured
+// from theme tokens (no hardcoded syntax-theme hex).
+function tokenizeCode(code) {
+  const re = /(\/\/[^\n]*|#[^\n]*)|("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`)|(\b(?:import|export|from|const|let|var|function|return|if|else|interface|type|extends|implements|class|new|async|await|throw|try|catch|public|private|readonly|default|as|typeof|instanceof|for|while|of|in|true|false|null|undefined|module|exports)\b)/g;
+  let last = 0, out = [], m;
+  while ((m = re.exec(code))) {
+    if (m.index > last) out.push({ k: "plain", s: code.slice(last, m.index) });
+    if (m[1]) out.push({ k: "com", s: m[1] });
+    else if (m[2]) out.push({ k: "str", s: m[2] });
+    else if (m[3]) out.push({ k: "kw", s: m[3] });
+    last = re.lastIndex;
+  }
+  if (last < code.length) out.push({ k: "plain", s: code.slice(last) });
+  return out;
+}
+function CodeBlock({ lang, code }) {
+  const [copied, setCopied] = useStateBlog(false);
+  const tokens = tokenizeCode(code);
+  const colors = { plain: N.fg, com: N.faint, str: N.goldHi, kw: N.gold };
+  const copy = () => {
+    if (navigator.clipboard) navigator.clipboard.writeText(code).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1400);
+  };
+  return (
+    <div style={{ margin: "0 0 24px", borderRadius: 12, overflow: "hidden", border: `1px solid ${N.border}`, background: N.bg2 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "9px 14px", borderBottom: `1px solid ${N.borderSoft}` }}>
+        <span style={{ fontSize: 12, fontWeight: 700, color: N.faint, fontFamily: "ui-monospace, Menlo, monospace", textTransform: "uppercase", letterSpacing: 0.6 }}>{lang}</span>
+        <button onClick={copy} className="ul-press ul-link" style={{ display: "flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", color: copied ? N.gold : N.faint, fontSize: 12, fontWeight: 600, fontFamily: N.ui }}>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><rect x="8" y="8" width="12" height="12" rx="2" /><path d="M5 16a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2" /></svg>
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre style={{ margin: 0, padding: "16px 18px", overflowX: "auto" }}>
+        <code style={{ fontFamily: "ui-monospace, Menlo, monospace", fontSize: 13.5, lineHeight: 1.7, whiteSpace: "pre" }}>
+          {tokens.map((t, i) => <span key={i} style={{ color: colors[t.k], fontStyle: t.k === "com" ? "italic" : "normal" }}>{t.s}</span>)}
+        </code>
+      </pre>
+    </div>
+  );
+}
+
+// ── Table of contents — sticky rail, active section tracked by scroll ────────
+function ArticleTOC({ headings }) {
+  const [active, setActiveTOC] = useStateBlog(headings[0]?.id);
+  React.useEffect(() => {
+    const onScroll = () => {
+      const probe = 120;
+      let current = headings[0]?.id;
+      for (const h of headings) {
+        const el = document.getElementById(h.id);
+        if (el && el.getBoundingClientRect().top - probe <= 0) current = h.id;
+      }
+      setActiveTOC(current);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [headings]);
+
+  const jump = (id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const top = el.getBoundingClientRect().top + window.pageYOffset - 84;
+    window.scrollTo({ top, behavior: "smooth" });
+  };
+
+  return (
+    <nav aria-label="Table of contents" style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: 1, textTransform: "uppercase", color: N.faint, marginBottom: 10 }}>On this page</div>
+      {headings.map((h) => (
+        <button key={h.id} onClick={() => jump(h.id)} className="ul-press ul-link"
+          style={{
+            textAlign: "left", background: "none", border: "none", cursor: "pointer", fontFamily: N.ui,
+            padding: "6px 0 6px 12px", borderLeft: `2px solid ${active === h.id ? N.gold : N.borderSoft}`,
+            fontSize: 13, lineHeight: 1.4, fontWeight: active === h.id ? 700 : 500,
+            color: active === h.id ? N.fg : N.faint,
+          }}>
+          {h.text}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+// ── End-of-article components ─────────────────────────────────────────────────
+function ContributeCallout() {
+  return (
+    <div style={{ margin: "40px 0", borderRadius: 16, padding: 28, background: N.goldSoft, border: `1px solid ${N.gold}` }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+        <Khatam size={20} color={N.gold} sw={1.8} />
+        <h3 style={{ margin: 0, fontSize: 18, fontWeight: 800, color: N.fg }}>Contribute to Ummah Library</h3>
+      </div>
+      <p style={{ margin: "0 0 18px", fontSize: 15, lineHeight: 1.65, color: N.muted, maxWidth: 560 }}>
+        Ummah Library is open source. If this post left you with an opinion about the boundary, or you're looking for a good first issue, we'd welcome the pull request.
+      </p>
+      <Btn variant="gold" icon="arrowR" onClick={() => window.open("https://github.com/ummah-library/ummah-library/blob/main/CONTRIBUTING.md", "_blank")}>
+        Read CONTRIBUTING.md
+      </Btn>
+    </div>
+  );
+}
+
+// prev/next are each either an article or null — a missing neighbor renders
+// no control at all (no dead link, no placeholder). If neither exists, only
+// the "back to all posts" link shows.
+function SeriesNav({ prev, next, onOpen, onIndex }) {
+  return (
+    <div style={{ margin: "8px 0 40px", display: "flex", flexDirection: "column", gap: 14 }}>
+      {(prev || next) && (
+        <div style={{ display: "flex", gap: 14 }}>
+          {prev && (
+            <button onClick={() => onOpen(prev.slug)} className="ul-press ul-link" style={{ ...card, flex: 1, textAlign: "left", padding: 16, background: N.card, border: `1px solid ${N.border}`, cursor: "pointer", display: "flex", flexDirection: "column", gap: 6 }}>
+              <span style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, fontWeight: 700, color: N.faint, textTransform: "uppercase", letterSpacing: 0.6 }}><Icon name="arrowL" size={13} color={N.faint} />Previous in series</span>
+              <span style={{ fontSize: 14.5, fontWeight: 700, color: N.fg }}>{prev.title}</span>
+            </button>
+          )}
+          {next && (
+            <button onClick={() => onOpen(next.slug)} className="ul-press ul-link" style={{ ...card, flex: 1, textAlign: "right", padding: 16, background: N.card, border: `1px solid ${N.border}`, cursor: "pointer", display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
+              <span style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, fontWeight: 700, color: N.faint, textTransform: "uppercase", letterSpacing: 0.6 }}>Next in series<Icon name="arrowR" size={13} color={N.faint} /></span>
+              <span style={{ fontSize: 14.5, fontWeight: 700, color: N.fg }}>{next.title}</span>
+            </button>
+          )}
+        </div>
+      )}
+      <button onClick={onIndex} className="ul-press ul-link" style={{ alignSelf: "center", background: "none", border: "none", cursor: "pointer", fontSize: 13.5, fontWeight: 600, color: N.gold, fontFamily: N.ui }}>
+        ← Back to all posts
+      </button>
+    </div>
+  );
+}
+
+function BlogFooter() {
+  return (
+    <footer style={{ borderTop: `1px solid ${N.borderSoft}`, marginTop: 20 }}>
+      <div style={{ maxWidth: 1040, margin: "0 auto", padding: "24px 28px", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
+        <span style={{ fontSize: 13, color: N.faint }}>© {new Date().getFullYear()} Ummah Library · Open source</span>
+        <div style={{ display: "flex", gap: 18 }}>
+          <a href="#" onClick={(e) => e.preventDefault()} style={{ fontSize: 13, color: N.muted, textDecoration: "none" }}>GitHub</a>
+          <a href="#" onClick={(e) => e.preventDefault()} style={{ fontSize: 13, color: N.muted, textDecoration: "none" }}>Open the app</a>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+// Thin reading-progress bar under the sticky header, filling as the reader
+// scrolls the article — the same lightweight affordance Medium/Substack use.
+function ScrollProgress() {
+  const [pct, setPct] = useStateBlog(0);
+  React.useEffect(() => {
+    const onScroll = () => {
+      const h = document.documentElement;
+      const max = h.scrollHeight - h.clientHeight;
+      setPct(max > 0 ? Math.min(100, (h.scrollTop / max) * 100) : 0);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => { window.removeEventListener("scroll", onScroll); window.removeEventListener("resize", onScroll); };
+  }, []);
+  return (
+    <div style={{ position: "sticky", top: 64, zIndex: 19, height: 3, background: N.borderSoft }}>
+      <div style={{ height: "100%", width: pct + "%", background: N.goldGrad, transition: "width 80ms linear" }} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  BlogHeader, RssIcon, SeriesBadge, PublishDate, PostMeta, readMinutes, TagPill, ArticleCard, FilterBar, LoadMoreButton,
+  ArTerm, proseText, proseWidth, serif,
+  ProseP, ProseH2, ProseH3, ProseUL, ProseOL, InlineCode, ProseQuote, ProseHR,
+  ProseTable, DiagramFrame, CodeBlock, ContributeCallout, SeriesNav, BlogFooter, ScrollProgress, ArticleTOC,
+});

--- a/docs/design/noor-prototype-blog/blog/blogscreens.jsx
+++ b/docs/design/noor-prototype-blog/blog/blogscreens.jsx
@@ -1,0 +1,201 @@
+/* Ummah Library — blog view composition: index (grid + filters + load-more)
+   and article page, wired to a tiny hash router, the shared Noor theme
+   toggle (Obsidian ⇄ Ivory), and a Tweaks-only "simulated publish state" so
+   the growth states (2, 5, 20+ posts) can be previewed without waiting for
+   real publish dates. The real product only ever shows posts with a `date`. */
+
+const { useState: useStateScreens, useEffect: useEffectScreens } = React;
+
+const PAGE_SIZE_DEFAULT = 8;
+
+// Diagrams/tables/code are visually denser than prose, so they're allowed to
+// "break out" of the 680px reading column to the wider measure (matches the
+// editorial-site pattern of a narrow text column + wide media/data blocks).
+const BREAKOUT_TYPES = new Set(["diagram", "table", "code"]);
+
+function slugifyHeading(text, i) {
+  return "h-" + i + "-" + String(text).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "").slice(0, 40);
+}
+
+function ArticleBody({ blocks }) {
+  return (
+    <>
+      {blocks.map((b, i) => {
+        const wide = BREAKOUT_TYPES.has(b.type);
+        let node = null;
+        if (b.type === "p") node = <ProseP key={i}>{proseText(b.text)}</ProseP>;
+        else if (b.type === "h2") node = <ProseH2 key={i} id={slugifyHeading(b.text, i)}>{b.text}</ProseH2>;
+        else if (b.type === "h3") node = <ProseH3 key={i}>{b.text}</ProseH3>;
+        else if (b.type === "ul") node = <ProseUL key={i} items={b.items} />;
+        else if (b.type === "ol") node = <ProseOL key={i} items={b.items} />;
+        else if (b.type === "quote") node = <ProseQuote key={i} text={b.text} cite={b.cite} />;
+        else if (b.type === "hr") node = <ProseHR key={i} />;
+        else if (b.type === "table") node = <ProseTable key={i} head={b.head} rows={b.rows} />;
+        else if (b.type === "diagram") node = <DiagramFrame key={i} caption={b.caption} />;
+        else if (b.type === "code") node = <CodeBlock key={i} lang={b.lang} code={b.code} />;
+        if (!node) return null;
+        return wide ? <React.Fragment key={"w" + i}>{node}</React.Fragment> : <div key={i} className="ul-textcol">{node}</div>;
+      })}
+    </>
+  );
+}
+
+// TOC entries come straight from the article's own h2 blocks — no separate
+// outline to keep in sync.
+function articleHeadings(blocks) {
+  return blocks.map((b, i) => (b.type === "h2" ? { id: slugifyHeading(b.text, i), text: b.text } : null)).filter(Boolean);
+}
+
+// A demo-only synthetic date for articles the Tweaks panel "simulates" as
+// published (real unpublished posts have date: null and never appear here).
+function demoDate(order) {
+  const base = new Date("2026-07-13T00:00:00");
+  base.setDate(base.getDate() + (order - 1) * 6);
+  return base.toISOString().slice(0, 10);
+}
+
+// ── Index ──────────────────────────────────────────────────────────────────────
+function BlogIndex({ onOpen, published, pageSize }) {
+  const [activeSeries, setActiveSeries] = useStateScreens(null);
+  const [activeTag, setActiveTag] = useStateScreens(null);
+  const [shown, setShown] = useStateScreens(pageSize);
+
+  const sorted = [...published].sort((a, b) => (a.date < b.date ? 1 : -1));
+  const seriesList = [...new Set(sorted.map((a) => a.series).filter(Boolean))];
+  const filtered = sorted.filter((a) => (!activeSeries || a.series === activeSeries) && (!activeTag || a.tags.includes(activeTag)));
+  const tagList = [...new Set(filtered.length ? filtered.flatMap((a) => a.tags) : sorted.flatMap((a) => a.tags))].sort();
+  const visible = filtered.slice(0, shown);
+  const showFilters = sorted.length > 1 && (seriesList.length > 1 || tagList.length > 3);
+
+  return (
+    <div style={{ maxWidth: 1040, margin: "0 auto", padding: "56px 28px 80px" }}>
+      <div style={{ marginBottom: 40, maxWidth: 680 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: 1.4, textTransform: "uppercase", color: N.gold, marginBottom: 12 }}>Blog</div>
+        <h1 style={{ margin: "0 0 14px", fontSize: 38, fontWeight: 800, letterSpacing: -0.9, lineHeight: 1.1, color: N.fg }}>Building Ummah Library</h1>
+        <p style={{ margin: 0, fontSize: 16.5, lineHeight: 1.65, color: N.muted }}>
+          Ideas, architecture write-ups, and lessons from building Ummah Library in the open.
+        </p>
+      </div>
+      {showFilters && (
+        <FilterBar series={seriesList} activeSeries={activeSeries} onSeries={(s) => { setActiveSeries(s); setShown(pageSize); }}
+          tags={tagList} activeTag={activeTag} onTag={(t) => { setActiveTag(t); setShown(pageSize); }} />
+      )}
+      {visible.length === 0 ? (
+        <p style={{ fontSize: 15, color: N.muted }}>No posts match those filters.</p>
+      ) : (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))", gap: 18 }}>
+          {visible.map((a) => <ArticleCard key={a.slug} article={a} onOpen={onOpen} />)}
+        </div>
+      )}
+      {shown < filtered.length && <LoadMoreButton remaining={filtered.length - shown} pageSize={pageSize} onClick={() => setShown((s) => s + pageSize)} />}
+    </div>
+  );
+}
+
+// ── Article ─────────────────────────────────────────────────────────────────────
+function ArticlePage({ slug, onOpen, onIndex, published }) {
+  const article = published.find((a) => a.slug === slug) || published[0];
+  const mins = readMinutes(article.body);
+  // Prev/next are computed within the SAME series, ordered by publish date —
+  // a side with no neighbor (or a post with no series at all) simply hides.
+  const siblings = article.series
+    ? published.filter((a) => a.series === article.series).sort((a, b) => (a.date < b.date ? -1 : 1))
+    : [];
+  const idx = siblings.findIndex((a) => a.slug === article.slug);
+  const prev = idx > 0 ? siblings[idx - 1] : null;
+  const next = idx >= 0 && idx < siblings.length - 1 ? siblings[idx + 1] : null;
+  const headings = articleHeadings(article.body);
+
+  return (
+    <>
+      <ScrollProgress />
+      <div className="ul-article-shell">
+        <aside className="ul-toc-rail">
+          {headings.length > 1 && <div><ArticleTOC headings={headings} /></div>}
+        </aside>
+        <div className="ul-article-measure">
+          <div className="ul-textcol">
+            <button onClick={onIndex} className="ul-press ul-link" style={{ display: "inline-flex", alignItems: "center", gap: 7, background: "none", border: "none", cursor: "pointer", fontSize: 13.5, fontWeight: 600, color: N.muted, fontFamily: N.ui, marginBottom: 22, padding: 0 }}>
+              <Icon name="arrowL" size={15} color={N.muted} /> All posts
+            </button>
+            {article.series && <div style={{ marginBottom: 14 }}><SeriesBadge series={article.series} /></div>}
+            <h1 style={{ margin: "0 0 16px", fontSize: 36, fontWeight: 800, letterSpacing: -0.7, lineHeight: 1.15, color: N.fg, fontFamily: N.ui }}>{article.title}</h1>
+            <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 8, marginBottom: 22, fontSize: 13.5, color: N.faint }}>
+              <span style={{ whiteSpace: "nowrap", fontWeight: 600, color: N.muted }}>Ummah Library</span>
+              <span aria-hidden="true">·</span>
+              <PostMeta date={article.date} mins={mins} style={{ fontSize: 13.5 }} />
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 40 }}>
+              {article.tags.map((t) => <TagPill key={t}>{t}</TagPill>)}
+            </div>
+          </div>
+          <ArticleBody blocks={article.body} />
+          <div className="ul-textcol">
+            <ContributeCallout />
+            <SeriesNav prev={prev} next={next} onOpen={onOpen} onIndex={onIndex} />
+          </div>
+        </div>
+        <div className="ul-toc-gutter" aria-hidden="true" />
+      </div>
+    </>
+  );
+}
+
+// ── App shell + tiny hash router ────────────────────────────────────────────────
+function parseHash() {
+  const h = (typeof location !== "undefined" && location.hash) || "";
+  const m = h.match(/^#\/blog\/(.+)$/);
+  if (m) return { view: "article", slug: decodeURIComponent(m[1]) };
+  return { view: "index" };
+}
+
+function BlogApp() {
+  const [route, setRoute] = useStateScreens(parseHash());
+  const [theme, setTheme] = useStateScreens((typeof localStorage !== "undefined" && localStorage.getItem("ul.appTheme")) || "obsidian");
+  const [t, setTweak] = useTweaks({ publishedCount: 2, pageSize: PAGE_SIZE_DEFAULT, extraTestPosts: 0 });
+
+  useEffectScreens(() => {
+    const onHash = () => setRoute(parseHash());
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
+
+  // Real rule: a post is published iff it has a date. The Tweaks slider only
+  // controls how many of the 12 *demo* articles simulate having one, so the
+  // low-count launch states are easy to preview.
+  const published = ARTICLES
+    .filter((a) => a.order <= t.publishedCount)
+    .map((a) => ({ ...a, date: a.date || demoDate(a.order) }))
+    .concat(generateTestArticles(t.extraTestPosts));
+
+  const goIndex = () => { location.hash = "#/blog"; window.scrollTo(0, 0); };
+  const goArticle = (slug) => { location.hash = "#/blog/" + slug; window.scrollTo(0, 0); };
+  const toggleTheme = () => {
+    const next = THEME_MODE[theme] === "dark" ? "ivory" : "obsidian";
+    applyAppTheme(next);
+    setTheme(next);
+  };
+
+  return (
+    <div style={{ minHeight: "100vh", display: "flex", flexDirection: "column", background: N.bg }}>
+      <BlogHeader page="blog" onNavigate={(v) => (v === "index" ? goIndex() : null)} theme={theme} onToggleTheme={toggleTheme} />
+      <div style={{ flex: 1 }}>
+        {route.view === "index"
+          ? <BlogIndex onOpen={goArticle} published={published} pageSize={t.pageSize} />
+          : <ArticlePage slug={route.slug} onOpen={goArticle} onIndex={goIndex} published={published} />}
+      </div>
+      <BlogFooter />
+      <TweaksPanel>
+        <TweakSection label="Demo publish state" />
+        <TweakSlider label="Posts published" value={t.publishedCount} min={1} max={12} step={1}
+          onChange={(v) => setTweak("publishedCount", v)} />
+        <TweakSlider label="Extra test posts" value={t.extraTestPosts} min={0} max={60} step={2}
+          onChange={(v) => setTweak("extraTestPosts", v)} />
+        <TweakSlider label="Posts per page" value={t.pageSize} min={2} max={12} step={1}
+          onChange={(v) => setTweak("pageSize", v)} />
+      </TweaksPanel>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<BlogApp />);

--- a/docs/design/noor-prototype-blog/blog/tweaks-panel.jsx
+++ b/docs/design/noor-prototype-blog/blog/tweaks-panel.jsx
@@ -1,0 +1,542 @@
+// @ds-adherence-ignore -- omelette starter scaffold (raw elements/hex/px by design)
+// Copied omelette starter. Re-running copy_starter_component with this kind overwrites this file with the latest version (page content is unaffected).
+
+/* BEGIN USAGE */
+// tweaks-panel.jsx
+// Reusable Tweaks shell + form-control helpers.
+// Exports (to window): useTweaks, TweaksPanel, TweakSection, TweakRow, TweakSlider,
+//   TweakToggle, TweakRadio, TweakSelect, TweakText, TweakNumber, TweakColor, TweakButton.
+//
+// Owns the host protocol (listens for __activate_edit_mode / __deactivate_edit_mode,
+// posts __edit_mode_available / __edit_mode_set_keys / __edit_mode_dismissed) so
+// individual prototypes don't re-roll it. Ships a consistent set of controls so you
+// don't hand-draw <input type="range">, segmented radios, steppers, etc.
+//
+// Usage (in an HTML file that loads React + Babel):
+//
+//   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+//     "primaryColor": "#D97757",
+//     "palette": ["#D97757", "#29261b", "#f6f4ef"],
+//     "fontSize": 16,
+//     "density": "regular",
+//     "dark": false
+//   }/*EDITMODE-END*/;
+//
+//   function App() {
+//     const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+//     return (
+//       <div style={{ fontSize: t.fontSize, color: t.primaryColor }}>
+//         Hello
+//         <TweaksPanel>
+//           <TweakSection label="Typography" />
+//           <TweakSlider label="Font size" value={t.fontSize} min={10} max={32} unit="px"
+//                        onChange={(v) => setTweak('fontSize', v)} />
+//           <TweakRadio  label="Density" value={t.density}
+//                        options={['compact', 'regular', 'comfy']}
+//                        onChange={(v) => setTweak('density', v)} />
+//           <TweakSection label="Theme" />
+//           <TweakColor  label="Primary" value={t.primaryColor}
+//                        options={['#D97757', '#2A6FDB', '#1F8A5B', '#7A5AE0']}
+//                        onChange={(v) => setTweak('primaryColor', v)} />
+//           <TweakColor  label="Palette" value={t.palette}
+//                        options={[['#D97757', '#29261b', '#f6f4ef'],
+//                                  ['#475569', '#0f172a', '#f1f5f9']]}
+//                        onChange={(v) => setTweak('palette', v)} />
+//           <TweakToggle label="Dark mode" value={t.dark}
+//                        onChange={(v) => setTweak('dark', v)} />
+//         </TweaksPanel>
+//       </div>
+//     );
+//   }
+//
+// TweakRadio is the segmented control for 2–3 short options (auto-falls-back to
+// TweakSelect past ~16/~10 chars per label); reach for TweakSelect directly when
+// options are many or long. For color tweaks always curate 3-4 options rather than
+// a free picker; an option can also be a whole 2–5 color palette (the stored value
+// is the array). The Tweak* controls are a floor, not a ceiling — build custom
+// controls inside the panel if a tweak calls for UI they don't cover.
+/* END USAGE */
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom right;
+    background:rgba(250,249,247,.78);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0;
+    scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.15) transparent}
+  .twk-body::-webkit-scrollbar{width:8px}
+  .twk-body::-webkit-scrollbar-track{background:transparent;margin:2px}
+  .twk-body::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15);border-radius:4px;
+    border:2px solid transparent;background-clip:content-box}
+  .twk-body::-webkit-scrollbar-thumb:hover{background:rgba(0,0,0,.25);
+    border:2px solid transparent;background-clip:content-box}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;
+    color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-val{color:rgba(41,38,27,.5);font-variant-numeric:tabular-nums}
+
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+
+  .twk-field{appearance:none;box-sizing:border-box;width:100%;min-width:0;height:26px;padding:0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;
+    background:rgba(255,255,255,.6);color:inherit;font:inherit;outline:none}
+  .twk-field:focus{border-color:rgba(0,0,0,.25);background:rgba(255,255,255,.85)}
+  select.twk-field{padding-right:22px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(0,0,0,.5)' d='M0 0h10L5 6z'/></svg>");
+    background-repeat:no-repeat;background-position:right 8px center}
+
+  .twk-slider{appearance:none;-webkit-appearance:none;width:100%;height:4px;margin:6px 0;
+    border-radius:999px;background:rgba(0,0,0,.12);outline:none}
+  .twk-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
+    width:14px;height:14px;border-radius:50%;background:#fff;
+    border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+  .twk-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;
+    background:#fff;border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+
+  .twk-seg{position:relative;display:flex;padding:2px;border-radius:8px;
+    background:rgba(0,0,0,.06);user-select:none}
+  .twk-seg-thumb{position:absolute;top:2px;bottom:2px;border-radius:6px;
+    background:rgba(255,255,255,.9);box-shadow:0 1px 2px rgba(0,0,0,.12);
+    transition:left .15s cubic-bezier(.3,.7,.4,1),width .15s}
+  .twk-seg.dragging .twk-seg-thumb{transition:none}
+  .twk-seg button{appearance:none;position:relative;z-index:1;flex:1;border:0;
+    background:transparent;color:inherit;font:inherit;font-weight:500;min-height:22px;
+    border-radius:6px;cursor:default;padding:4px 6px;line-height:1.2;
+    overflow-wrap:anywhere}
+
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+
+  .twk-num{display:flex;align-items:center;box-sizing:border-box;min-width:0;height:26px;padding:0 0 0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;background:rgba(255,255,255,.6)}
+  .twk-num-lbl{font-weight:500;color:rgba(41,38,27,.6);cursor:ew-resize;
+    user-select:none;padding-right:8px}
+  .twk-num input{flex:1;min-width:0;height:100%;border:0;background:transparent;
+    font:inherit;font-variant-numeric:tabular-nums;text-align:right;padding:0 8px 0 0;
+    outline:none;color:inherit;-moz-appearance:textfield}
+  .twk-num input::-webkit-inner-spin-button,.twk-num input::-webkit-outer-spin-button{
+    -webkit-appearance:none;margin:0}
+  .twk-num-unit{padding-right:8px;color:rgba(41,38,27,.45)}
+
+  .twk-btn{appearance:none;height:26px;padding:0 12px;border:0;border-radius:7px;
+    background:rgba(0,0,0,.78);color:#fff;font:inherit;font-weight:500;cursor:default}
+  .twk-btn:hover{background:rgba(0,0,0,.88)}
+  .twk-btn.secondary{background:rgba(0,0,0,.06);color:inherit}
+  .twk-btn.secondary:hover{background:rgba(0,0,0,.1)}
+
+  .twk-swatch{appearance:none;-webkit-appearance:none;width:56px;height:22px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:6px;padding:0;cursor:default;
+    background:transparent;flex-shrink:0}
+  .twk-swatch::-webkit-color-swatch-wrapper{padding:0}
+  .twk-swatch::-webkit-color-swatch{border:0;border-radius:5.5px}
+  .twk-swatch::-moz-color-swatch{border:0;border-radius:5.5px}
+
+  .twk-chips{display:flex;gap:6px}
+  .twk-chip{position:relative;appearance:none;flex:1;min-width:0;height:46px;
+    padding:0;border:0;border-radius:6px;overflow:hidden;cursor:default;
+    box-shadow:0 0 0 .5px rgba(0,0,0,.12),0 1px 2px rgba(0,0,0,.06);
+    transition:transform .12s cubic-bezier(.3,.7,.4,1),box-shadow .12s}
+  .twk-chip:hover{transform:translateY(-1px);
+    box-shadow:0 0 0 .5px rgba(0,0,0,.18),0 4px 10px rgba(0,0,0,.12)}
+  .twk-chip[data-on="1"]{box-shadow:0 0 0 1.5px rgba(0,0,0,.85),
+    0 2px 6px rgba(0,0,0,.15)}
+  .twk-chip>span{position:absolute;top:0;bottom:0;right:0;width:34%;
+    display:flex;flex-direction:column;box-shadow:-1px 0 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i{flex:1;box-shadow:0 -1px 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i:first-child{box-shadow:none}
+  .twk-chip svg{position:absolute;top:6px;left:6px;width:13px;height:13px;
+    filter:drop-shadow(0 1px 1px rgba(0,0,0,.3))}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys → host rewrites the EDITMODE block on disk).
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  // Accepts either setTweak('key', value) or setTweak({ key: value, ... }) so a
+  // useState-style call doesn't write a "[object Object]" key into the persisted
+  // JSON block.
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null
+      ? keyOrEdits : { [keyOrEdits]: val };
+    setValues((prev) => ({ ...prev, ...edits }));
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits }, '*');
+    // Same-window signal so in-page listeners (deck-stage rail thumbnails)
+    // can react — the parent message only reaches the host, not peers.
+    window.dispatchEvent(new CustomEvent('tweakchange', { detail: edits }));
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell. Registers the protocol listener BEFORE announcing
+// availability — if the announce ran first, the host's activate could land
+// before our handler exists and the toolbar toggle would silently no-op.
+// The close button posts __edit_mode_dismissed so the host's toolbar toggle
+// flips off in lockstep; the host echoes __deactivate_edit_mode back which
+// is what actually hides the panel.
+function TweaksPanel({ title = 'Tweaks', children }) {
+  const [open, setOpen] = React.useState(false);
+  const dragRef = React.useRef(null);
+  const offsetRef = React.useRef({ x: 16, y: 16 });
+  const PAD = 16;
+
+  const clampToViewport = React.useCallback(() => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const w = panel.offsetWidth, h = panel.offsetHeight;
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD);
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD);
+    offsetRef.current = {
+      x: Math.min(maxRight, Math.max(PAD, offsetRef.current.x)),
+      y: Math.min(maxBottom, Math.max(PAD, offsetRef.current.y)),
+    };
+    panel.style.right = offsetRef.current.x + 'px';
+    panel.style.bottom = offsetRef.current.y + 'px';
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    clampToViewport();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', clampToViewport);
+      return () => window.removeEventListener('resize', clampToViewport);
+    }
+    const ro = new ResizeObserver(clampToViewport);
+    ro.observe(document.documentElement);
+    return () => ro.disconnect();
+  }, [open, clampToViewport]);
+
+  React.useEffect(() => {
+    const onMsg = (e) => {
+      const t = e?.data?.type;
+      if (t === '__activate_edit_mode') setOpen(true);
+      else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  const dismiss = () => {
+    setOpen(false);
+    window.parent.postMessage({ type: '__edit_mode_dismissed' }, '*');
+  };
+
+  const onDragStart = (e) => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+    const move = (ev) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      };
+      clampToViewport();
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+  return (
+    <>
+      <style>{__TWEAKS_STYLE}</style>
+      <div ref={dragRef} className="twk-panel" data-omelette-chrome=""
+           style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
+        <div className="twk-hd" onMouseDown={onDragStart}>
+          <b>{title}</b>
+          <button className="twk-x" aria-label="Close tweaks"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={dismiss}>✕</button>
+        </div>
+        <div className="twk-body">
+          {children}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+function TweakSection({ label, children }) {
+  return (
+    <>
+      <div className="twk-sect">{label}</div>
+      {children}
+    </>
+  );
+}
+
+function TweakRow({ label, value, children, inline = false }) {
+  return (
+    <div className={inline ? 'twk-row twk-row-h' : 'twk-row'}>
+      <div className="twk-lbl">
+        <span>{label}</span>
+        {value != null && <span className="twk-val">{value}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+function TweakSlider({ label, value, min = 0, max = 100, step = 1, unit = '', onChange }) {
+  return (
+    <TweakRow label={label} value={`${value}${unit}`}>
+      <input type="range" className="twk-slider" min={min} max={max} step={step}
+             value={value} onChange={(e) => onChange(Number(e.target.value))} />
+    </TweakRow>
+  );
+}
+
+function TweakToggle({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <button type="button" className="twk-toggle" data-on={value ? '1' : '0'}
+              role="switch" aria-checked={!!value}
+              onClick={() => onChange(!value)}><i /></button>
+    </div>
+  );
+}
+
+function TweakRadio({ label, value, options, onChange }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  // The active value is read by pointer-move handlers attached for the lifetime
+  // of a drag — ref it so a stale closure doesn't fire onChange for every move.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  // Segments wrap mid-word once per-segment width runs out. The track is
+  // ~248px (280 panel − 28 body pad − 4 seg pad), each button loses 12px
+  // to its own padding, and 11.5px system-ui averages ~6.3px/char — so 2
+  // options fit ~16 chars each, 3 fit ~10. Past that (or >3 options), fall
+  // back to a dropdown rather than wrap.
+  const labelLen = (o) => String(typeof o === 'object' ? o.label : o).length;
+  const maxLen = options.reduce((m, o) => Math.max(m, labelLen(o)), 0);
+  const fitsAsSegments = maxLen <= ({ 2: 16, 3: 10 }[options.length] ?? 0);
+  if (!fitsAsSegments) {
+    // <select> emits strings — map back to the original option value so the
+    // fallback stays type-preserving (numbers, booleans) like the segment path.
+    const resolve = (s) => {
+      const m = options.find((o) => String(typeof o === 'object' ? o.value : o) === s);
+      return m === undefined ? s : typeof m === 'object' ? m.value : m;
+    };
+    return <TweakSelect label={label} value={value} options={options}
+                        onChange={(s) => onChange(resolve(s))} />;
+  }
+  const opts = options.map((o) => (typeof o === 'object' ? o : { value: o, label: o }));
+  const idx = Math.max(0, opts.findIndex((o) => o.value === value));
+  const n = opts.length;
+
+  const segAt = (clientX) => {
+    const r = trackRef.current.getBoundingClientRect();
+    const inner = r.width - 4;
+    const i = Math.floor(((clientX - r.left - 2) / inner) * n);
+    return opts[Math.max(0, Math.min(n - 1, i))].value;
+  };
+
+  const onPointerDown = (e) => {
+    setDragging(true);
+    const v0 = segAt(e.clientX);
+    if (v0 !== valueRef.current) onChange(v0);
+    const move = (ev) => {
+      if (!trackRef.current) return;
+      const v = segAt(ev.clientX);
+      if (v !== valueRef.current) onChange(v);
+    };
+    const up = () => {
+      setDragging(false);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  return (
+    <TweakRow label={label}>
+      <div ref={trackRef} role="radiogroup" onPointerDown={onPointerDown}
+           className={dragging ? 'twk-seg dragging' : 'twk-seg'}>
+        <div className="twk-seg-thumb"
+             style={{ left: `calc(2px + ${idx} * (100% - 4px) / ${n})`,
+                      width: `calc((100% - 4px) / ${n})` }} />
+        {opts.map((o) => (
+          <button key={o.value} type="button" role="radio" aria-checked={o.value === value}>
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakSelect({ label, value, options, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <select className="twk-field" value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => {
+          const v = typeof o === 'object' ? o.value : o;
+          const l = typeof o === 'object' ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </TweakRow>
+  );
+}
+
+function TweakText({ label, value, placeholder, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <input className="twk-field" type="text" value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </TweakRow>
+  );
+}
+
+function TweakNumber({ label, value, min, max, step = 1, unit = '', onChange }) {
+  const clamp = (n) => {
+    if (min != null && n < min) return min;
+    if (max != null && n > max) return max;
+    return n;
+  };
+  const startRef = React.useRef({ x: 0, val: 0 });
+  const onScrubStart = (e) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, val: value };
+    const decimals = (String(step).split('.')[1] || '').length;
+    const move = (ev) => {
+      const dx = ev.clientX - startRef.current.x;
+      const raw = startRef.current.val + dx * step;
+      const snapped = Math.round(raw / step) * step;
+      onChange(clamp(Number(snapped.toFixed(decimals))));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+  return (
+    <div className="twk-num">
+      <span className="twk-num-lbl" onPointerDown={onScrubStart}>{label}</span>
+      <input type="number" value={value} min={min} max={max} step={step}
+             onChange={(e) => onChange(clamp(Number(e.target.value)))} />
+      {unit && <span className="twk-num-unit">{unit}</span>}
+    </div>
+  );
+}
+
+// Relative-luminance contrast pick — checkmarks drawn over a swatch need to
+// read on both #111 and #fafafa without per-option configuration. Hex input
+// only (#rgb / #rrggbb); named or rgb()/hsl() colors fall through to "light".
+function __twkIsLight(hex) {
+  const h = String(hex).replace('#', '');
+  const x = h.length === 3 ? h.replace(/./g, (c) => c + c) : h.padEnd(6, '0');
+  const n = parseInt(x.slice(0, 6), 16);
+  if (Number.isNaN(n)) return true;
+  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
+  return r * 299 + g * 587 + b * 114 > 148000;
+}
+
+const __TwkCheck = ({ light }) => (
+  <svg viewBox="0 0 14 14" aria-hidden="true">
+    <path d="M3 7.2 5.8 10 11 4.2" fill="none" strokeWidth="2.2"
+          strokeLinecap="round" strokeLinejoin="round"
+          stroke={light ? 'rgba(0,0,0,.78)' : '#fff'} />
+  </svg>
+);
+
+// TweakColor — curated color/palette picker. Each option is either a single
+// hex string or an array of 1-5 hex strings; the card adapts — a lone color
+// renders solid, a palette renders colors[0] as the hero (left ~2/3) with the
+// rest stacked in a sharp column on the right. onChange emits the
+// option in the shape it was passed (string stays string, array stays array).
+// Without options it falls back to the native color input for back-compat.
+function TweakColor({ label, value, options, onChange }) {
+  if (!options || !options.length) {
+    return (
+      <div className="twk-row twk-row-h">
+        <div className="twk-lbl"><span>{label}</span></div>
+        <input type="color" className="twk-swatch" value={value}
+               onChange={(e) => onChange(e.target.value)} />
+      </div>
+    );
+  }
+  // Native <input type=color> emits lowercase hex per the HTML spec, so
+  // compare case-insensitively. String() guards JSON.stringify(undefined),
+  // which returns the primitive undefined (no .toLowerCase).
+  const key = (o) => String(JSON.stringify(o)).toLowerCase();
+  const cur = key(value);
+  return (
+    <TweakRow label={label}>
+      <div className="twk-chips" role="radiogroup">
+        {options.map((o, i) => {
+          const colors = Array.isArray(o) ? o : [o];
+          const [hero, ...rest] = colors;
+          const sup = rest.slice(0, 4);
+          const on = key(o) === cur;
+          return (
+            <button key={i} type="button" className="twk-chip" role="radio"
+                    aria-checked={on} data-on={on ? '1' : '0'}
+                    aria-label={colors.join(', ')} title={colors.join(' · ')}
+                    style={{ background: hero }}
+                    onClick={() => onChange(o)}>
+              {sup.length > 0 && (
+                <span>
+                  {sup.map((c, j) => <i key={j} style={{ background: c }} />)}
+                </span>
+              )}
+              {on && <__TwkCheck light={__twkIsLight(hero)} />}
+            </button>
+          );
+        })}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakButton({ label, onClick, secondary = false }) {
+  return (
+    <button type="button" className={secondary ? 'twk-btn secondary' : 'twk-btn'}
+            onClick={onClick}>{label}</button>
+  );
+}
+
+Object.assign(window, {
+  useTweaks, TweaksPanel, TweakSection, TweakRow,
+  TweakSlider, TweakToggle, TweakRadio, TweakSelect,
+  TweakText, TweakNumber, TweakColor, TweakButton,
+});

--- a/docs/design/noor-prototype-blog/brand/logo.jsx
+++ b/docs/design/noor-prototype-blog/brand/logo.jsx
@@ -1,0 +1,39 @@
+/* Ummah Library — CANONICAL brand mark (Direction: Noor).
+   Single source of truth for the Khatam star + wordmark across app / mobile / web.
+   Load AFTER the design kit (so window.N exists) and before the screen scripts.
+   Exports Khatam + Logo to window.
+
+   Defaults read the live theme token window.N at render time, so the mark recolours
+   with the app's Dark/Light palettes. Pass an explicit `color` to override.
+
+   Brand color: gold #E6B855 (hi #F4D58A · dim #A98432 for light backgrounds).
+   The mark = two overlapped 56×56 squares (8-point khatam seal) + center dot. */
+
+// 8-point khatam star. stroke-only by default; filledDot for favicon/tiny sizes.
+function Khatam({ size = 120, color, sw = 1, opacity = 1, fill = "none", filledDot = false, style }) {
+  const c = color || (window.N && window.N.gold) || "#E6B855";
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 100" style={{ display: "block", opacity, ...style }} aria-hidden="true">
+      <rect x="22" y="22" width="56" height="56" fill={fill} stroke={c} strokeWidth={sw} />
+      <rect x="22" y="22" width="56" height="56" fill={fill} stroke={c} strokeWidth={sw} transform="rotate(45 50 50)" />
+      <circle cx="50" cy="50" r="11" fill={filledDot ? c : fill} stroke={c} strokeWidth={sw} />
+    </svg>
+  );
+}
+
+// Horizontal lockup: mark + "Ummah Library" wordmark.
+function Logo({ scale = 1, color, text, onClick, style }) {
+  const c = color || (window.N && window.N.gold) || "#E6B855";
+  const t = text || (window.N && window.N.fg) || "#F4F1EA";
+  return (
+    <div className={onClick ? "ul-link" : ""} onClick={onClick}
+      style={{ display: "flex", alignItems: "center", gap: 10 * scale, ...style }}>
+      <Khatam size={26 * scale} color={c} sw={2.2} />
+      <span style={{ fontWeight: 700, fontSize: 17 * scale, color: t, letterSpacing: 0.2 }}>
+        Ummah<span style={{ color: c, fontWeight: 600 }}> Library</span>
+      </span>
+    </div>
+  );
+}
+
+Object.assign(window, { Khatam, Logo });

--- a/docs/design/noor-prototype-blog/index.html
+++ b/docs/design/noor-prototype-blog/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Ummah Library — Blog</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=IBM+Plex+Sans+Arabic:wght@400;500;600;700&family=Source+Serif+4:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet" />
+<style>
+  html, body { margin: 0; padding: 0; }
+  code { font-family: ui-monospace, Menlo, monospace; }
+  a { color: var(--ul-gold); }
+  a:hover { color: var(--ul-goldHi); }
+  ::selection { background: var(--ul-goldSoft); }
+
+  /* Article layout: a 680px reading column for text, flanked by a sticky TOC
+     rail on the left and a matching empty gutter on the right so the column
+     stays visually centered rather than shifting toward the rail. The outer
+     measure column itself goes up to 920px — diagrams/tables/code use that
+     full width, while text blocks are capped at 680px within it. */
+  .ul-article-shell { display: flex; align-items: flex-start; gap: 40px; max-width: 1240px; margin: 0 auto; padding: 48px 24px 24px; }
+  .ul-toc-rail, .ul-toc-gutter { flex: 0 0 216px; display: none; }
+  .ul-toc-rail > div { position: sticky; top: 84px; }
+  .ul-article-measure { flex: 1 1 0%; max-width: 920px; margin: 0 auto; min-width: 0; }
+  .ul-textcol { max-width: 680px; margin: 0 auto; }
+  @media (min-width: 1220px) {
+    .ul-toc-rail, .ul-toc-gutter { display: block; }
+  }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<template id="__bundler_thumbnail" data-bg-color="#0A0B0F">
+  <svg viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+    <rect width="1200" height="800" fill="#0A0B0F"/>
+    <g transform="translate(600 400)" fill="none" stroke="#E6B855" stroke-width="9">
+      <rect x="-150" y="-150" width="300" height="300"/>
+      <rect x="-150" y="-150" width="300" height="300" transform="rotate(45)"/>
+      <circle cx="0" cy="0" r="62"/>
+    </g>
+  </svg>
+</template>
+<div id="root"></div>
+<script type="text/babel" src="mobile/kit.jsx" data-presets="react"></script>
+<script type="text/babel" src="brand/logo.jsx" data-presets="react"></script>
+<script src="blog/blogdata.js"></script>
+<script type="text/babel" src="blog/tweaks-panel.jsx" data-presets="react"></script>
+<script type="text/babel" src="blog/blogkit.jsx" data-presets="react"></script>
+<script type="text/babel" src="blog/blogscreens.jsx" data-presets="react"></script>
+</body>
+</html>

--- a/docs/design/noor-prototype-blog/mobile/kit.jsx
+++ b/docs/design/noor-prototype-blog/mobile/kit.jsx
@@ -1,0 +1,245 @@
+/* Ummah Library — Noor design kit (Obsidian & Gold).
+   Tokens, base CSS, Khatam motif, line-icon set, shared UI primitives.
+   App-wide Dark + Light theming via a mutable N object (so SVG strokes get hex)
+   plus CSS variables for global chrome. Exports: N, Khatam, Icon, Logo, Btn, Seg,
+   applyAppTheme, AppThemes. */
+
+// Curated full-app palettes. Each defines neutrals + the accent set (gold*),
+// the accent gradient (goldGrad) and the readable text on accent (ink). Tokenised
+// so a theme recolours the entire app — reader accents follow too. WCAG-conscious:
+// deep greys over pure black (except the AMOLED "Midnight" high-contrast option).
+const AppThemes = {
+  // ── DARK ──
+  obsidian: {
+    bg: "#0A0B0F", bg2: "#0E1017", card: "#14171F", cardHi: "#191D27",
+    border: "#242A38", borderSoft: "#1B2029", fg: "#F4F1EA", muted: "#9AA0B2",
+    faint: "#5C6273", gold: "#E6B855", goldHi: "#F4D58A", goldDim: "#A98432",
+    goldSoft: "rgba(230,184,85,0.12)", goldGrad: "linear-gradient(180deg,#F4D58A,#E6B855)", ink: "#1A1404",
+  },
+  midnight: {
+    bg: "#000000", bg2: "#060608", card: "#0C0D11", cardHi: "#14151B",
+    border: "#262830", borderSoft: "#16171D", fg: "#FFFFFF", muted: "#B7BBC7",
+    faint: "#6B707D", gold: "#F0C868", goldHi: "#FFE39A", goldDim: "#B9933F",
+    goldSoft: "rgba(240,200,104,0.15)", goldGrad: "linear-gradient(180deg,#FFE39A,#F0C868)", ink: "#15100A",
+  },
+  emerald: {
+    bg: "#07140E", bg2: "#0A1A12", card: "#0E2118", cardHi: "#13291E",
+    border: "#1F3A2C", borderSoft: "#16281E", fg: "#EFF4EE", muted: "#94AC9F",
+    faint: "#557064", gold: "#E3B756", goldHi: "#F2D184", goldDim: "#A07E32",
+    goldSoft: "rgba(227,183,86,0.13)", goldGrad: "linear-gradient(180deg,#F2D184,#E3B756)", ink: "#11200A",
+  },
+  ocean: {
+    bg: "#08121A", bg2: "#0C1822", card: "#102230", cardHi: "#15293A",
+    border: "#21384B", borderSoft: "#182838", fg: "#ECF2F6", muted: "#93A6B5",
+    faint: "#556979", gold: "#45C7BD", goldHi: "#74E2D9", goldDim: "#2C8A83",
+    goldSoft: "rgba(69,199,189,0.14)", goldGrad: "linear-gradient(180deg,#74E2D9,#45C7BD)", ink: "#04201D",
+  },
+  // ── LIGHT ──
+  ivory: {
+    bg: "#FAF6EE", bg2: "#F3ECDD", card: "#FFFFFF", cardHi: "#FBF6EC",
+    border: "#E7DECB", borderSoft: "#F0E9DA", fg: "#1F1B12", muted: "#6E6757",
+    faint: "#A99E86", gold: "#B0842A", goldHi: "#C99A3A", goldDim: "#CBB488",
+    goldSoft: "rgba(176,132,40,0.14)", goldGrad: "linear-gradient(180deg,#F4D58A,#E6B855)", ink: "#2A1F08",
+  },
+  sepia: {
+    bg: "#F3EAD8", bg2: "#ECE0C8", card: "#FBF4E3", cardHi: "#F4EAD3",
+    border: "#DECDA8", borderSoft: "#EADDC0", fg: "#3A2E1B", muted: "#6E5C3F",
+    faint: "#A0895F", gold: "#A6781E", goldHi: "#C2933A", goldDim: "#C8B07A",
+    goldSoft: "rgba(166,120,30,0.16)", goldGrad: "linear-gradient(180deg,#E7C572,#C99A3A)", ink: "#2A1E08",
+  },
+  mint: {
+    bg: "#F0F6F3", bg2: "#E4EFEA", card: "#FFFFFF", cardHi: "#F2F8F5",
+    border: "#D5E5DD", borderSoft: "#E6F0EB", fg: "#16241D", muted: "#5A6E64",
+    faint: "#93A89C", gold: "#13857A", goldHi: "#1BA192", goldDim: "#7FB3A9",
+    goldSoft: "rgba(19,133,122,0.13)", goldGrad: "linear-gradient(180deg,#2FB3A4,#13857A)", ink: "#EAFBF6",
+  },
+  rose: {
+    bg: "#FAF3F1", bg2: "#F1E5E2", card: "#FFFFFF", cardHi: "#FBF1EE",
+    border: "#ECD9D3", borderSoft: "#F4E6E2", fg: "#271A18", muted: "#6E5A56",
+    faint: "#AE968F", gold: "#B14A6B", goldHi: "#C76283", goldDim: "#C99AA6",
+    goldSoft: "rgba(177,74,107,0.12)", goldGrad: "linear-gradient(180deg,#CE6E8C,#B14A6B)", ink: "#FFF0F4",
+  },
+};
+// Picker metadata (order, label, mode, one-line description).
+const THEME_LIST = [
+  { key: "obsidian", label: "Obsidian", mode: "dark", desc: "Charcoal & gold" },
+  { key: "midnight", label: "Midnight", mode: "dark", desc: "True-black, high contrast" },
+  { key: "emerald", label: "Emerald", mode: "dark", desc: "Deep green & gold" },
+  { key: "ocean", label: "Ocean", mode: "dark", desc: "Slate & teal" },
+  { key: "ivory", label: "Ivory", mode: "light", desc: "Warm paper & gold" },
+  { key: "sepia", label: "Sepia", mode: "light", desc: "Parchment & amber" },
+  { key: "mint", label: "Mint", mode: "light", desc: "Cool light & teal" },
+  { key: "rose", label: "Rose", mode: "light", desc: "Soft light & rose" },
+];
+const THEME_MODE = THEME_LIST.reduce((m, t) => ((m[t.key] = t.mode), m), {});
+const __legacyTheme = { dark: "obsidian", light: "ivory" };
+
+const N = {
+  // neutrals/accent are filled by applyAppTheme() at load; obsidian defaults below.
+  bg: "#0A0B0F", bg2: "#0E1017", card: "#14171F", cardHi: "#191D27",
+  border: "#242A38", borderSoft: "#1B2029", fg: "#F4F1EA", muted: "#9AA0B2",
+  faint: "#5C6273", gold: "#E6B855", goldHi: "#F4D58A", goldDim: "#A98432",
+  goldSoft: "rgba(230,184,85,0.12)",
+  goldGrad: "linear-gradient(180deg, #F4D58A, #E6B855)",
+  ui: "'Hanken Grotesk', system-ui, sans-serif",
+  ar: "'IBM Plex Sans Arabic', serif",
+  ink: "#1A1404",
+};
+
+// Apply a theme: mutate N (for hex-based inline/SVG values, refreshed on re-render)
+// and set CSS variables on <html> (for the injected global chrome + var()-based consts).
+function applyAppTheme(name) {
+  name = __legacyTheme[name] || name;
+  if (!AppThemes[name]) name = "obsidian";
+  const t = AppThemes[name];
+  Object.assign(N, t);
+  if (typeof document !== "undefined") {
+    const r = document.documentElement;
+    Object.keys(t).forEach((k) => r.style.setProperty("--ul-" + k, t[k]));
+    r.dataset.theme = name;
+    r.dataset.mode = THEME_MODE[name] || "dark";
+    try { localStorage.setItem("ul.appTheme", name); } catch (e) {}
+  }
+  return name;
+}
+// initialise before first render (default obsidian; map any legacy value)
+const __rawTheme = (typeof localStorage !== "undefined" && localStorage.getItem("ul.appTheme")) || "obsidian";
+applyAppTheme(__rawTheme);
+
+// One-time base CSS + font scale variables + responsive helpers. Uses CSS vars so
+// the global chrome (body, scrollbar, selection) re-themes instantly.
+if (typeof document !== "undefined" && !document.getElementById("ul-base")) {
+  const s = document.createElement("style");
+  s.id = "ul-base";
+  s.textContent = `
+    :root { --ar-scale: 1; --tr-show: block; }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: var(--ul-bg); }
+    body { font-family: 'Hanken Grotesk', system-ui, sans-serif; color: var(--ul-fg); -webkit-font-smoothing: antialiased; }
+    ::selection { background: var(--ul-goldSoft); }
+    .ul-scroll { scrollbar-width: thin; scrollbar-color: var(--ul-border) transparent; }
+    .ul-scroll::-webkit-scrollbar { width: 10px; height: 10px; }
+    .ul-scroll::-webkit-scrollbar-thumb { background: var(--ul-border); border-radius: 6px; border: 3px solid var(--ul-bg); }
+    .ul-scroll::-webkit-scrollbar-track { background: transparent; }
+    .ul-ar { font-family: 'IBM Plex Sans Arabic', serif; direction: rtl; }
+    .ul-press { transition: transform .12s ease, opacity .15s ease; }
+    .ul-press:active { transform: scale(.97); }
+    .ul-link { cursor: pointer; }
+    /* Entrance: transform-only so content is ALWAYS visible (opacity stays 1)
+       even where the animation clock is frozen at frame 0 (preview/capture/print). */
+    .ul-fade { animation: ulFade .5s cubic-bezier(.2,.7,.2,1) both; }
+    @keyframes ulFade { from { transform: translateY(10px); } to { transform: none; } }
+    .ul-rise > * { animation: ulRise .55s cubic-bezier(.2,.7,.2,1) both; }
+    @keyframes ulRise { from { transform: translateY(16px); } to { transform: none; } }
+    @media (prefers-reduced-motion: reduce) { .ul-fade, .ul-rise > * { animation: none !important; } }
+    .ul-only-sm { display: none !important; }
+    @media (max-width: 760px) {
+      .ul-hide-sm { display: none !important; }
+      .ul-only-sm { display: revert !important; }
+    }
+    @media (max-width: 980px) { .ul-hide-md { display: none !important; } }
+  `;
+  document.head.appendChild(s);
+}
+
+// Khatam motif + Logo lockup now live in the canonical brand/logo.jsx
+// (loaded right after this kit). They read window.N so they still recolour
+// with the active theme. Do not redefine them here.
+
+// Line-icon set. stroke=currentColor, consistent 1.7 weight.
+const ICONS = {
+  search: "M11 4a7 7 0 1 0 0 14 7 7 0 0 0 0-14ZM20 20l-3.6-3.6",
+  play: null, // drawn as filled triangle below
+  pause: null,
+  heart: "M12 20s-7-4.3-9.2-8.4C1.2 8.3 2.6 5 6 5c2 0 3.2 1.3 4 2.5C10.8 6.3 12 5 14 5c3.4 0 4.8 3.3 3.2 6.6C19 15.7 12 20 12 20Z",
+  bookmark: "M6 4h12v16l-6-4-6 4V4Z",
+  share: "M16 6l-4-3-4 3M12 3v12M5 12v7a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-7",
+  settings: "M12 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6ZM19.4 13.5a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0v-.1A1.6 1.6 0 0 0 6.8 19.4l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0-1.1-2.7H3a2 2 0 1 1 0-4h.1A1.6 1.6 0 0 0 4.6 6.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3H9a1.6 1.6 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.6 1.6 0 0 0 1 1.5 1.6 1.6 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8V9a1.6 1.6 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1Z",
+  chevL: "M15 5l-7 7 7 7",
+  chevR: "M9 5l7 7-7 7",
+  chevD: "M5 9l7 7 7-7",
+  arrowR: "M5 12h14M13 6l6 6-6 6",
+  arrowL: "M19 12H5M11 6l-6 6 6 6",
+  menu: "M4 7h16M4 12h16M4 17h16",
+  close: "M6 6l12 12M18 6L6 18",
+  moon: "M20 14.5A8 8 0 0 1 9.5 4 7 7 0 1 0 20 14.5Z",
+  sun: "M12 17a5 5 0 1 0 0-10 5 5 0 0 0 0 10ZM12 1v3M12 20v3M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M1 12h3M20 12h3M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1",
+  bell: "M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.7 21a2 2 0 0 1-3.4 0",
+  hands: "M7 11V6a1.5 1.5 0 0 1 3 0v4M10 10V4.5a1.5 1.5 0 0 1 3 0V10M13 10V6a1.5 1.5 0 0 1 3 0v6c0 3-2 6-5.5 6S5 16 5 13v-1a1.5 1.5 0 0 1 3 0",
+  cal: "M4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6ZM4 9h16M8 3v3M16 3v3",
+  fire: "M12 3c1 3-1 5-1 5s4 1 4 6a5 5 0 1 1-10 0c0-2 1-3 1-3s0 2 2 2c0 0-1-4 4-10Z",
+  user: "M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8ZM4 21a8 8 0 0 1 16 0",
+  route: "M6 19a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM18 11a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM9 16h6a3 3 0 0 0 3-3V11M6 13V8",
+  book: "M4 5a2 2 0 0 1 2-2h6v16H6a2 2 0 0 0-2 2V5ZM20 5a2 2 0 0 0-2-2h-6v16h6a2 2 0 0 1 2 2V5Z",
+  headphones: "M4 14v-2a8 8 0 0 1 16 0v2M4 14a2 2 0 0 1 2-2h0a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h0a2 2 0 0 1-2-2v-2ZM20 14a2 2 0 0 0-2-2h0a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h0a2 2 0 0 0 2-2v-2Z",
+  grid: "M4 4h7v7H4zM13 4h7v7h-7zM4 13h7v7H4zM13 13h7v7h-7z",
+  more: "M5 12h.01M12 12h.01M19 12h.01",
+  plus: "M12 5v14M5 12h14",
+  minus: "M5 12h14",
+  check: "M5 12l4.5 4.5L19 7",
+  compass: "M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20ZM15.5 8.5l-2 5-5 2 2-5 5-2Z",
+  layers: "M12 3l9 5-9 5-9-5 9-5ZM3 13l9 5 9-5",
+  repeat: "M4 9V7a2 2 0 0 1 2-2h12l-3-3M20 15v2a2 2 0 0 1-2 2H6l3 3",
+  download: "M12 3v12M8 11l4 4 4-4M5 21h14",
+  home: "M4 11l8-7 8 7v8a1 1 0 0 1-1 1h-4v-6h-6v6H5a1 1 0 0 1-1-1v-8Z",
+  star: "M12 3l2.6 5.3 5.9.9-4.3 4.1 1 5.8L12 16.9 6.8 19.2l1-5.8L3.5 9.2l5.9-.9L12 3Z",
+  eye: "M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7ZM12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z",
+  tafsir: "M5 4h11a3 3 0 0 1 3 3v13H8a3 3 0 0 0-3 3V4ZM9 8h7M9 12h7",
+  globe: "M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20ZM2 12h20M12 2c3 3 3 17 0 20M12 2c-3 3-3 17 0 20",
+  type: "M5 7V5h14v2M9 19h6M12 5v14",
+};
+
+function Icon({ name, size = 20, sw = 1.7, color = "currentColor", style }) {
+  const base = { width: size, height: size, display: "block", ...style };
+  if (name === "play") return (
+    <svg viewBox="0 0 24 24" style={base} aria-hidden="true"><path d="M7 4.5v15l13-7.5-13-7.5Z" fill={color} /></svg>
+  );
+  if (name === "pause") return (
+    <svg viewBox="0 0 24 24" style={base} aria-hidden="true"><rect x="6" y="4.5" width="4" height="15" rx="1" fill={color} /><rect x="14" y="4.5" width="4" height="15" rx="1" fill={color} /></svg>
+  );
+  const d = ICONS[name] || "";
+  return (
+    <svg viewBox="0 0 24 24" style={base} fill="none" stroke={color} strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d={d} />
+    </svg>
+  );
+}
+
+function Btn({ children, variant = "gold", size = "md", onClick, style, icon }) {
+  const sizes = { sm: { p: "8px 14px", fs: 13.5, r: 9 }, md: { p: "12px 22px", fs: 15, r: 11 }, lg: { p: "15px 30px", fs: 16, r: 12 } };
+  const z = sizes[size];
+  const variants = {
+    gold: { background: N.goldGrad, color: N.ink, border: "1px solid transparent", fontWeight: 700 },
+    ghost: { background: N.card, color: N.fg, border: `1px solid ${N.border}`, fontWeight: 600 },
+    soft: { background: N.goldSoft, color: N.gold, border: `1px solid ${N.gold}`, fontWeight: 600 },
+    quiet: { background: "transparent", color: N.muted, border: "1px solid transparent", fontWeight: 600 },
+  };
+  return (
+    <button className="ul-press ul-link" onClick={onClick} style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 9, padding: z.p, borderRadius: z.r, fontSize: z.fs, fontFamily: N.ui, cursor: "pointer", whiteSpace: "nowrap", ...variants[variant], ...style }}>
+      {icon && <Icon name={icon} size={z.fs + 3} sw={1.8} />}
+      {children}
+    </button>
+  );
+}
+
+// Segmented control (e.g. Verse / Reading / Mushaf)
+function Seg({ options, value, onChange, size = "md" }) {
+  const pad = size === "sm" ? "6px 12px" : "8px 15px";
+  const fs = size === "sm" ? 13 : 14;
+  return (
+    <div style={{ display: "flex", borderRadius: 10, border: `1px solid ${N.border}`, overflow: "hidden", background: N.card }}>
+      {options.map((o) => {
+        const v = typeof o === "string" ? o : o.value;
+        const label = typeof o === "string" ? o : o.label;
+        const active = v === value;
+        return (
+          <button key={v} className="ul-press ul-link" onClick={() => onChange(v)} style={{ padding: pad, fontSize: fs, fontFamily: N.ui, fontWeight: active ? 700 : 500, color: active ? N.ink : N.muted, background: active ? N.gold : "transparent", border: "none", cursor: "pointer", whiteSpace: "nowrap" }}>
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+Object.assign(window, { N, Icon, Btn, Seg, applyAppTheme, AppThemes, THEME_LIST, THEME_MODE });


### PR DESCRIPTION
## Summary
- Vendors the Noor blog/article design at `docs/design/noor-prototype-blog/`, in the same served-Babel-in-browser format as the existing `noor-prototype` and `noor-prototype-mobile` reference snapshots.
- Reference only — nothing here is built, bundled, or imported by `apps/web`.
- Adds the new directory to `.prettierignore`, matching the two existing snapshots.

## Details
Covers the engineering blog index and article page: standalone editorial header (no app sidebar), series/tag filtering, "Load more" pagination, full prose set (headings, lists, blockquote, table, code block with copy + syntax highlighting, diagram frame for Mermaid), inline Arabic-term treatment, reading time, scroll progress, contribute callout, and series prev/next navigation.

The implementation plan for turning this into the real `/blog` route — including two things the design mockup gets wrong that must not ship as-is (invented article slugs/placeholder body text, and a wrong GitHub org URL) — is tracked in #226.

## Test plan
- [x] Verified locally by serving the directory (`npx serve docs/design/noor-prototype-blog`) and confirming every file the loader references resolves (200) and the root page loads.
- [ ] CI (lint/typecheck/test/build) — expected to pass untouched, since `docs/design/**` is eslint-ignored and this snapshot is prettier-ignored and not referenced by any app code.