### PR TITLE
feat(web): implement the engineering blog (/blog)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,9 +18,17 @@
     "@ummahlibrary/api": "workspace:*",
     "@ummahlibrary/core": "workspace:*",
     "@ummahlibrary/ui": "workspace:*",
+    "gray-matter": "^4.0.3",
+    "mdast-util-to-string": "^4.0.0",
+    "mermaid": "^11.16.0",
     "next": "^15.1.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "remark-directive": "^4.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { N } from "@ummahlibrary/ui";
+import {
+  getArticleBySlug,
+  getPublishedArticles,
+  getSeriesNeighbors,
+} from "../../../lib/blog/articles";
+import { SITE_URL } from "../../../lib/site";
+import { ArticleBody } from "../../../components/blog/ArticleBody";
+import { ArticleTOC } from "../../../components/blog/ArticleTOC";
+import { ContributeCallout } from "../../../components/blog/ContributeCallout";
+import { PostMeta } from "../../../components/blog/PostMeta";
+import { ScrollProgress } from "../../../components/blog/ScrollProgress";
+import { SeriesBadge } from "../../../components/blog/SeriesBadge";
+import { SeriesNav } from "../../../components/blog/SeriesNav";
+import { TagPill } from "../../../components/blog/TagPill";
+
+// Only published articles (a real `date` AND `status: "published"`) ever get
+// a page here — everything else has no static param and no route at all, so
+// a draft can never be reached by URL, guessed or otherwise (ADR 0037).
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getPublishedArticles().map((a) => ({ slug: a.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const article = getArticleBySlug(slug);
+  if (!article) return { title: "Not found" };
+  const url = `/blog/${article.slug}`;
+  return {
+    title: article.title,
+    description: article.description,
+    alternates: { canonical: url },
+    openGraph: { title: article.title, description: article.description, url, type: "article" },
+    twitter: { card: "summary", title: article.title, description: article.description },
+  };
+}
+
+export default async function ArticlePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const article = getArticleBySlug(slug);
+  if (!article) notFound();
+
+  const published = getPublishedArticles();
+  const { prev, next } = getSeriesNeighbors(article, published);
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: article.title,
+    description: article.description,
+    datePublished: article.date,
+    author: { "@type": "Organization", name: "Ummah Library" },
+    url: `${SITE_URL}/blog/${article.slug}`,
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ScrollProgress />
+      <div className="ul-blog-article-shell">
+        <aside className="ul-blog-toc-rail">
+          {article.headings.length > 1 && (
+            <div>
+              <ArticleTOC headings={article.headings} />
+            </div>
+          )}
+        </aside>
+        <div className="ul-blog-article-measure">
+          <div className="ul-blog-textcol">
+            {article.series && (
+              <div style={{ marginBottom: 14 }}>
+                <SeriesBadge series={article.series} />
+              </div>
+            )}
+            <h1
+              style={{
+                margin: "0 0 16px",
+                fontSize: 36,
+                fontWeight: 800,
+                letterSpacing: -0.7,
+                lineHeight: 1.15,
+                color: N.fg,
+                fontFamily: N.ui,
+              }}
+            >
+              {article.title}
+            </h1>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                flexWrap: "wrap",
+                gap: 8,
+                marginBottom: 22,
+                fontSize: 13.5,
+                color: N.faint,
+              }}
+            >
+              <span style={{ whiteSpace: "nowrap", fontWeight: 600, color: N.muted }}>
+                Ummah Library
+              </span>
+              <span aria-hidden="true">·</span>
+              <PostMeta
+                date={article.date!}
+                mins={article.readingMinutes}
+                style={{ fontSize: 13.5 }}
+              />
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 40 }}>
+              {article.tags.map((t) => (
+                <TagPill key={t}>{t}</TagPill>
+              ))}
+            </div>
+          </div>
+          <ArticleBody blocks={article.blocks} />
+          <div className="ul-blog-textcol">
+            <ContributeCallout />
+            <SeriesNav prev={prev} next={next} />
+          </div>
+        </div>
+        <div className="ul-blog-toc-gutter" aria-hidden="true" />
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/blog/blog.css
+++ b/apps/web/src/app/blog/blog.css
@@ -1,0 +1,46 @@
+/* Blog-only layout (ADR 0037) — scoped to /blog via this segment's layout.tsx.
+   Mirrors docs/design/noor-prototype-blog/index.html's article measure rules. */
+
+.ul-blog-textcol {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+/* A 680px reading column for text, flanked by a sticky TOC rail on the left
+   and a matching empty gutter on the right so the column stays visually
+   centered rather than shifting toward the rail. The outer measure column
+   itself goes up to 920px — diagrams/tables/code use that full width, while
+   text blocks are capped at 680px within it. */
+.ul-blog-article-shell {
+  display: flex;
+  align-items: flex-start;
+  gap: 40px;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 48px 24px 24px;
+}
+
+.ul-blog-toc-rail,
+.ul-blog-toc-gutter {
+  flex: 0 0 216px;
+  display: none;
+}
+
+.ul-blog-toc-rail > div {
+  position: sticky;
+  top: 84px;
+}
+
+.ul-blog-article-measure {
+  flex: 1 1 0%;
+  max-width: 920px;
+  margin: 0 auto;
+  min-width: 0;
+}
+
+@media (min-width: 1220px) {
+  .ul-blog-toc-rail,
+  .ul-blog-toc-gutter {
+    display: block;
+  }
+}

--- a/apps/web/src/app/blog/layout.tsx
+++ b/apps/web/src/app/blog/layout.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import { Source_Serif_4 } from "next/font/google";
+import { BlogFooter } from "../../components/blog/BlogFooter";
+import { BlogHeader } from "../../components/blog/BlogHeader";
+import "./blog.css";
+
+const sourceSerif = Source_Serif_4({
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+  style: ["normal", "italic"],
+  variable: "--font-source-serif",
+  display: "swap",
+});
+
+export default function BlogLayout({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className={sourceSerif.variable}
+      style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
+    >
+      <BlogHeader />
+      <div style={{ flex: 1 }}>{children}</div>
+      <BlogFooter />
+    </div>
+  );
+}

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import { N } from "@ummahlibrary/ui";
+import { getPublishedArticles } from "../../lib/blog/articles";
+import { BlogIndexClient } from "../../components/blog/BlogIndexClient";
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description:
+    "Ideas, architecture write-ups, and lessons from building Ummah Library in the open.",
+  alternates: {
+    canonical: "/blog",
+    types: { "application/rss+xml": "/blog/rss.xml" },
+  },
+  openGraph: {
+    title: "Building Ummah Library",
+    description:
+      "Ideas, architecture write-ups, and lessons from building Ummah Library in the open.",
+    url: "/blog",
+    type: "website",
+  },
+};
+
+export default function BlogIndexPage() {
+  const articles = getPublishedArticles();
+
+  return (
+    <div style={{ maxWidth: 1040, margin: "0 auto", padding: "56px 28px 80px" }}>
+      <div style={{ marginBottom: 40, maxWidth: 680 }}>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: 1.4,
+            textTransform: "uppercase",
+            color: N.gold,
+            marginBottom: 12,
+          }}
+        >
+          Blog
+        </div>
+        <h1
+          style={{
+            margin: "0 0 14px",
+            fontSize: 38,
+            fontWeight: 800,
+            letterSpacing: -0.9,
+            lineHeight: 1.1,
+            color: N.fg,
+          }}
+        >
+          Building Ummah Library
+        </h1>
+        <p style={{ margin: 0, fontSize: 16.5, lineHeight: 1.65, color: N.muted }}>
+          Ideas, architecture write-ups, and lessons from building Ummah Library in the open.
+        </p>
+      </div>
+      <BlogIndexClient articles={articles} />
+    </div>
+  );
+}

--- a/apps/web/src/app/blog/rss.xml/route.ts
+++ b/apps/web/src/app/blog/rss.xml/route.ts
@@ -1,0 +1,14 @@
+import { getPublishedArticles } from "../../../lib/blog/articles";
+import { buildRssFeed } from "../../../lib/blog/feed";
+import { SITE_URL } from "../../../lib/site";
+
+// Prerendered at build time, like every other content route (ADR 0003) —
+// republishing an article means a rebuild, not a runtime request.
+export const dynamic = "force-static";
+
+export function GET() {
+  const xml = buildRssFeed(getPublishedArticles(), SITE_URL);
+  return new Response(xml, {
+    headers: { "Content-Type": "application/rss+xml; charset=utf-8" },
+  });
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { TOTAL_JUZ, TOTAL_PAGES_MADANI, TOTAL_SURAHS } from "@ummahlibrary/core";
+import { getPublishedArticles } from "../lib/blog/articles";
 import { SITE_URL } from "../lib/site";
 
 const BASE = SITE_URL;
@@ -21,10 +22,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/calendar",
     "/zakat",
     "/settings",
+    "/blog",
   ].map((path) => ({
     url: `${BASE}${path}`,
     changeFrequency: "monthly" as const,
     priority: path === "" ? 1 : 0.7,
+  }));
+
+  // Only published articles get a sitemap entry — an unpublished draft has no
+  // route to list (see ADR 0037).
+  const blogPosts = getPublishedArticles().map((a) => ({
+    url: `${BASE}/blog/${a.slug}`,
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
   }));
 
   const surahs = Array.from({ length: TOTAL_SURAHS }, (_, i) => ({
@@ -45,5 +55,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.5,
   }));
 
-  return [...staticRoutes, ...surahs, ...juz, ...pages];
+  return [...staticRoutes, ...blogPosts, ...surahs, ...juz, ...pages];
 }

--- a/apps/web/src/components/AppShellWrapper.tsx
+++ b/apps/web/src/components/AppShellWrapper.tsx
@@ -4,7 +4,7 @@ import { usePathname } from "next/navigation";
 import { AppShell } from "./shell/AppShell";
 
 /** Routes that render full-screen with their own layout (no shell). */
-const SHELL_EXCLUDED = ["/landing", "/surah"];
+const SHELL_EXCLUDED = ["/landing", "/surah", "/blog"];
 
 interface Props {
   children: ReactNode;

--- a/apps/web/src/components/blog/ArticleBody.test.tsx
+++ b/apps/web/src/components/blog/ArticleBody.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Block } from "../../lib/blog/blocks";
+import { ArticleBody } from "./ArticleBody";
+
+describe("ArticleBody", () => {
+  it("renders a paragraph with bold, italic, code and an Arabic term", () => {
+    const blocks: Block[] = [
+      {
+        type: "p",
+        text: [
+          "Plain ",
+          { bold: "bold" },
+          " ",
+          { italic: "italic" },
+          " ",
+          { code: "code" },
+          " ",
+          { ar: "قِبْلَة", translit: "qibla" },
+        ],
+      },
+    ];
+    render(<ArticleBody blocks={blocks} />);
+    expect(screen.getByText("bold").tagName).toBe("STRONG");
+    expect(screen.getByText("italic").tagName).toBe("EM");
+    expect(screen.getByText("code").tagName).toBe("CODE");
+    expect(screen.getByText("قِبْلَة")).toBeInTheDocument();
+    expect(screen.getByText("(qibla)")).toBeInTheDocument();
+  });
+
+  it("renders headings with the h2 anchor id", () => {
+    const blocks: Block[] = [{ type: "h2", text: "A Heading", id: "h-0-a-heading" }];
+    render(<ArticleBody blocks={blocks} />);
+    const heading = screen.getByRole("heading", { level: 2, name: "A Heading" });
+    expect(heading).toHaveAttribute("id", "h-0-a-heading");
+  });
+
+  it("renders lists, a quote with a citation, and a rule", () => {
+    const blocks: Block[] = [
+      { type: "ul", items: [["one"], ["two"]] },
+      { type: "quote", text: ["Quoted text."], cite: "A Source" },
+      { type: "hr" },
+    ];
+    render(<ArticleBody blocks={blocks} />);
+    expect(screen.getByText("one")).toBeInTheDocument();
+    expect(screen.getByText("two")).toBeInTheDocument();
+    expect(screen.getByText("A Source")).toBeInTheDocument();
+    expect(document.querySelector("hr")).toBeInTheDocument();
+  });
+
+  it("renders a table with head and rows", () => {
+    const blocks: Block[] = [{ type: "table", head: ["A", "B"], rows: [["1", "2"]] }];
+    render(<ArticleBody blocks={blocks} />);
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("renders a code block via CodeBlock", () => {
+    const blocks: Block[] = [{ type: "code", lang: "ts", code: "const x = 1;" }];
+    render(<ArticleBody blocks={blocks} />);
+    expect(screen.getByText("ts")).toBeInTheDocument();
+    expect(screen.getByText("Copy")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/blog/ArticleBody.tsx
+++ b/apps/web/src/components/blog/ArticleBody.tsx
@@ -1,0 +1,257 @@
+import { Fragment } from "react";
+import { N } from "@ummahlibrary/ui";
+import { BREAKOUT_BLOCK_TYPES, type Block, type Inline } from "../../lib/blog/blocks";
+import { CodeBlock } from "./CodeBlock";
+import { DiagramFrame } from "./DiagramFrame";
+
+const serif = "var(--font-source-serif), Georgia, serif";
+
+function ArTerm({ ar, translit }: { ar: string; translit: string }) {
+  return (
+    <bdi style={{ fontWeight: 600, color: N.fg, margin: "0 2px", fontFamily: N.ar }}>
+      {ar}
+      <span
+        style={{
+          fontFamily: N.ui,
+          fontStyle: "italic",
+          color: N.muted,
+          fontWeight: 400,
+          marginLeft: 5,
+        }}
+      >
+        ({translit})
+      </span>
+    </bdi>
+  );
+}
+
+function InlineCode({ children }: { children: string }) {
+  return (
+    <code
+      style={{
+        fontFamily: "ui-monospace, Menlo, monospace",
+        fontSize: "0.82em",
+        color: N.gold,
+        background: N.goldSoft,
+        borderRadius: 5,
+        padding: "2px 6px",
+      }}
+    >
+      {children}
+    </code>
+  );
+}
+
+function renderInline(text: Inline) {
+  return text.map((part, i) => {
+    if (typeof part === "string") return <Fragment key={i}>{part}</Fragment>;
+    if ("ar" in part) return <ArTerm key={i} ar={part.ar} translit={part.translit} />;
+    if ("code" in part) return <InlineCode key={i}>{part.code}</InlineCode>;
+    if ("bold" in part) return <strong key={i}>{part.bold}</strong>;
+    return <em key={i}>{part.italic}</em>;
+  });
+}
+
+function ProseP({ text }: { text: Inline }) {
+  return (
+    <p
+      style={{ fontSize: 19, lineHeight: 1.75, color: N.fg, margin: "0 0 26px", fontFamily: serif }}
+    >
+      {renderInline(text)}
+    </p>
+  );
+}
+
+function ProseH2({ text, id }: { text: string; id: string }) {
+  return (
+    <h2
+      id={id}
+      style={{
+        fontSize: 26,
+        fontWeight: 800,
+        letterSpacing: -0.4,
+        color: N.fg,
+        fontFamily: N.ui,
+        margin: "52px 0 18px",
+        scrollMarginTop: 84,
+      }}
+    >
+      {text}
+    </h2>
+  );
+}
+
+function ProseH3({ text }: { text: string }) {
+  return (
+    <h3
+      style={{
+        fontSize: 20,
+        fontWeight: 700,
+        letterSpacing: -0.2,
+        color: N.fg,
+        fontFamily: N.ui,
+        margin: "38px 0 14px",
+      }}
+    >
+      {text}
+    </h3>
+  );
+}
+
+function ProseList({ items, ordered }: { items: Inline[]; ordered: boolean }) {
+  const Tag = ordered ? "ol" : "ul";
+  return (
+    <Tag
+      style={{
+        margin: "0 0 26px",
+        padding: "0 0 0 24px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        fontFamily: serif,
+      }}
+    >
+      {items.map((item, i) => (
+        <li key={i} style={{ fontSize: 18, lineHeight: 1.65, color: N.fg }}>
+          {renderInline(item)}
+        </li>
+      ))}
+    </Tag>
+  );
+}
+
+function ProseQuote({ text, cite }: { text: Inline; cite?: string }) {
+  return (
+    <blockquote
+      style={{
+        margin: "0 0 26px",
+        padding: "20px 24px",
+        background: N.bg2,
+        borderLeft: `3px solid ${N.gold}`,
+        borderRadius: "0 10px 10px 0",
+      }}
+    >
+      <p
+        style={{
+          margin: 0,
+          fontSize: 18.5,
+          lineHeight: 1.65,
+          color: N.muted,
+          fontFamily: serif,
+          fontStyle: "italic",
+        }}
+      >
+        “{renderInline(text)}”
+      </p>
+      {cite && (
+        <div
+          style={{
+            marginTop: 12,
+            fontSize: 12.5,
+            fontWeight: 700,
+            letterSpacing: 0.6,
+            textTransform: "uppercase",
+            color: N.faint,
+            fontFamily: N.ui,
+          }}
+        >
+          {cite}
+        </div>
+      )}
+    </blockquote>
+  );
+}
+
+function ProseHR() {
+  return (
+    <hr style={{ border: "none", borderTop: `1px solid ${N.borderSoft}`, margin: "36px 0" }} />
+  );
+}
+
+function ProseTable({ head, rows }: { head: string[]; rows: string[][] }) {
+  return (
+    <div
+      style={{
+        margin: "0 0 24px",
+        background: N.card,
+        border: `1px solid ${N.border}`,
+        borderRadius: 16,
+        overflow: "hidden",
+      }}
+    >
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14.5 }}>
+        <thead>
+          <tr style={{ background: N.bg2 }}>
+            {head.map((h) => (
+              <th
+                key={h}
+                style={{
+                  textAlign: "left",
+                  padding: "11px 16px",
+                  fontSize: 11.5,
+                  fontWeight: 700,
+                  letterSpacing: 0.8,
+                  textTransform: "uppercase",
+                  color: N.faint,
+                  borderBottom: `1px solid ${N.border}`,
+                }}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              {r.map((c, j) => (
+                <td
+                  key={j}
+                  style={{
+                    padding: "12px 16px",
+                    color: j === 0 ? N.fg : N.muted,
+                    fontWeight: j === 0 ? 700 : 400,
+                    borderTop: `1px solid ${N.borderSoft}`,
+                    fontFamily: j === 0 ? "ui-monospace, Menlo, monospace" : N.ui,
+                  }}
+                >
+                  {c}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Maps a parsed article's blocks onto the prose component set (ADR 0037). */
+export function ArticleBody({ blocks }: { blocks: Block[] }) {
+  return (
+    <>
+      {blocks.map((b, i) => {
+        let node: React.ReactNode = null;
+        if (b.type === "p") node = <ProseP text={b.text} />;
+        else if (b.type === "h2") node = <ProseH2 text={b.text} id={b.id} />;
+        else if (b.type === "h3") node = <ProseH3 text={b.text} />;
+        else if (b.type === "ul") node = <ProseList items={b.items} ordered={false} />;
+        else if (b.type === "ol") node = <ProseList items={b.items} ordered={true} />;
+        else if (b.type === "quote") node = <ProseQuote text={b.text} cite={b.cite} />;
+        else if (b.type === "hr") node = <ProseHR />;
+        else if (b.type === "table") node = <ProseTable head={b.head} rows={b.rows} />;
+        else if (b.type === "diagram") node = <DiagramFrame code={b.code} caption={b.caption} />;
+        else if (b.type === "code") node = <CodeBlock lang={b.lang} code={b.code} />;
+
+        if (!node) return null;
+        return BREAKOUT_BLOCK_TYPES.has(b.type) ? (
+          <Fragment key={i}>{node}</Fragment>
+        ) : (
+          <div key={i} className="ul-blog-textcol">
+            {node}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/src/components/blog/ArticleCard.tsx
+++ b/apps/web/src/components/blog/ArticleCard.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { N } from "@ummahlibrary/ui";
+import type { Article } from "../../lib/blog/articles";
+import { PostMeta } from "./PostMeta";
+import { SeriesBadge } from "./SeriesBadge";
+import { TagPill } from "./TagPill";
+
+export function ArticleCard({ article }: { article: Article }) {
+  return (
+    <Link
+      href={`/blog/${article.slug}`}
+      style={{
+        background: N.card,
+        border: `1px solid ${N.border}`,
+        borderRadius: 16,
+        padding: 24,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        textDecoration: "none",
+        color: "inherit",
+      }}
+    >
+      {article.series && <SeriesBadge series={article.series} size="sm" />}
+      <div>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 19,
+            fontWeight: 800,
+            letterSpacing: -0.3,
+            lineHeight: 1.32,
+            color: N.fg,
+          }}
+        >
+          {article.title}
+        </h3>
+        <p style={{ margin: "9px 0 0", fontSize: 14.5, lineHeight: 1.6, color: N.muted }}>
+          {article.description}
+        </p>
+      </div>
+      <div style={{ flex: 1 }} />
+      <PostMeta date={article.date!} mins={article.readingMinutes} />
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {article.tags.slice(0, 5).map((t) => (
+          <TagPill key={t}>{t}</TagPill>
+        ))}
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/components/blog/ArticleTOC.tsx
+++ b/apps/web/src/components/blog/ArticleTOC.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useEffect, useState } from "react";
+import { N } from "@ummahlibrary/ui";
+import type { Heading } from "../../lib/blog/blocks";
+
+const SCROLL_PROBE_PX = 120;
+const SCROLL_OFFSET_PX = 84;
+
+export function ArticleTOC({ headings }: { headings: Heading[] }) {
+  const [active, setActive] = useState(headings[0]?.id);
+
+  useEffect(() => {
+    const onScroll = () => {
+      let current = headings[0]?.id;
+      for (const h of headings) {
+        const el = document.getElementById(h.id);
+        if (el && el.getBoundingClientRect().top - SCROLL_PROBE_PX <= 0) current = h.id;
+      }
+      setActive(current);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [headings]);
+
+  const jump = (id: string) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const top = el.getBoundingClientRect().top + window.pageYOffset - SCROLL_OFFSET_PX;
+    window.scrollTo({ top, behavior: "smooth" });
+  };
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      style={{ display: "flex", flexDirection: "column", gap: 2 }}
+    >
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: 1,
+          textTransform: "uppercase",
+          color: N.faint,
+          marginBottom: 10,
+        }}
+      >
+        On this page
+      </div>
+      {headings.map((h) => (
+        <button
+          key={h.id}
+          type="button"
+          onClick={() => jump(h.id)}
+          style={{
+            textAlign: "left",
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            fontFamily: N.ui,
+            padding: "6px 0 6px 12px",
+            borderLeft: `2px solid ${active === h.id ? N.gold : N.borderSoft}`,
+            fontSize: 13,
+            lineHeight: 1.4,
+            fontWeight: active === h.id ? 700 : 500,
+            color: active === h.id ? N.fg : N.faint,
+          }}
+        >
+          {h.text}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/components/blog/BlogFooter.tsx
+++ b/apps/web/src/components/blog/BlogFooter.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { N } from "@ummahlibrary/ui";
+
+export function BlogFooter() {
+  return (
+    <footer style={{ borderTop: `1px solid ${N.borderSoft}`, marginTop: 20 }}>
+      <div
+        style={{
+          maxWidth: 1040,
+          margin: "0 auto",
+          padding: "24px 28px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        <span style={{ fontSize: 13, color: N.faint }}>
+          © {new Date().getFullYear()} Ummah Library · Open source
+        </span>
+        <div style={{ display: "flex", gap: 18 }}>
+          <a
+            href="https://github.com/UmmahLibrary/ummah-library"
+            target="_blank"
+            rel="noreferrer"
+            style={{ fontSize: 13, color: N.muted, textDecoration: "none" }}
+          >
+            GitHub
+          </a>
+          <Link href="/" style={{ fontSize: 13, color: N.muted, textDecoration: "none" }}>
+            Open the app
+          </Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/src/components/blog/BlogHeader.tsx
+++ b/apps/web/src/components/blog/BlogHeader.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import { Logo, N } from "@ummahlibrary/ui";
+import { RssIcon } from "./RssIcon";
+
+/** Slim editorial header — no app sidebar/tool nav (the blog route is shell-excluded). */
+export function BlogHeader() {
+  return (
+    <header
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 20,
+        background: N.bg,
+        borderBottom: `1px solid ${N.borderSoft}`,
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1040,
+          margin: "0 auto",
+          height: 64,
+          display: "flex",
+          alignItems: "center",
+          gap: 28,
+          padding: "0 28px",
+        }}
+      >
+        <Link href="/blog" style={{ textDecoration: "none" }}>
+          <Logo scale={0.92} />
+        </Link>
+        <div style={{ flex: 1 }} />
+        <nav style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <Link
+            href="/blog"
+            style={{
+              fontFamily: N.ui,
+              fontSize: 14,
+              fontWeight: 700,
+              padding: "8px 12px",
+              borderRadius: 8,
+              color: N.gold,
+              textDecoration: "none",
+            }}
+          >
+            Blog
+          </Link>
+          <Link
+            href="/"
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              padding: "8px 12px",
+              borderRadius: 8,
+              color: N.muted,
+              textDecoration: "none",
+            }}
+          >
+            Open the app
+          </Link>
+        </nav>
+        <Link
+          href="/blog/rss.xml"
+          title="RSS feed"
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 10,
+            background: N.card,
+            border: `1px solid ${N.border}`,
+            display: "grid",
+            placeItems: "center",
+            color: N.muted,
+          }}
+        >
+          <RssIcon size={15} color={N.muted} />
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/blog/BlogIndexClient.test.tsx
+++ b/apps/web/src/components/blog/BlogIndexClient.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Article } from "../../lib/blog/articles";
+import { BlogIndexClient } from "./BlogIndexClient";
+
+function article(overrides: Partial<Article>): Article {
+  return {
+    slug: "slug",
+    title: "Title",
+    description: "Description",
+    tags: [],
+    series: null,
+    order: 1,
+    date: "2026-01-01",
+    status: "published",
+    blocks: [],
+    headings: [],
+    readingMinutes: 1,
+    file: "f.md",
+    ...overrides,
+  };
+}
+
+describe("BlogIndexClient", () => {
+  it("shows an empty state when there are no published articles", () => {
+    render(<BlogIndexClient articles={[]} />);
+    expect(screen.getByText("No posts yet — check back soon.")).toBeInTheDocument();
+  });
+
+  it("renders every article and hides the filter bar with too few series/tags", () => {
+    const articles = [
+      article({ slug: "a", title: "A", tags: ["x"] }),
+      article({ slug: "b", title: "B", tags: ["x"] }),
+    ];
+    render(<BlogIndexClient articles={articles} />);
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+    expect(screen.queryByText("All")).not.toBeInTheDocument();
+  });
+
+  it("filters by series and shows a no-match state", async () => {
+    const articles = [
+      article({ slug: "a", title: "A", series: "Series One" }),
+      article({ slug: "b", title: "B", series: "Series Two" }),
+    ];
+    render(<BlogIndexClient articles={articles} />);
+    await userEvent.click(screen.getByRole("button", { name: "Series Two" }));
+    expect(screen.queryByText("A")).not.toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Series One" }));
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.queryByText("B")).not.toBeInTheDocument();
+  });
+
+  it("paginates with Load more", async () => {
+    const articles = Array.from({ length: 9 }, (_, i) =>
+      article({ slug: `p${i}`, title: `Post ${i}`, series: i % 2 === 0 ? "S1" : "S2" }),
+    );
+    render(<BlogIndexClient articles={articles} />);
+    expect(screen.getByText("Post 0")).toBeInTheDocument();
+    expect(screen.queryByText("Post 8")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /Load 1 more/ }));
+    expect(screen.getByText("Post 8")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/blog/BlogIndexClient.tsx
+++ b/apps/web/src/components/blog/BlogIndexClient.tsx
@@ -1,0 +1,158 @@
+"use client";
+import { useMemo, useState } from "react";
+import { Btn, N } from "@ummahlibrary/ui";
+import type { Article } from "../../lib/blog/articles";
+import { getSeriesList, getTagList } from "../../lib/blog/selectors";
+import { ArticleCard } from "./ArticleCard";
+
+const PAGE_SIZE = 8;
+
+interface Props {
+  /** Published articles, newest first. */
+  articles: Article[];
+}
+
+export function BlogIndexClient({ articles }: Props) {
+  const [activeSeries, setActiveSeries] = useState<string | null>(null);
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [shown, setShown] = useState(PAGE_SIZE);
+
+  const seriesList = useMemo(() => getSeriesList(articles), [articles]);
+
+  const filtered = useMemo(
+    () =>
+      articles.filter(
+        (a) =>
+          (!activeSeries || a.series === activeSeries) &&
+          (!activeTag || a.tags.includes(activeTag)),
+      ),
+    [articles, activeSeries, activeTag],
+  );
+
+  const tagList = useMemo(
+    () => getTagList(filtered.length ? filtered : articles),
+    [filtered, articles],
+  );
+
+  const showFilters = articles.length > 1 && (seriesList.length > 1 || tagList.length > 3);
+  const visible = filtered.slice(0, shown);
+
+  if (articles.length === 0) {
+    return <p style={{ fontSize: 15, color: N.muted }}>No posts yet — check back soon.</p>;
+  }
+
+  return (
+    <>
+      {showFilters && (
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 28,
+          }}
+        >
+          {seriesList.length > 0 && (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+              <button
+                onClick={() => {
+                  setActiveSeries(null);
+                  setShown(PAGE_SIZE);
+                }}
+                style={{
+                  fontSize: 12.5,
+                  fontWeight: 600,
+                  color: !activeSeries ? N.ink : N.muted,
+                  background: !activeSeries ? N.gold : N.card,
+                  border: `1px solid ${!activeSeries ? N.gold : N.border}`,
+                  borderRadius: 999,
+                  padding: "6px 13px",
+                  cursor: "pointer",
+                  fontFamily: N.ui,
+                }}
+              >
+                All
+              </button>
+              {seriesList.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => {
+                    setActiveSeries(s);
+                    setShown(PAGE_SIZE);
+                  }}
+                  style={{
+                    fontSize: 12.5,
+                    fontWeight: 600,
+                    color: activeSeries === s ? N.ink : N.muted,
+                    background: activeSeries === s ? N.gold : N.card,
+                    border: `1px solid ${activeSeries === s ? N.gold : N.border}`,
+                    borderRadius: 999,
+                    padding: "6px 13px",
+                    cursor: "pointer",
+                    fontFamily: N.ui,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          )}
+          {tagList.length > 0 && (
+            <select
+              value={activeTag ?? ""}
+              onChange={(e) => {
+                setActiveTag(e.target.value || null);
+                setShown(PAGE_SIZE);
+              }}
+              style={{
+                fontSize: 12.5,
+                fontWeight: 600,
+                color: N.fg,
+                background: N.card,
+                border: `1px solid ${N.border}`,
+                borderRadius: 10,
+                padding: "7px 12px",
+                fontFamily: N.ui,
+                cursor: "pointer",
+                marginLeft: "auto",
+              }}
+            >
+              <option value="">All tags</option>
+              {tagList.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      )}
+
+      {visible.length === 0 ? (
+        <p style={{ fontSize: 15, color: N.muted }}>No posts match those filters.</p>
+      ) : (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+            gap: 18,
+          }}
+        >
+          {visible.map((a) => (
+            <ArticleCard key={a.slug} article={a} />
+          ))}
+        </div>
+      )}
+
+      {shown < filtered.length && (
+        <div style={{ display: "flex", justifyContent: "center", marginTop: 32 }}>
+          <Btn variant="ghost" onClick={() => setShown((s) => s + PAGE_SIZE)}>
+            Load {Math.min(filtered.length - shown, PAGE_SIZE)} more
+          </Btn>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/blog/CodeBlock.test.tsx
+++ b/apps/web/src/components/blog/CodeBlock.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CodeBlock, tokenizeCode } from "./CodeBlock";
+
+describe("tokenizeCode", () => {
+  it("splits keywords, strings and comments from plain text", () => {
+    const tokens = tokenizeCode('const x = "hi"; // note');
+    expect(tokens.map((t) => t.kind)).toEqual(["kw", "plain", "str", "plain", "com"]);
+  });
+});
+
+describe("CodeBlock", () => {
+  it("shows the language and copies the code to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<CodeBlock lang="ts" code="const x = 1;" />);
+    expect(screen.getByText("ts")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Copy"));
+    expect(writeText).toHaveBeenCalledWith("const x = 1;");
+    expect(await screen.findByText("Copied")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/blog/CodeBlock.tsx
+++ b/apps/web/src/components/blog/CodeBlock.tsx
@@ -1,0 +1,118 @@
+"use client";
+import { useState } from "react";
+import { N } from "@ummahlibrary/ui";
+
+type TokenKind = "plain" | "com" | "str" | "kw";
+interface Token {
+  kind: TokenKind;
+  text: string;
+}
+
+const TOKEN_RE =
+  /(\/\/[^\n]*|#[^\n]*)|("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`)|(\b(?:import|export|from|const|let|var|function|return|if|else|interface|type|extends|implements|class|new|async|await|throw|try|catch|public|private|readonly|default|as|typeof|instanceof|for|while|of|in|true|false|null|undefined|module|exports)\b)/g;
+
+/** A small regex tokenizer for keyword/string/comment coloring — no syntax-highlighter dependency. */
+export function tokenizeCode(code: string): Token[] {
+  const tokens: Token[] = [];
+  let last = 0;
+  let match: RegExpExecArray | null;
+  TOKEN_RE.lastIndex = 0;
+  while ((match = TOKEN_RE.exec(code))) {
+    if (match.index > last) tokens.push({ kind: "plain", text: code.slice(last, match.index) });
+    if (match[1]) tokens.push({ kind: "com", text: match[1] });
+    else if (match[2]) tokens.push({ kind: "str", text: match[2] });
+    else if (match[3]) tokens.push({ kind: "kw", text: match[3] });
+    last = TOKEN_RE.lastIndex;
+  }
+  if (last < code.length) tokens.push({ kind: "plain", text: code.slice(last) });
+  return tokens;
+}
+
+export function CodeBlock({ lang, code }: { lang: string; code: string }) {
+  const [copied, setCopied] = useState(false);
+  const tokens = tokenizeCode(code);
+  const colors: Record<TokenKind, string> = {
+    plain: N.fg,
+    com: N.faint,
+    str: N.goldHi,
+    kw: N.gold,
+  };
+
+  const copy = () => {
+    if (navigator.clipboard) navigator.clipboard.writeText(code).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1400);
+  };
+
+  return (
+    <div
+      style={{
+        margin: "0 0 24px",
+        borderRadius: 12,
+        overflow: "hidden",
+        border: `1px solid ${N.border}`,
+        background: N.bg2,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "9px 14px",
+          borderBottom: `1px solid ${N.borderSoft}`,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            color: N.faint,
+            fontFamily: "ui-monospace, Menlo, monospace",
+            textTransform: "uppercase",
+            letterSpacing: 0.6,
+          }}
+        >
+          {lang}
+        </span>
+        <button
+          onClick={copy}
+          type="button"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            color: copied ? N.gold : N.faint,
+            fontSize: 12,
+            fontWeight: 600,
+            fontFamily: N.ui,
+          }}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre style={{ margin: 0, padding: "16px 18px", overflowX: "auto" }}>
+        <code
+          style={{
+            fontFamily: "ui-monospace, Menlo, monospace",
+            fontSize: 13.5,
+            lineHeight: 1.7,
+            whiteSpace: "pre",
+          }}
+        >
+          {tokens.map((t, i) => (
+            <span
+              key={i}
+              style={{ color: colors[t.kind], fontStyle: t.kind === "com" ? "italic" : "normal" }}
+            >
+              {t.text}
+            </span>
+          ))}
+        </code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/src/components/blog/ContributeCallout.tsx
+++ b/apps/web/src/components/blog/ContributeCallout.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { Btn, Khatam, N } from "@ummahlibrary/ui";
+
+const CONTRIBUTING_URL = "https://github.com/UmmahLibrary/ummah-library/blob/main/CONTRIBUTING.md";
+
+export function ContributeCallout() {
+  return (
+    <div
+      style={{
+        margin: "40px 0",
+        borderRadius: 16,
+        padding: 28,
+        background: N.goldSoft,
+        border: `1px solid ${N.gold}`,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+        <Khatam size={20} color={N.gold} sw={1.8} />
+        <h3 style={{ margin: 0, fontSize: 18, fontWeight: 800, color: N.fg }}>
+          Contribute to Ummah Library
+        </h3>
+      </div>
+      <p
+        style={{
+          margin: "0 0 18px",
+          fontSize: 15,
+          lineHeight: 1.65,
+          color: N.muted,
+          maxWidth: 560,
+        }}
+      >
+        Ummah Library is open source. If this post left you with an opinion about the boundary, or
+        you&rsquo;re looking for a good first issue, we&rsquo;d welcome the pull request.
+      </p>
+      <Btn variant="gold" icon="arrowR" onClick={() => window.open(CONTRIBUTING_URL, "_blank")}>
+        Read CONTRIBUTING.md
+      </Btn>
+    </div>
+  );
+}

--- a/apps/web/src/components/blog/DiagramFrame.tsx
+++ b/apps/web/src/components/blog/DiagramFrame.tsx
@@ -1,0 +1,95 @@
+"use client";
+import { useEffect, useId, useState } from "react";
+import { Icon, N } from "@ummahlibrary/ui";
+
+/**
+ * Renders a Mermaid diagram inside the bordered "Diagram" chrome from the
+ * Noor blog design. Mermaid is browser-only, so rendering happens client-side
+ * in an effect; the dashed placeholder covers the loading state and the rare
+ * render failure (a malformed diagram never breaks the surrounding page).
+ */
+export function DiagramFrame({ code, caption }: { code: string; caption?: string }) {
+  const rawId = useId();
+  const diagramId = `mermaid-${rawId.replace(/[^a-zA-Z0-9]/g, "")}`;
+  const [svg, setSvg] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const mode = document.documentElement.dataset.mode === "light" ? "default" : "dark";
+    import("mermaid")
+      .then(async ({ default: mermaid }) => {
+        mermaid.initialize({ startOnLoad: false, theme: mode, securityLevel: "strict" });
+        const { svg: rendered } = await mermaid.render(diagramId, code);
+        if (!cancelled) setSvg(rendered);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, diagramId]);
+
+  return (
+    <div
+      style={{
+        margin: "0 0 24px",
+        background: N.card,
+        border: `1px solid ${N.border}`,
+        borderRadius: 16,
+        padding: 20,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 14,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 1.2,
+            textTransform: "uppercase",
+            color: N.faint,
+          }}
+        >
+          Diagram
+        </span>
+        <Icon name="grid" size={15} color={N.faint} />
+      </div>
+      {svg ? (
+        <div
+          role="img"
+          aria-label={caption ?? "Diagram"}
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
+      ) : (
+        <div
+          style={{
+            height: 180,
+            borderRadius: 10,
+            border: `1px dashed ${N.border}`,
+            background: `repeating-linear-gradient(135deg, ${N.bg2} 0px, ${N.bg2} 10px, transparent 10px, transparent 20px)`,
+            display: "grid",
+            placeItems: "center",
+            textAlign: "center",
+            padding: 16,
+          }}
+        >
+          <span
+            style={{ fontFamily: "ui-monospace, Menlo, monospace", fontSize: 12.5, color: N.faint }}
+          >
+            {failed
+              ? `[ diagram unavailable — ${caption ?? "see source"} ]`
+              : `[ rendering diagram${caption ? ` — ${caption}` : ""} ]`}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/blog/PostMeta.tsx
+++ b/apps/web/src/components/blog/PostMeta.tsx
@@ -1,0 +1,41 @@
+import type { CSSProperties } from "react";
+import { N } from "@ummahlibrary/ui";
+
+const dateFmt = new Intl.DateTimeFormat("en", { month: "short", day: "numeric", year: "numeric" });
+
+export function PublishDate({ date, style }: { date: string; style?: CSSProperties }) {
+  const d = new Date(`${date}T00:00:00`);
+  return (
+    <time dateTime={date} style={{ fontSize: 13, color: N.faint, whiteSpace: "nowrap", ...style }}>
+      {dateFmt.format(d)}
+    </time>
+  );
+}
+
+/** One small, muted meta line: publish date · reading time. */
+export function PostMeta({
+  date,
+  mins,
+  style,
+}: {
+  date: string;
+  mins: number;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 7,
+        fontSize: 13,
+        color: N.faint,
+        ...style,
+      }}
+    >
+      <PublishDate date={date} />
+      <span aria-hidden="true">·</span>
+      <span>{mins} min read</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/blog/RssIcon.tsx
+++ b/apps/web/src/components/blog/RssIcon.tsx
@@ -1,0 +1,19 @@
+/** A small RSS glyph — not in the app's shared Icon set (the app has no other feed). */
+export function RssIcon({ size = 16, color = "currentColor" }: { size?: number; color?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <circle cx="5.5" cy="18.5" r="1.8" fill={color} stroke="none" />
+      <path d="M4 11a9 9 0 0 1 9 9" />
+      <path d="M4 4.5A15.5 15.5 0 0 1 19.5 20" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/blog/ScrollProgress.tsx
+++ b/apps/web/src/components/blog/ScrollProgress.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect, useState } from "react";
+import { N } from "@ummahlibrary/ui";
+
+/** Thin reading-progress bar under the sticky header, filling as the reader scrolls the article. */
+export function ScrollProgress() {
+  const [pct, setPct] = useState(0);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const h = document.documentElement;
+      const max = h.scrollHeight - h.clientHeight;
+      setPct(max > 0 ? Math.min(100, (h.scrollTop / max) * 100) : 0);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, []);
+
+  return (
+    <div style={{ position: "sticky", top: 64, zIndex: 19, height: 3, background: N.borderSoft }}>
+      <div
+        style={{
+          height: "100%",
+          width: `${pct}%`,
+          background: N.goldGrad,
+          transition: "width 80ms linear",
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/blog/SeriesBadge.tsx
+++ b/apps/web/src/components/blog/SeriesBadge.tsx
@@ -1,0 +1,31 @@
+import { N } from "@ummahlibrary/ui";
+
+/** Renders nothing when the post has no series — a standalone post is a first-class case, not a fallback. */
+export function SeriesBadge({
+  series,
+  size = "md",
+}: {
+  series: string | null;
+  size?: "sm" | "md";
+}) {
+  if (!series) return null;
+  const fontSize = size === "sm" ? 11.5 : 12.5;
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        whiteSpace: "nowrap",
+        fontSize,
+        fontWeight: 700,
+        letterSpacing: 0.2,
+        color: N.gold,
+        background: N.goldSoft,
+        border: `1px solid ${N.gold}`,
+        borderRadius: 999,
+        padding: size === "sm" ? "4px 10px" : "5px 12px",
+      }}
+    >
+      {series}
+    </span>
+  );
+}

--- a/apps/web/src/components/blog/SeriesNav.test.tsx
+++ b/apps/web/src/components/blog/SeriesNav.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Article } from "../../lib/blog/articles";
+import { SeriesNav } from "./SeriesNav";
+
+function article(overrides: Partial<Article>): Article {
+  return {
+    slug: "slug",
+    title: "Title",
+    description: "D",
+    tags: [],
+    series: "S",
+    order: 1,
+    date: "2026-01-01",
+    status: "published",
+    blocks: [],
+    headings: [],
+    readingMinutes: 1,
+    file: "f.md",
+    ...overrides,
+  };
+}
+
+describe("SeriesNav", () => {
+  it("renders only the back-to-index link when neither neighbor exists", () => {
+    render(<SeriesNav prev={null} next={null} />);
+    expect(screen.getByText("← Back to all posts")).toBeInTheDocument();
+    expect(screen.queryByText("Previous in series")).not.toBeInTheDocument();
+    expect(screen.queryByText("Next in series")).not.toBeInTheDocument();
+  });
+
+  it("renders only prev when there is no next", () => {
+    render(<SeriesNav prev={article({ slug: "p", title: "Prev Post" })} next={null} />);
+    expect(screen.getByText("Prev Post")).toBeInTheDocument();
+    expect(screen.queryByText("Next in series")).not.toBeInTheDocument();
+  });
+
+  it("renders only next when there is no prev", () => {
+    render(<SeriesNav prev={null} next={article({ slug: "n", title: "Next Post" })} />);
+    expect(screen.getByText("Next Post")).toBeInTheDocument();
+    expect(screen.queryByText("Previous in series")).not.toBeInTheDocument();
+  });
+
+  it("renders both when both exist, each linking to the right slug", () => {
+    render(
+      <SeriesNav
+        prev={article({ slug: "prev-slug", title: "Prev Post" })}
+        next={article({ slug: "next-slug", title: "Next Post" })}
+      />,
+    );
+    expect(screen.getByText("Prev Post").closest("a")).toHaveAttribute("href", "/blog/prev-slug");
+    expect(screen.getByText("Next Post").closest("a")).toHaveAttribute("href", "/blog/next-slug");
+  });
+});

--- a/apps/web/src/components/blog/SeriesNav.tsx
+++ b/apps/web/src/components/blog/SeriesNav.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { Icon, N } from "@ummahlibrary/ui";
+import type { Article } from "../../lib/blog/articles";
+
+const cardStyle = {
+  background: N.card,
+  border: `1px solid ${N.border}`,
+  borderRadius: 16,
+  flex: 1,
+  padding: 16,
+  display: "flex" as const,
+  flexDirection: "column" as const,
+  gap: 6,
+  textDecoration: "none",
+  color: "inherit",
+};
+
+/**
+ * prev/next are each either an article or null — a missing neighbor renders no
+ * control at all (no dead link, no placeholder). If neither exists, only the
+ * "back to all posts" link shows.
+ */
+export function SeriesNav({ prev, next }: { prev: Article | null; next: Article | null }) {
+  return (
+    <div style={{ margin: "8px 0 40px", display: "flex", flexDirection: "column", gap: 14 }}>
+      {(prev || next) && (
+        <div style={{ display: "flex", gap: 14 }}>
+          {prev && (
+            <Link href={`/blog/${prev.slug}`} style={{ ...cardStyle, textAlign: "left" }}>
+              <span
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  color: N.faint,
+                  textTransform: "uppercase",
+                  letterSpacing: 0.6,
+                }}
+              >
+                <Icon name="arrowL" size={13} color={N.faint} />
+                Previous in series
+              </span>
+              <span style={{ fontSize: 14.5, fontWeight: 700, color: N.fg }}>{prev.title}</span>
+            </Link>
+          )}
+          {next && (
+            <Link
+              href={`/blog/${next.slug}`}
+              style={{ ...cardStyle, textAlign: "right", alignItems: "flex-end" }}
+            >
+              <span
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  color: N.faint,
+                  textTransform: "uppercase",
+                  letterSpacing: 0.6,
+                }}
+              >
+                Next in series
+                <Icon name="arrowR" size={13} color={N.faint} />
+              </span>
+              <span style={{ fontSize: 14.5, fontWeight: 700, color: N.fg }}>{next.title}</span>
+            </Link>
+          )}
+        </div>
+      )}
+      <Link
+        href="/blog"
+        style={{
+          alignSelf: "center",
+          fontSize: 13.5,
+          fontWeight: 600,
+          color: N.gold,
+          fontFamily: N.ui,
+          textDecoration: "none",
+        }}
+      >
+        ← Back to all posts
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/components/blog/TagPill.tsx
+++ b/apps/web/src/components/blog/TagPill.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import { N } from "@ummahlibrary/ui";
+
+export function TagPill({ children }: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        fontSize: 12,
+        fontWeight: 600,
+        color: N.muted,
+        background: N.card,
+        border: `1px solid ${N.border}`,
+        borderRadius: 999,
+        padding: "5px 11px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/shell/TopBar.test.tsx
+++ b/apps/web/src/components/shell/TopBar.test.tsx
@@ -24,4 +24,14 @@ describe("TopBar", () => {
 
     expect(push).toHaveBeenCalledWith("/search?q=mercy");
   });
+
+  it("links to the blog", () => {
+    render(
+      <SearchProvider>
+        <TopBar />
+      </SearchProvider>,
+    );
+
+    expect(screen.getByTitle("Read the blog")).toHaveAttribute("href", "/blog");
+  });
 });

--- a/apps/web/src/components/shell/TopBar.tsx
+++ b/apps/web/src/components/shell/TopBar.tsx
@@ -140,8 +140,31 @@ export function TopBar() {
         )}
       </form>
 
-      {/* Right: theme toggle + Hijri date + avatar */}
+      {/* Right: blog + theme toggle + Hijri date + avatar */}
       <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+        <Link
+          href="/blog"
+          title="Read the blog"
+          style={{
+            height: 40,
+            padding: "0 14px",
+            borderRadius: 11,
+            border: `1px solid ${N.border}`,
+            background: N.card,
+            color: N.muted,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            flexShrink: 0,
+            textDecoration: "none",
+            fontFamily: N.ui,
+            fontSize: 13.5,
+            fontWeight: 600,
+          }}
+        >
+          <Icon name="tafsir" size={17} />
+          <span className="noor-hide-sm">Blog</span>
+        </Link>
         <ThemeToggle />
         {hijriLabel && (
           <div className="noor-hide-sm" style={{ textAlign: "right", flexShrink: 0 }}>

--- a/apps/web/src/lib/blog/__fixtures__/duplicate-slug/one.md
+++ b/apps/web/src/lib/blog/__fixtures__/duplicate-slug/one.md
@@ -1,0 +1,12 @@
+---
+title: "One"
+description: "First file with a colliding slug."
+tags: ["x"]
+series: null
+order: 1
+date: "2026-01-01"
+canonical_url: "same-slug"
+status: "published"
+---
+
+Body one.

--- a/apps/web/src/lib/blog/__fixtures__/duplicate-slug/two.md
+++ b/apps/web/src/lib/blog/__fixtures__/duplicate-slug/two.md
@@ -1,0 +1,12 @@
+---
+title: "Two"
+description: "Second file with a colliding slug."
+tags: ["x"]
+series: null
+order: 2
+date: "2026-01-02"
+canonical_url: "same-slug"
+status: "published"
+---
+
+Body two.

--- a/apps/web/src/lib/blog/__fixtures__/valid/README.md
+++ b/apps/web/src/lib/blog/__fixtures__/valid/README.md
@@ -1,0 +1,3 @@
+# Fixture directory
+
+This mirrors the real `docs/articles/README.md` — it must never be treated as an article.

--- a/apps/web/src/lib/blog/__fixtures__/valid/dated-draft-post.md
+++ b/apps/web/src/lib/blog/__fixtures__/valid/dated-draft-post.md
@@ -1,0 +1,12 @@
+---
+title: "A Dated but Still Draft Post"
+description: "Has a date but status is still draft — must stay hidden."
+tags: ["draft"]
+series: null
+order: 201
+date: "2026-04-01"
+canonical_url: "dated-draft-post"
+status: "draft"
+---
+
+A date alone must not be enough to publish.

--- a/apps/web/src/lib/blog/__fixtures__/valid/draft-post.md
+++ b/apps/web/src/lib/blog/__fixtures__/valid/draft-post.md
@@ -1,0 +1,12 @@
+---
+title: "A Draft Post"
+description: "Not yet published — must never be routable or listed."
+tags: ["draft"]
+series: null
+order: 200
+date: null
+canonical_url: "draft-post"
+status: "draft"
+---
+
+This should never appear anywhere public.

--- a/apps/web/src/lib/blog/__fixtures__/valid/first-post.md
+++ b/apps/web/src/lib/blog/__fixtures__/valid/first-post.md
@@ -1,0 +1,14 @@
+---
+title: "The First Post"
+description: "An early post in the series."
+tags: ["architecture", "typescript"]
+series: "Test Series"
+order: 1
+date: "2026-01-01"
+canonical_url: "first-post"
+status: "published"
+---
+
+Intro paragraph.
+
+## First heading

--- a/apps/web/src/lib/blog/__fixtures__/valid/second-post.md
+++ b/apps/web/src/lib/blog/__fixtures__/valid/second-post.md
@@ -1,0 +1,12 @@
+---
+title: "The Second Post"
+description: "A later post in the same series."
+tags: ["architecture", "testing"]
+series: "Test Series"
+order: 2
+date: "2026-02-01"
+canonical_url: "second-post"
+status: "published"
+---
+
+A second post to test series prev/next ordering.

--- a/apps/web/src/lib/blog/__fixtures__/valid/standalone-post.md
+++ b/apps/web/src/lib/blog/__fixtures__/valid/standalone-post.md
@@ -1,0 +1,12 @@
+---
+title: "A Standalone Post"
+description: "Not part of any series."
+tags: ["standalone"]
+series: null
+order: 100
+date: "2026-03-01"
+canonical_url: "standalone-post"
+status: "published"
+---
+
+No series here.

--- a/apps/web/src/lib/blog/articles.test.ts
+++ b/apps/web/src/lib/blog/articles.test.ts
@@ -1,0 +1,197 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  getAllArticles,
+  getArticleBySlug,
+  getPublishedArticles,
+  getSeriesList,
+  getSeriesNeighbors,
+  getTagList,
+  isPublished,
+  parseArticleFile,
+} from "./articles";
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), "__fixtures__");
+const VALID_DIR = join(FIXTURES, "valid");
+const DUPLICATE_DIR = join(FIXTURES, "duplicate-slug");
+
+const VALID_FRONTMATTER = `---
+title: "T"
+description: "D"
+tags: ["a"]
+series: null
+order: 1
+date: "2026-01-01"
+canonical_url: "t"
+status: "published"
+---
+
+Body.
+`;
+
+function withField(field: string, value: string): string {
+  const lines = VALID_FRONTMATTER.split("\n");
+  const idx = lines.findIndex((l) => l.startsWith(`${field}:`));
+  lines[idx] = value;
+  return lines.join("\n");
+}
+
+describe("parseArticleFile — frontmatter validation", () => {
+  it("parses a fully valid article", () => {
+    const article = parseArticleFile("t.md", VALID_FRONTMATTER);
+    expect(article.title).toBe("T");
+    expect(article.slug).toBe("t");
+    expect(article.series).toBeNull();
+    expect(article.blocks).toEqual([{ type: "p", text: ["Body."] }]);
+    expect(article.readingMinutes).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects a missing title", () => {
+    expect(() => parseArticleFile("bad.md", withField("title", "title: 123"))).toThrow(
+      /title.*required/i,
+    );
+  });
+
+  it("rejects a missing description", () => {
+    expect(() => parseArticleFile("bad.md", withField("description", ""))).toThrow(
+      /description.*required/i,
+    );
+  });
+
+  it("rejects a missing canonical_url", () => {
+    expect(() =>
+      parseArticleFile("bad.md", withField("canonical_url", "canonical_url: 5")),
+    ).toThrow(/canonical_url.*required/i);
+  });
+
+  it("rejects tags that aren't an array of strings", () => {
+    expect(() => parseArticleFile("bad.md", withField("tags", 'tags: "not-an-array"'))).toThrow(
+      /tags.*array of strings/i,
+    );
+    expect(() => parseArticleFile("bad.md", withField("tags", "tags: [1, 2]"))).toThrow(
+      /tags.*array of strings/i,
+    );
+  });
+
+  it("rejects a non-numeric order", () => {
+    expect(() => parseArticleFile("bad.md", withField("order", 'order: "one"'))).toThrow(
+      /order.*number/i,
+    );
+  });
+
+  it("rejects a date that is neither a string nor null", () => {
+    expect(() => parseArticleFile("bad.md", withField("date", "date: 20260101"))).toThrow(
+      /date.*YYYY-MM-DD.*null/i,
+    );
+  });
+
+  it("rejects a status other than draft/published", () => {
+    expect(() => parseArticleFile("bad.md", withField("status", 'status: "live"'))).toThrow(
+      /status.*draft.*published/i,
+    );
+  });
+
+  it("rejects a series that isn't a string or null", () => {
+    expect(() => parseArticleFile("bad.md", withField("series", "series: 5"))).toThrow(
+      /series.*string or null/i,
+    );
+  });
+
+  it("defaults series to null when omitted entirely", () => {
+    const noSeries = VALID_FRONTMATTER.replace("series: null\n", "");
+    expect(parseArticleFile("t.md", noSeries).series).toBeNull();
+  });
+});
+
+describe("isPublished — the gating rule", () => {
+  it("requires both a date and status published", () => {
+    expect(isPublished({ date: "2026-01-01", status: "published" })).toBe(true);
+    expect(isPublished({ date: null, status: "published" })).toBe(false);
+    expect(isPublished({ date: "2026-01-01", status: "draft" })).toBe(false);
+    expect(isPublished({ date: null, status: "draft" })).toBe(false);
+  });
+});
+
+describe("getAllArticles / getPublishedArticles (fixture directory)", () => {
+  it("returns an empty array for a directory that doesn't exist", () => {
+    expect(getAllArticles(join(FIXTURES, "does-not-exist"))).toEqual([]);
+    expect(getPublishedArticles(join(FIXTURES, "does-not-exist"))).toEqual([]);
+  });
+
+  it("reads every .md file in the directory except README.md", () => {
+    const articles = getAllArticles(VALID_DIR);
+    expect(articles).toHaveLength(5);
+    expect(articles.map((a) => a.file)).not.toContain("README.md");
+  });
+
+  it("excludes draft and undated articles from the published set", () => {
+    const published = getPublishedArticles(VALID_DIR);
+    const slugs = published.map((a) => a.slug);
+    expect(slugs).not.toContain("draft-post");
+    expect(slugs).not.toContain("dated-draft-post");
+    expect(slugs).toEqual(expect.arrayContaining(["first-post", "second-post", "standalone-post"]));
+    expect(published).toHaveLength(3);
+  });
+
+  it("sorts published articles newest date first", () => {
+    const published = getPublishedArticles(VALID_DIR);
+    expect(published.map((a) => a.slug)).toEqual(["standalone-post", "second-post", "first-post"]);
+  });
+
+  it("throws a descriptive error on a duplicate canonical_url", () => {
+    expect(() => getAllArticles(DUPLICATE_DIR)).toThrow(/same-slug.*duplicates/i);
+  });
+});
+
+describe("getArticleBySlug", () => {
+  it("finds a published article by slug", () => {
+    expect(getArticleBySlug("first-post", VALID_DIR)?.title).toBe("The First Post");
+  });
+
+  it("returns undefined for a draft slug — it is not routable", () => {
+    expect(getArticleBySlug("draft-post", VALID_DIR)).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown slug", () => {
+    expect(getArticleBySlug("nope", VALID_DIR)).toBeUndefined();
+  });
+});
+
+describe("getSeriesList / getTagList", () => {
+  it("lists distinct series among published articles", () => {
+    expect(getSeriesList(getPublishedArticles(VALID_DIR))).toEqual(["Test Series"]);
+  });
+
+  it("lists distinct tags, alphabetically", () => {
+    expect(getTagList(getPublishedArticles(VALID_DIR))).toEqual([
+      "architecture",
+      "standalone",
+      "testing",
+      "typescript",
+    ]);
+  });
+});
+
+describe("getSeriesNeighbors", () => {
+  const published = getPublishedArticles(VALID_DIR);
+
+  it("has no neighbors for a standalone (no-series) article", () => {
+    const standalone = published.find((a) => a.slug === "standalone-post")!;
+    expect(getSeriesNeighbors(standalone, published)).toEqual({ prev: null, next: null });
+  });
+
+  it("finds the next article in the series (oldest -> newest)", () => {
+    const first = published.find((a) => a.slug === "first-post")!;
+    const { prev, next } = getSeriesNeighbors(first, published);
+    expect(prev).toBeNull();
+    expect(next?.slug).toBe("second-post");
+  });
+
+  it("finds the previous article in the series", () => {
+    const second = published.find((a) => a.slug === "second-post")!;
+    const { prev, next } = getSeriesNeighbors(second, published);
+    expect(prev?.slug).toBe("first-post");
+    expect(next).toBeNull();
+  });
+});

--- a/apps/web/src/lib/blog/articles.ts
+++ b/apps/web/src/lib/blog/articles.ts
@@ -1,0 +1,154 @@
+/**
+ * Loads and validates blog articles from `docs/articles/*.md` at build time
+ * (see ADR 0037). An article is **published** — and only then routable and
+ * visible — iff its frontmatter has both a real `date` and
+ * `status: "published"`; anything else (missing date, `status: "draft"`,
+ * or absent entirely) never appears in the index, RSS feed, sitemap, or
+ * `generateStaticParams`, so it has no reachable URL.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+import type { Block } from "./blocks";
+import { headingsOf, parseMarkdownToBlocks, readingMinutesOf } from "./parse-markdown";
+import { isPublished } from "./selectors";
+
+export {
+  isPublished,
+  getSeriesList,
+  getTagList,
+  getSeriesNeighbors,
+  type SeriesNeighbors,
+} from "./selectors";
+
+export interface Article {
+  slug: string;
+  title: string;
+  description: string;
+  tags: string[];
+  series: string | null;
+  order: number;
+  date: string | null;
+  status: "draft" | "published";
+  blocks: Block[];
+  headings: { id: string; text: string }[];
+  readingMinutes: number;
+  /** Source file name, surfaced in validation error messages. */
+  file: string;
+}
+
+const REQUIRED_STRING_FIELDS = ["title", "description", "canonical_url"] as const;
+
+/** Repo-root `docs/articles` — resolved from this module's own file location. */
+export const DEFAULT_ARTICLES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "docs",
+  "articles",
+);
+
+function fail(file: string, message: string): never {
+  throw new Error(`docs/articles/${file}: ${message}`);
+}
+
+function parseFrontmatter(
+  file: string,
+  raw: Record<string, unknown>,
+): Omit<Article, "blocks" | "headings" | "readingMinutes" | "slug"> & { canonical_url: string } {
+  for (const field of REQUIRED_STRING_FIELDS) {
+    if (typeof raw[field] !== "string" || raw[field] === "") {
+      fail(file, `frontmatter field "${field}" is required and must be a non-empty string.`);
+    }
+  }
+  if (!Array.isArray(raw.tags) || raw.tags.some((t) => typeof t !== "string")) {
+    fail(file, `frontmatter field "tags" is required and must be an array of strings.`);
+  }
+  if (typeof raw.order !== "number") {
+    fail(file, `frontmatter field "order" is required and must be a number.`);
+  }
+  if (raw.date !== null && typeof raw.date !== "string") {
+    fail(file, `frontmatter field "date" must be a string (YYYY-MM-DD) or null.`);
+  }
+  if (raw.status !== "draft" && raw.status !== "published") {
+    fail(file, `frontmatter field "status" must be "draft" or "published".`);
+  }
+  if (raw.series !== undefined && raw.series !== null && typeof raw.series !== "string") {
+    fail(file, `frontmatter field "series", if present, must be a string or null.`);
+  }
+
+  return {
+    title: raw.title as string,
+    description: raw.description as string,
+    tags: raw.tags as string[],
+    series: (raw.series as string | null | undefined) ?? null,
+    order: raw.order as number,
+    date: raw.date as string | null,
+    status: raw.status as "draft" | "published",
+    canonical_url: raw.canonical_url as string,
+    file,
+  };
+}
+
+/** Parses and validates a single article from its raw Markdown+frontmatter source. Exported for unit testing. */
+export function parseArticleFile(file: string, source: string): Article {
+  const { data, content } = matter(source);
+  const meta = parseFrontmatter(file, data as Record<string, unknown>);
+  const blocks = parseMarkdownToBlocks(content);
+  return {
+    slug: meta.canonical_url,
+    title: meta.title,
+    description: meta.description,
+    tags: meta.tags,
+    series: meta.series,
+    order: meta.order,
+    date: meta.date,
+    status: meta.status,
+    file,
+    blocks,
+    headings: headingsOf(blocks),
+    readingMinutes: readingMinutesOf(blocks),
+  };
+}
+
+/** Reads and validates every article in `dir` (every `.md` file except `README.md`). Throws on any invalid file or duplicate slug. */
+export function getAllArticles(dir: string = DEFAULT_ARTICLES_DIR): Article[] {
+  if (!existsSync(dir)) return [];
+  const files = readdirSync(dir).filter(
+    (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
+  );
+  const articles = files.map((file) =>
+    parseArticleFile(file, readFileSync(join(dir, file), "utf8")),
+  );
+
+  const bySlug = new Map<string, string>();
+  for (const a of articles) {
+    const existing = bySlug.get(a.slug);
+    if (existing) {
+      throw new Error(
+        `docs/articles/${a.file}: canonical_url "${a.slug}" duplicates ${existing} — slugs must be unique.`,
+      );
+    }
+    bySlug.set(a.slug, a.file);
+  }
+
+  return articles;
+}
+
+/** Published articles only, newest first — the set that is ever routable or visible. */
+export function getPublishedArticles(dir: string = DEFAULT_ARTICLES_DIR): Article[] {
+  return getAllArticles(dir)
+    .filter(isPublished)
+    .sort((a, b) => (a.date! < b.date! ? 1 : a.date! > b.date! ? -1 : 0));
+}
+
+export function getArticleBySlug(
+  slug: string,
+  dir: string = DEFAULT_ARTICLES_DIR,
+): Article | undefined {
+  return getPublishedArticles(dir).find((a) => a.slug === slug);
+}

--- a/apps/web/src/lib/blog/blocks.ts
+++ b/apps/web/src/lib/blog/blocks.ts
@@ -1,0 +1,43 @@
+/**
+ * The typed block shape the blog article renderer maps over — mirrors the
+ * Noor blog design prototype's data shape (`docs/design/noor-prototype-blog`),
+ * produced from real Markdown by `parse-markdown.ts` instead of hand-written
+ * JS. Kept as plain, JSON-serializable data (no functions) so it can cross
+ * the server → client boundary as component props.
+ */
+
+/** One inline span within a paragraph, list item, or blockquote. */
+export type InlinePart =
+  | string
+  | { bold: string }
+  | { italic: string }
+  | { code: string }
+  /** An Arabic term with its transliteration, e.g. `:ar[قِبْلَة]{translit=qibla}`. */
+  | { ar: string; translit: string };
+
+export type Inline = InlinePart[];
+
+export interface Heading {
+  id: string;
+  text: string;
+}
+
+export type Block =
+  | { type: "p"; text: Inline }
+  | { type: "h2"; text: string; id: string }
+  | { type: "h3"; text: string }
+  | { type: "ul"; items: Inline[] }
+  | { type: "ol"; items: Inline[] }
+  | { type: "quote"; text: Inline; cite?: string }
+  | { type: "hr" }
+  | { type: "table"; head: string[]; rows: string[][] }
+  | { type: "code"; lang: string; code: string }
+  /** A Mermaid diagram — `code` is the raw Mermaid definition. */
+  | { type: "diagram"; code: string; caption?: string };
+
+/** Block types allowed to break out of the narrow prose measure (denser content). */
+export const BREAKOUT_BLOCK_TYPES: ReadonlySet<Block["type"]> = new Set([
+  "diagram",
+  "table",
+  "code",
+]);

--- a/apps/web/src/lib/blog/feed.test.ts
+++ b/apps/web/src/lib/blog/feed.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { Article } from "./articles";
+import { buildRssFeed } from "./feed";
+
+function article(overrides: Partial<Article>): Article {
+  return {
+    slug: "a",
+    title: "A",
+    description: "D",
+    tags: [],
+    series: null,
+    order: 1,
+    date: "2026-01-01",
+    status: "published",
+    blocks: [],
+    headings: [],
+    readingMinutes: 1,
+    file: "a.md",
+    ...overrides,
+  };
+}
+
+describe("buildRssFeed", () => {
+  it("produces a well-formed RSS 2.0 channel with no items", () => {
+    const xml = buildRssFeed([], "https://ummahlibrary.org");
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<rss version="2.0">');
+    expect(xml).toContain("<link>https://ummahlibrary.org/blog</link>");
+    expect(xml).not.toContain("<item>");
+    expect(xml).not.toContain("<lastBuildDate>");
+  });
+
+  it("emits one <item> per article with an absolute link and guid", () => {
+    const xml = buildRssFeed(
+      [article({ slug: "hello-world", title: "Hello World", date: "2026-05-01" })],
+      "https://ummahlibrary.org",
+    );
+    expect(xml).toContain("<title>Hello World</title>");
+    expect(xml).toContain("<link>https://ummahlibrary.org/blog/hello-world</link>");
+    expect(xml).toContain("<guid>https://ummahlibrary.org/blog/hello-world</guid>");
+    expect(xml).toContain("<lastBuildDate>");
+  });
+
+  it("escapes XML-special characters in title and description", () => {
+    const xml = buildRssFeed(
+      [article({ title: "A & B <Title>", description: 'Quote "this" & that' })],
+      "https://ummahlibrary.org",
+    );
+    expect(xml).toContain("A &amp; B &lt;Title&gt;");
+    expect(xml).toContain("Quote &quot;this&quot; &amp; that");
+  });
+
+  it("orders items exactly as given (caller is responsible for sort order)", () => {
+    const xml = buildRssFeed(
+      [
+        article({ slug: "second", title: "Second", date: "2026-02-01" }),
+        article({ slug: "first", title: "First", date: "2026-01-01" }),
+      ],
+      "https://ummahlibrary.org",
+    );
+    expect(xml.indexOf("Second")).toBeLessThan(xml.indexOf("First"));
+  });
+});

--- a/apps/web/src/lib/blog/feed.ts
+++ b/apps/web/src/lib/blog/feed.ts
@@ -1,0 +1,44 @@
+/** Builds the blog's RSS 2.0 feed XML from published articles (build-time only). */
+import type { Article } from "./articles";
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function rfc822(date: string): string {
+  return new Date(`${date}T00:00:00Z`).toUTCString();
+}
+
+export function buildRssFeed(published: readonly Article[], siteUrl: string): string {
+  const items = published
+    .map((a) => {
+      const url = `${siteUrl}/blog/${a.slug}`;
+      return [
+        "<item>",
+        `<title>${escapeXml(a.title)}</title>`,
+        `<link>${escapeXml(url)}</link>`,
+        `<guid>${escapeXml(url)}</guid>`,
+        `<pubDate>${rfc822(a.date!)}</pubDate>`,
+        `<description>${escapeXml(a.description)}</description>`,
+        "</item>",
+      ].join("");
+    })
+    .join("");
+
+  const latest = published[0]?.date;
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<rss version="2.0"><channel>' +
+    "<title>Building Ummah Library</title>" +
+    `<link>${escapeXml(`${siteUrl}/blog`)}</link>` +
+    "<description>Ideas, architecture write-ups, and lessons from building Ummah Library in the open.</description>" +
+    (latest ? `<lastBuildDate>${rfc822(latest)}</lastBuildDate>` : "") +
+    items +
+    "</channel></rss>"
+  );
+}

--- a/apps/web/src/lib/blog/parse-markdown.test.ts
+++ b/apps/web/src/lib/blog/parse-markdown.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { headingsOf, parseMarkdownToBlocks, readingMinutesOf } from "./parse-markdown";
+
+describe("parseMarkdownToBlocks", () => {
+  it("parses a paragraph with plain text", () => {
+    const blocks = parseMarkdownToBlocks("Hello world.");
+    expect(blocks).toEqual([{ type: "p", text: ["Hello world."] }]);
+  });
+
+  it("parses bold, italic and inline code within a paragraph", () => {
+    const [block] = parseMarkdownToBlocks("A **bold** word, an *italic* word, and `code`.");
+    expect(block).toEqual({
+      type: "p",
+      text: [
+        "A ",
+        { bold: "bold" },
+        " word, an ",
+        { italic: "italic" },
+        " word, and ",
+        { code: "code" },
+        ".",
+      ],
+    });
+  });
+
+  it("parses the :ar[]{translit=} directive as an inline Arabic term", () => {
+    const [block] = parseMarkdownToBlocks("Say :ar[قِبْلَة]{translit=qibla} please.");
+    expect(block).toEqual({
+      type: "p",
+      text: ["Say ", { ar: "قِبْلَة", translit: "qibla" }, " please."],
+    });
+  });
+
+  it("assigns h2 blocks a stable, slugified id and ignores h1/h4", () => {
+    const blocks = parseMarkdownToBlocks("# Title\n\n## The Shape of the Repo!\n\n#### Too deep");
+    expect(blocks).toEqual([
+      { type: "h2", text: "The Shape of the Repo!", id: "h-0-the-shape-of-the-repo" },
+    ]);
+  });
+
+  it("parses h3 as plain subheadings", () => {
+    const blocks = parseMarkdownToBlocks("### A subheading");
+    expect(blocks).toEqual([{ type: "h3", text: "A subheading" }]);
+  });
+
+  it("parses an unordered list with inline formatting per item", () => {
+    const blocks = parseMarkdownToBlocks("- plain item\n- item with **emphasis**");
+    expect(blocks).toEqual([
+      { type: "ul", items: [["plain item"], ["item with ", { bold: "emphasis" }]] },
+    ]);
+  });
+
+  it("parses an ordered list", () => {
+    const blocks = parseMarkdownToBlocks("1. first\n2. second");
+    expect(blocks).toEqual([{ type: "ol", items: [["first"], ["second"]] }]);
+  });
+
+  it("parses a blockquote with no citation", () => {
+    const blocks = parseMarkdownToBlocks("> Just a quote.");
+    expect(blocks).toEqual([{ type: "quote", text: ["Just a quote."] }]);
+  });
+
+  it("splits a trailing em-dash paragraph into a citation", () => {
+    const blocks = parseMarkdownToBlocks("> The rule that matters.\n>\n> — Internal ADR-0003");
+    expect(blocks).toEqual([
+      { type: "quote", text: ["The rule that matters."], cite: "Internal ADR-0003" },
+    ]);
+  });
+
+  it("parses a thematic break", () => {
+    expect(parseMarkdownToBlocks("---")).toEqual([{ type: "hr" }]);
+  });
+
+  it("parses a GFM table", () => {
+    const blocks = parseMarkdownToBlocks("| A | B |\n| - | - |\n| 1 | 2 |\n| 3 | 4 |");
+    expect(blocks).toEqual([
+      {
+        type: "table",
+        head: ["A", "B"],
+        rows: [
+          ["1", "2"],
+          ["3", "4"],
+        ],
+      },
+    ]);
+  });
+
+  it("parses a fenced code block with a language", () => {
+    const blocks = parseMarkdownToBlocks("```ts\nconst x = 1;\n```");
+    expect(blocks).toEqual([{ type: "code", lang: "ts", code: "const x = 1;" }]);
+  });
+
+  it("defaults an unlabeled fenced code block to text", () => {
+    const blocks = parseMarkdownToBlocks("```\nplain\n```");
+    expect(blocks).toEqual([{ type: "code", lang: "text", code: "plain" }]);
+  });
+
+  it("turns a mermaid fence into a diagram block with an optional caption", () => {
+    const blocks = parseMarkdownToBlocks(
+      '```mermaid caption="apps to core"\ngraph TD; A-->B;\n```',
+    );
+    expect(blocks).toEqual([
+      { type: "diagram", code: "graph TD; A-->B;", caption: "apps to core" },
+    ]);
+  });
+
+  it("omits the caption field when a mermaid fence has none", () => {
+    const [block] = parseMarkdownToBlocks("```mermaid\ngraph TD; A-->B;\n```");
+    expect(block).toEqual({ type: "diagram", code: "graph TD; A-->B;" });
+    expect(block).not.toHaveProperty("caption");
+  });
+
+  it("skips unsupported node types (e.g. raw HTML) rather than guessing", () => {
+    const blocks = parseMarkdownToBlocks("<div>raw html</div>\n\nA real paragraph.");
+    expect(blocks).toEqual([{ type: "p", text: ["A real paragraph."] }]);
+  });
+});
+
+describe("headingsOf", () => {
+  it("extracts only h2 blocks as the table of contents", () => {
+    const blocks = parseMarkdownToBlocks("## One\n\nBody\n\n### Sub\n\n## Two");
+    expect(headingsOf(blocks)).toEqual([
+      { id: "h-0-one", text: "One" },
+      { id: "h-1-two", text: "Two" },
+    ]);
+  });
+
+  it("returns an empty array for an article with no h2 headings", () => {
+    expect(headingsOf(parseMarkdownToBlocks("Just a paragraph."))).toEqual([]);
+  });
+});
+
+describe("readingMinutesOf", () => {
+  it("is always at least 1 minute", () => {
+    expect(readingMinutesOf(parseMarkdownToBlocks("One two."))).toBe(1);
+  });
+
+  it("scales with word count across block types at ~200wpm", () => {
+    const words = Array.from({ length: 450 }, (_, i) => `word${i}`).join(" ");
+    const blocks = parseMarkdownToBlocks(`## Heading also has words\n\n${words}\n\n- ${words}`);
+    // 450 (paragraph) + 450 (list item) + a handful in the heading, at 200wpm.
+    expect(readingMinutesOf(blocks)).toBeGreaterThanOrEqual(4);
+  });
+
+  it("counts table cell words", () => {
+    const blocks = parseMarkdownToBlocks(
+      "| Column Header | Another |\n| - | - |\n| cell value | more words here |",
+    );
+    expect(readingMinutesOf(blocks)).toBe(1);
+  });
+
+  it("counts blockquote words", () => {
+    const blocks = parseMarkdownToBlocks("> A quoted sentence with several words in it.");
+    expect(readingMinutesOf(blocks)).toBe(1);
+  });
+});

--- a/apps/web/src/lib/blog/parse-markdown.ts
+++ b/apps/web/src/lib/blog/parse-markdown.ts
@@ -1,0 +1,172 @@
+/**
+ * Markdown → typed block pipeline (build-time only; see ADR 0037).
+ *
+ * Parses an article's Markdown body into the `Block[]` shape the blog
+ * renderer expects. Runs once per article at build time via
+ * `getStaticProps`/`generateStaticParams` — never at request time.
+ */
+import remarkDirective from "remark-directive";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { toString as mdastToString } from "mdast-util-to-string";
+import type { Blockquote, Heading, List, PhrasingContent, Root, RootContent, Table } from "mdast";
+import { unified } from "unified";
+import type { Block, Inline, InlinePart } from "./blocks";
+
+const processor = unified().use(remarkParse).use(remarkGfm).use(remarkDirective);
+
+/** A directive node produced by `remark-directive` for `:ar[text]{translit=...}`. */
+interface ArDirectiveNode {
+  type: "textDirective";
+  name: string;
+  attributes?: Record<string, string | null | undefined> | null;
+  children: PhrasingContent[];
+}
+
+function isArDirective(node: PhrasingContent): node is PhrasingContent & ArDirectiveNode {
+  return node.type === "textDirective" && (node as { name?: string }).name === "ar";
+}
+
+/** Converts a run of inline mdast phrasing nodes into flat, serializable parts. */
+function inlineFromChildren(children: readonly PhrasingContent[]): Inline {
+  const parts: InlinePart[] = [];
+  for (const node of children) {
+    if (node.type === "text") {
+      parts.push(node.value);
+    } else if (node.type === "inlineCode") {
+      parts.push({ code: node.value });
+    } else if (node.type === "strong") {
+      parts.push({ bold: mdastToString(node) });
+    } else if (node.type === "emphasis") {
+      parts.push({ italic: mdastToString(node) });
+    } else if (isArDirective(node)) {
+      const translit = node.attributes?.translit ?? "";
+      parts.push({ ar: mdastToString(node), translit });
+    } else if ("children" in node && Array.isArray(node.children)) {
+      parts.push(...inlineFromChildren(node.children as PhrasingContent[]));
+    } else if ("value" in node && typeof node.value === "string") {
+      parts.push(node.value);
+    }
+  }
+  return parts;
+}
+
+function headingId(text: string, index: number): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+    .slice(0, 40);
+  return `h-${index}-${slug}`;
+}
+
+/**
+ * A blockquote's optional citation: a trailing paragraph starting with an
+ * em dash (`— Cited work`), stripped from the quoted text itself. Documented
+ * in `docs/articles/README.md`.
+ */
+function splitQuoteCite(node: Blockquote): { text: Inline; cite?: string } {
+  const paragraphs = node.children.filter(
+    (c): c is RootContent & { type: "paragraph" } => c.type === "paragraph",
+  );
+  const last = paragraphs.at(-1);
+  const lastText = last ? mdastToString(last).trim() : "";
+  const isCite = paragraphs.length > 1 && /^[—-]\s*/.test(lastText);
+  const bodyParagraphs = isCite ? paragraphs.slice(0, -1) : paragraphs;
+  const text = bodyParagraphs.flatMap((p) => inlineFromChildren(p.children));
+  const cite = isCite ? lastText.replace(/^[—-]\s*/, "") : undefined;
+  return cite ? { text, cite } : { text };
+}
+
+function listItemsOf(node: List): Inline[] {
+  return node.children.map((item) => {
+    const paragraphs = item.children.filter(
+      (c): c is RootContent & { type: "paragraph" } => c.type === "paragraph",
+    );
+    return paragraphs.flatMap((p) => inlineFromChildren(p.children));
+  });
+}
+
+const MERMAID_CAPTION_RE = /caption="([^"]*)"/;
+
+function tableCellText(node: Table): string[][] {
+  return node.children.map((row) => row.children.map((cell) => mdastToString(cell)));
+}
+
+/** Parses one article's Markdown body (frontmatter already stripped) into blocks. */
+export function parseMarkdownToBlocks(markdown: string): Block[] {
+  const tree = processor.parse(markdown) as Root;
+  const blocks: Block[] = [];
+  let headingIndex = 0;
+
+  for (const node of tree.children) {
+    if (node.type === "paragraph") {
+      blocks.push({ type: "p", text: inlineFromChildren(node.children) });
+    } else if (node.type === "heading") {
+      const h = node as Heading;
+      const text = mdastToString(h);
+      if (h.depth === 2) {
+        blocks.push({ type: "h2", text, id: headingId(text, headingIndex++) });
+      } else if (h.depth === 3) {
+        blocks.push({ type: "h3", text });
+      }
+      // Depth 1 (and >3) headings are ignored — the article title comes from
+      // frontmatter, and the design defines only two prose heading levels.
+    } else if (node.type === "list") {
+      const items = listItemsOf(node);
+      blocks.push(node.ordered ? { type: "ol", items } : { type: "ul", items });
+    } else if (node.type === "blockquote") {
+      blocks.push({ type: "quote", ...splitQuoteCite(node) });
+    } else if (node.type === "thematicBreak") {
+      blocks.push({ type: "hr" });
+    } else if (node.type === "table") {
+      const [head, ...rows] = tableCellText(node);
+      blocks.push({ type: "table", head: head ?? [], rows });
+    } else if (node.type === "code") {
+      const lang = node.lang ?? "text";
+      if (lang === "mermaid") {
+        const caption = node.meta?.match(MERMAID_CAPTION_RE)?.[1];
+        blocks.push({ type: "diagram", code: node.value, ...(caption ? { caption } : {}) });
+      } else {
+        blocks.push({ type: "code", lang, code: node.value });
+      }
+    }
+    // Other node types (html, etc.) are not part of the supported block set
+    // and are intentionally skipped rather than guessed at.
+  }
+
+  return blocks;
+}
+
+/** Extracts the h2-derived table of contents from a parsed article's blocks. */
+export function headingsOf(blocks: readonly Block[]): { id: string; text: string }[] {
+  return blocks
+    .filter((b): b is Extract<Block, { type: "h2" }> => b.type === "h2")
+    .map((b) => ({ id: b.id, text: b.text }));
+}
+
+const WPM = 200;
+
+function inlineWordCount(text: Inline): number {
+  return text.reduce((sum, part) => {
+    const s = typeof part === "string" ? part : "ar" in part ? part.ar : Object.values(part)[0];
+    return sum + String(s).split(/\s+/).filter(Boolean).length;
+  }, 0);
+}
+
+/** Estimated reading time in minutes at ~200wpm, from the article's own block content. */
+export function readingMinutesOf(blocks: readonly Block[]): number {
+  let words = 0;
+  for (const b of blocks) {
+    if (b.type === "p" || b.type === "quote") words += inlineWordCount(b.text);
+    else if (b.type === "h2" || b.type === "h3")
+      words += b.text.split(/\s+/).filter(Boolean).length;
+    else if (b.type === "ul" || b.type === "ol") {
+      for (const item of b.items) words += inlineWordCount(item);
+    } else if (b.type === "table") {
+      words += b.head.join(" ").split(/\s+/).filter(Boolean).length;
+      for (const row of b.rows) words += row.join(" ").split(/\s+/).filter(Boolean).length;
+    }
+  }
+  return Math.max(1, Math.round(words / WPM));
+}

--- a/apps/web/src/lib/blog/selectors.ts
+++ b/apps/web/src/lib/blog/selectors.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure, fs-free selectors over already-loaded articles — safe to import from
+ * client components (unlike `articles.ts`, which reads `docs/articles` via
+ * `node:fs` and must stay server-only; see ADR 0037).
+ */
+import type { Article } from "./articles";
+
+/** An article is public iff it has both a real date and `status: "published"`. */
+export function isPublished(article: Pick<Article, "date" | "status">): boolean {
+  return article.date !== null && article.status === "published";
+}
+
+/** Distinct series among published articles, in order of first appearance (newest-first order). */
+export function getSeriesList(published: readonly Article[]): string[] {
+  return [...new Set(published.map((a) => a.series).filter((s): s is string => s !== null))];
+}
+
+/** Distinct tags among the given articles, alphabetical. */
+export function getTagList(published: readonly Article[]): string[] {
+  return [...new Set(published.flatMap((a) => a.tags))].sort();
+}
+
+export interface SeriesNeighbors {
+  prev: Article | null;
+  next: Article | null;
+}
+
+/**
+ * The previous/next article in the same series, ordered by publish date.
+ * A standalone post (no series), or one with no neighbor on a side, simply
+ * has that side be `null` — never a dead link.
+ */
+export function getSeriesNeighbors(
+  article: Article,
+  published: readonly Article[],
+): SeriesNeighbors {
+  if (!article.series) return { prev: null, next: null };
+  const siblings = published
+    .filter((a) => a.series === article.series)
+    .sort((a, b) => (a.date! < b.date! ? -1 : a.date! > b.date! ? 1 : 0));
+  const idx = siblings.findIndex((a) => a.slug === article.slug);
+  return {
+    prev: idx > 0 ? siblings[idx - 1]! : null,
+    next: idx >= 0 && idx < siblings.length - 1 ? siblings[idx + 1]! : null,
+  };
+}

--- a/apps/web/src/lib/hifz-review-log-store.test.ts
+++ b/apps/web/src/lib/hifz-review-log-store.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readReviewLog, recordReview, writeReviewLog } from "./hifz-review-log-store";
+
+const KEY = "ul.hifz.reviewLog";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe("hifz-review-log-store", () => {
+  it("reads an empty log by default", () => {
+    expect(readReviewLog()).toEqual({});
+  });
+
+  it("round-trips a written log", () => {
+    writeReviewLog({ "2026-06-01": 2, "2026-06-02": 1 });
+    expect(readReviewLog()).toEqual({ "2026-06-01": 2, "2026-06-02": 1 });
+  });
+
+  it("falls back to empty on malformed JSON", () => {
+    localStorage.setItem(KEY, "{nope");
+    expect(readReviewLog()).toEqual({});
+  });
+
+  it("falls back to empty on a corrupt/peer-synced shape (null, array, or scalar)", () => {
+    for (const bad of ["null", "[1,2,3]", '"just a string"', "42"]) {
+      localStorage.setItem(KEY, bad);
+      expect(readReviewLog()).toEqual({});
+    }
+  });
+
+  it("records a review at the given instant, incrementing that day's count", () => {
+    const now = new Date("2026-06-15T10:00:00Z");
+    recordReview(now);
+    expect(readReviewLog()).toEqual({ "2026-06-15": 1 });
+    recordReview(now);
+    expect(readReviewLog()).toEqual({ "2026-06-15": 2 });
+  });
+});

--- a/docs/adr/0037-engineering-blog.md
+++ b/docs/adr/0037-engineering-blog.md
@@ -1,0 +1,112 @@
+# ADR 0037 — Engineering blog: Markdown at build time, gated by frontmatter
+
+- **Status:** Accepted
+- **Date:** 2026-07-13
+
+## Context
+
+Issue #226 asks for a real, ongoing engineering blog at `/blog` — architecture
+write-ups and open-source recruitment content, growing indefinitely as new
+posts are written, not a fixed series. A Noor-styled design prototype for it
+was vendored at `docs/design/noor-prototype-blog` (#227): a standalone React
+mockup with its own hand-written JS data (`blog/blogdata.js`) using a typed
+block shape (`{type: "p" | "h2" | "ul" | "table" | "code" | "diagram" | ...}`).
+
+The real content is **Markdown**, written one article at a time in
+`docs/articles/*.md` as the project grows — not hand-authored JS block arrays.
+Something has to turn Markdown into that block shape, and something has to
+decide which articles are public.
+
+## Decision
+
+**1. A build-time Markdown → block pipeline, not a runtime one.**
+`apps/web/src/lib/blog/parse-markdown.ts` parses an article's Markdown body
+with `unified` + `remark-parse` + `remark-gfm` (tables) + `remark-directive`
+(the inline Arabic-term syntax below) into the design's `Block[]` shape
+(`apps/web/src/lib/blog/blocks.ts`). This runs once per article at build time,
+inside `generateStaticParams`/page rendering — never at request time, matching
+the static-first stance (ADR 0003). No port is added for this: it's a build
+step with one clear implementation and nothing to swap (see AGENTS.md, "when
+not to add a port"), the same reasoning that keeps ADR generation and other
+build-time-only Markdown reads unwrapped.
+
+**Inline Arabic terms** use a small `remark-directive` syntax rather than a
+bespoke regex: `:ar[قِبْلَة]{translit=qibla}` parses as a `textDirective` node
+and renders as the design's `ArTerm` (Arabic + parenthetical transliteration).
+**Mermaid diagrams** are an ordinary fenced code block tagged `mermaid`; an
+optional `caption="..."` in the fence's meta string is threaded through to the
+`DiagramFrame` chrome. A blockquote's optional citation is its own last
+paragraph, prefixed with an em dash (`— Citation`) — stripped from the quoted
+text and rendered as the design's small-caps attribution line. All three
+conventions are documented for contributors in `docs/articles/README.md`.
+
+**2. Frontmatter gates visibility — the actual "hide an article" mechanism.**
+Every article's frontmatter carries `title, description, tags, series, order,
+date, canonical_url, status` (`status: "draft" | "published"`). An article is
+**published** — and only then reachable — iff it has **both** a real `date`
+**and** `status: "published"` (`isPublished` in `articles.ts`). This is not
+just a filter on the index: `/blog/[slug]/page.tsx` sets
+`generateStaticParams` to the published slugs only and `dynamicParams = false`,
+so Next.js never builds a page — and 404s any request — for a draft slug, even
+a guessed one. A draft with a `date` but `status: "draft"` (or vice versa)
+stays hidden; both conditions are required. The same `getPublishedArticles()`
+feeds the index, the RSS feed, and `sitemap.ts`, so there is exactly one
+gating rule enforced in exactly one place.
+
+Frontmatter is validated at build time (`parseArticleFile` in `articles.ts`):
+a missing/malformed required field, or two articles sharing a
+`canonical_url`, throws with a file-specific message rather than silently
+producing a broken or ambiguous page — matching the "fails loudly" preference
+elsewhere in the codebase (e.g. the module-boundary lint rule).
+
+**3. The blog is a fully shell-excluded, standalone editorial surface.**
+`/blog` is added to `AppShellWrapper`'s `SHELL_EXCLUDED` list (joining
+`/landing` and `/surah`) — no app sidebar/tool nav. `apps/web/src/app/blog/layout.tsx`
+wraps the index and article routes in the design's own slim header/footer and
+loads the editorial serif face (`Source Serif 4`, via `next/font/google`,
+scoped to this layout only) alongside the app's existing Hanken
+Grotesk/IBM Plex Arabic. Blog-specific prose/editorial components
+(`ArticleBody`, `CodeBlock`, `DiagramFrame`, `ArticleTOC`, `SeriesNav`,
+`ContributeCallout`, `ScrollProgress`, etc.) live under
+`apps/web/src/components/blog/` rather than `packages/ui` — the blog is
+web-only (no mobile reader planned) and these aren't cross-platform Noor
+primitives (ADR 0023 reserves `packages/ui` for those). They do reuse the
+existing `Btn`, `Icon`, `Logo`, `Khatam`, and `N` tokens from `packages/ui`, and
+inherit the site-wide Noor theme automatically via the existing
+`[data-theme]` CSS variables — no separate theme toggle is added.
+
+**4. Pagination is static-data + client-side state, not infinite scroll.**
+The index page (`app/blog/page.tsx`, a server component) calls
+`getPublishedArticles()` once at build time and hands the full array to
+`BlogIndexClient`, a small client component holding only UI state (active
+series/tag filter, how many cards are shown so far, "Load more" appends a
+page). No dynamic data fetching, matching the static-first philosophy
+(ADR 0003) — the entire post list is already in the page's static payload.
+
+**5. `series` stays optional, per-post metadata — never a fixed set.**
+A post with `series: null` is a first-class standalone post, not a fallback
+case. Prev/next navigation (`getSeriesNeighbors`) only ever looks within the
+same series, ordered by date; a missing neighbor (or no series at all) simply
+renders nothing on that side — never a placeholder or dead link.
+
+## Consequences
+
+- **Zero new runtime surface.** Everything blog-related is `force-static`
+  (`[slug]/page.tsx`, `blog/page.tsx`, `blog/rss.xml/route.ts`) — republishing
+  an article is a commit + rebuild, not a database write. No entry is needed
+  in `next.config.mjs`'s `outputFileTracingIncludes` since nothing reads
+  `docs/articles` at request time.
+- **New dependencies:** `gray-matter` (frontmatter), `unified` + `remark-parse`
+  - `remark-gfm` + `remark-directive` + `mdast-util-to-string` (Markdown →
+    blocks), `mermaid` (client-side diagram rendering only, dynamically
+    imported so it never runs during the server/static render pass).
+- **Mermaid is best-effort at render time.** If `mermaid.render()` throws (a
+  malformed diagram), `DiagramFrame` shows a fallback frame instead of crashing
+  the article — it never blocks a build, since rendering happens client-side
+  after hydration, not during static generation.
+- **This ADR does not ship any of the 12 planned articles.** `docs/articles/`
+  starts empty except for `README.md` (the frontmatter schema for
+  contributors); the index and feed both handle zero published articles
+  cleanly ("No posts yet"). Articles are added one at a time as separate,
+  reviewable commits — each one is exactly the "publish gating" flip described
+  in #226.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,44 +7,45 @@ record is short: the problem, the decision, and what it costs us.
 ADRs 0002–0009 were written together to document decisions already made and shipped
 through Phases 1–3; later decisions get their own record at the time they're made.
 
-| #                                             | Decision                                                               | Status   |
-| --------------------------------------------- | ---------------------------------------------------------------------- | -------- |
-| [0001](0001-modular-monolith.md)              | Modular monolith with lint-enforced boundaries                         | Accepted |
-| [0002](0002-quran-data-sourcing.md)           | Quran data: sourcing, reproducible ingestion, licensing                | Accepted |
-| [0003](0003-static-first-delivery.md)         | Static-first delivery on Next.js / Vercel (no database)                | Accepted |
-| [0004](0004-public-api.md)                    | Public API: static REST/OpenAPI + typed tRPC                           | Accepted |
-| [0005](0005-content-plugin-system.md)         | Content plugin system (translations/reciters/tafsir/hadith)            | Accepted |
-| [0006](0006-local-first-persistence.md)       | Local-first persistence — no accounts                                  | Accepted |
-| [0007](0007-hifz-spaced-repetition.md)        | Hifz scheduling: SM-2 in core behind a port                            | Accepted |
-| [0008](0008-recitation-audio-highlighting.md) | Recitation audio + word-by-word highlighting                           | Accepted |
-| [0009](0009-mobile-app.md)                    | Mobile app (Expo) sharing the monorepo                                 | Accepted |
-| [0010](0010-translation-selection.md)         | Translation selection: grouped, searchable, local-first                | Accepted |
-| [0011](0011-translation-catalog-runtime.md)   | Full translation catalogue + multi-tafsir, runtime-fetched             | Accepted |
-| [0012](0012-prayer-times.md)                  | Prayer times: adhan behind a port, computed on demand                  | Accepted |
-| [0013](0013-qibla.md)                         | Qibla: a pure great-circle bearing in `core`, no port                  | Accepted |
-| [0014](0014-hijri-calendar.md)                | Hijri calendar: tabular arithmetic in `core` + adjustment              | Accepted |
-| [0015](0015-zakat.md)                         | Zakat: agreed monetary core in `core`, choice-points exposed           | Accepted |
-| [0016](0016-adhkar.md)                        | Adhkar: bundled Ḥiṣn al-Muslim content + a pure counter                | Accepted |
-| [0017](0017-adhkar-reminders.md)              | Adhkar reminders: pure windows off prayer times, in-app reach          | Accepted |
-| [0018](0018-local-data-backup.md)             | Local data backup: file export/import as the sync substitute           | Accepted |
-| [0019](0019-prayer-reminders.md)              | Per-prayer reminders behind a `Notifier` port                          | Accepted |
-| [0020](0020-prayer-tracker.md)                | Prayer tracker: a pure local prayer log, no port                       | Accepted |
-| [0021](0021-global-search.md)                 | Global search: one client index over several sources                   | Accepted |
-| [0022](0022-hadith-ingested-search.md)        | Hadith ingested at build time, searched on the client                  | Accepted |
-| [0023](0023-noor-design-system.md)            | Noor design system: single source of truth across web and mobile       | Accepted |
-| [0024](0024-local-storage-ports.md)           | Typed storage ports for local-first state (the sync seam)              | Accepted |
-| [0025](0025-reading-plans.md)                 | Reading plans: pure schedule engine, catalogue bundled in core         | Accepted |
-| [0026](0026-browser-extension.md)             | Browser extension: thin client over the public REST API                | Accepted |
-| [0027](0027-generated-theme-css.md)           | Theme CSS generated from one token source (amends 0023)                | Accepted |
-| [0028](0028-persistence-enforcement.md)       | Persistence behind store adapters is lint-enforced (amends 0024)       | Accepted |
-| [0029](0029-mobile-notifier.md)               | Mobile notifications: ExpoNotifier behind the Notifier port            | Accepted |
-| [0030](0030-qada-tracker.md)                  | Qaḍāʾ tracker: missed-prayer backlog behind a store port               | Accepted |
-| [0031](0031-haid-pause.md)                    | Ḥayḍ pause: menstrual pause preserves the prayer streak                | Accepted |
-| [0032](0032-achievements.md)                  | Achievements: declarative badge engine over existing local data        | Accepted |
-| [0033](0033-account-sync.md)                  | Cross-device sync: opt-in, E2E-encrypted, zero-PII (amends 0003, 0006) | Accepted |
-| [0034](0034-fasting-qada.md)                  | Fasting qaḍāʾ: make-up fasts derived from the ḥayḍ pause ∩ Ramaḍān     | Accepted |
+| #                                             | Decision                                                                    | Status   |
+| --------------------------------------------- | --------------------------------------------------------------------------- | -------- |
+| [0001](0001-modular-monolith.md)              | Modular monolith with lint-enforced boundaries                              | Accepted |
+| [0002](0002-quran-data-sourcing.md)           | Quran data: sourcing, reproducible ingestion, licensing                     | Accepted |
+| [0003](0003-static-first-delivery.md)         | Static-first delivery on Next.js / Vercel (no database)                     | Accepted |
+| [0004](0004-public-api.md)                    | Public API: static REST/OpenAPI + typed tRPC                                | Accepted |
+| [0005](0005-content-plugin-system.md)         | Content plugin system (translations/reciters/tafsir/hadith)                 | Accepted |
+| [0006](0006-local-first-persistence.md)       | Local-first persistence — no accounts                                       | Accepted |
+| [0007](0007-hifz-spaced-repetition.md)        | Hifz scheduling: SM-2 in core behind a port                                 | Accepted |
+| [0008](0008-recitation-audio-highlighting.md) | Recitation audio + word-by-word highlighting                                | Accepted |
+| [0009](0009-mobile-app.md)                    | Mobile app (Expo) sharing the monorepo                                      | Accepted |
+| [0010](0010-translation-selection.md)         | Translation selection: grouped, searchable, local-first                     | Accepted |
+| [0011](0011-translation-catalog-runtime.md)   | Full translation catalogue + multi-tafsir, runtime-fetched                  | Accepted |
+| [0012](0012-prayer-times.md)                  | Prayer times: adhan behind a port, computed on demand                       | Accepted |
+| [0013](0013-qibla.md)                         | Qibla: a pure great-circle bearing in `core`, no port                       | Accepted |
+| [0014](0014-hijri-calendar.md)                | Hijri calendar: tabular arithmetic in `core` + adjustment                   | Accepted |
+| [0015](0015-zakat.md)                         | Zakat: agreed monetary core in `core`, choice-points exposed                | Accepted |
+| [0016](0016-adhkar.md)                        | Adhkar: bundled Ḥiṣn al-Muslim content + a pure counter                     | Accepted |
+| [0017](0017-adhkar-reminders.md)              | Adhkar reminders: pure windows off prayer times, in-app reach               | Accepted |
+| [0018](0018-local-data-backup.md)             | Local data backup: file export/import as the sync substitute                | Accepted |
+| [0019](0019-prayer-reminders.md)              | Per-prayer reminders behind a `Notifier` port                               | Accepted |
+| [0020](0020-prayer-tracker.md)                | Prayer tracker: a pure local prayer log, no port                            | Accepted |
+| [0021](0021-global-search.md)                 | Global search: one client index over several sources                        | Accepted |
+| [0022](0022-hadith-ingested-search.md)        | Hadith ingested at build time, searched on the client                       | Accepted |
+| [0023](0023-noor-design-system.md)            | Noor design system: single source of truth across web and mobile            | Accepted |
+| [0024](0024-local-storage-ports.md)           | Typed storage ports for local-first state (the sync seam)                   | Accepted |
+| [0025](0025-reading-plans.md)                 | Reading plans: pure schedule engine, catalogue bundled in core              | Accepted |
+| [0026](0026-browser-extension.md)             | Browser extension: thin client over the public REST API                     | Accepted |
+| [0027](0027-generated-theme-css.md)           | Theme CSS generated from one token source (amends 0023)                     | Accepted |
+| [0028](0028-persistence-enforcement.md)       | Persistence behind store adapters is lint-enforced (amends 0024)            | Accepted |
+| [0029](0029-mobile-notifier.md)               | Mobile notifications: ExpoNotifier behind the Notifier port                 | Accepted |
+| [0030](0030-qada-tracker.md)                  | Qaḍāʾ tracker: missed-prayer backlog behind a store port                    | Accepted |
+| [0031](0031-haid-pause.md)                    | Ḥayḍ pause: menstrual pause preserves the prayer streak                     | Accepted |
+| [0032](0032-achievements.md)                  | Achievements: declarative badge engine over existing local data             | Accepted |
+| [0033](0033-account-sync.md)                  | Cross-device sync: opt-in, E2E-encrypted, zero-PII (amends 0003, 0006)      | Accepted |
+| [0034](0034-fasting-qada.md)                  | Fasting qaḍāʾ: make-up fasts derived from the ḥayḍ pause ∩ Ramaḍān          | Accepted |
 | [0035](0035-indopak-script.md)                | IndoPak Arabic script (text fetched live, not bundled — amended 2026-06-28) | Accepted |
-| [0036](0036-bundled-word-level-data.md)       | Bundle recitation timings (quran-align, CC-BY); keep transliteration live | Accepted |
+| [0036](0036-bundled-word-level-data.md)       | Bundle recitation timings (quran-align, CC-BY); keep transliteration live   | Accepted |
+| [0037](0037-engineering-blog.md)              | Engineering blog: Markdown at build time, gated by frontmatter              | Accepted |
 
 ## Writing a new ADR
 

--- a/docs/articles/README.md
+++ b/docs/articles/README.md
@@ -1,0 +1,76 @@
+# Blog articles
+
+Each file here is one post on the engineering blog at `/blog`. Add a new
+`.md` file to publish a new post — see ADR [0037](../adr/0037-engineering-blog.md)
+for how the pipeline works.
+
+## Frontmatter
+
+```yaml
+---
+title: "Anatomy of an Open-Source Quran Platform"
+description: "A one- or two-sentence summary shown on the index card and in link previews."
+tags: ["architecture", "typescript", "monorepo"]
+series: "The Ummah Library engineering series" # or: null for a standalone post
+order: 1 # your intended reading order within a series; also a tiebreak
+date: null # "YYYY-MM-DD", or null until it's ready to go live
+canonical_url: "anatomy-of-a-quran-platform" # the URL slug: /blog/<canonical_url>
+status: "draft" # "draft" | "published"
+---
+```
+
+## Publishing an article
+
+**An article is public only once it has both a real `date` _and_
+`status: "published"`.** Until then it has no route at all — not draft-with-a-banner,
+not reachable by a guessed URL, simply absent from the build. To publish:
+write the article with `status: "draft"` and `date: null`, get it reviewed,
+then in one commit set `date` to the real publish date and `status` to
+`"published"`. That single commit is the entire "go live" action.
+
+`canonical_url` must be unique across every file in this directory — the build
+fails loudly if two articles collide.
+
+## Writing the body
+
+The body below the frontmatter is plain Markdown, parsed into the blog's block
+set: paragraphs, `##`/`###` headings, bulleted/numbered lists, blockquotes,
+`---` rules, GitHub-flavored tables, and fenced code blocks. A few extras:
+
+- **Inline Arabic term with transliteration** — `:ar[قِبْلَة]{translit=qibla}`
+  renders as the Arabic word followed by its transliteration in parentheses.
+- **Mermaid diagram** — a fenced code block tagged `mermaid`, optionally with a
+  caption in the fence's info string:
+
+  ````
+  ```mermaid caption="apps → adapters → domain"
+  graph TD; Apps --> Adapters --> Domain;
+  ```
+  ````
+
+- **Blockquote citation** — an attributed quote is a blockquote whose last
+  paragraph starts with an em dash:
+
+  ```markdown
+  > The dependency rule is the overriding rule that makes this architecture work.
+  >
+  > — Internal ADR-0003
+  ```
+
+Headings deeper than `##`/`###` (a lone `#` or `####`+) are ignored — the
+article title comes from `title` in the frontmatter, not from the body.
+
+## Series
+
+`series` is optional, per-post metadata — not a fixed list maintained
+elsewhere. Leave it `null` for a standalone post. Posts sharing the same
+`series` string get "Previous/Next in series" navigation on the article page,
+ordered by `date`; a post with no neighbor on one side (the first or latest in
+its series) simply shows no control on that side.
+
+## Content policy
+
+Everything here is original engineering writing about this codebase — not
+Quranic or Hadith text or interpretation. If a post does quote or discuss
+Islamic content, follow the usual `needs-scholar-review` convention
+(see the root `AGENTS.md`).

--- a/docs/design/noor-prototype/app/app.jsx
+++ b/docs/design/noor-prototype/app/app.jsx
@@ -78,6 +78,9 @@ function TopBar({ query, setQuery, searchRef, go, mode, toggleTheme }) {
         {query ? <Icon name="close" size={16} color={N.faint} style={{ cursor: "pointer" }} onClick={() => setQuery("")} /> : <span style={{ fontSize: 12, color: N.faint, border: `1px solid ${N.border}`, borderRadius: 5, padding: "2px 6px" }}>⌘K</span>}
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+        <a href="Ummah Library Blog.html" className="ul-link ul-press" title="Read the blog" style={{ height: 40, padding: "0 14px", borderRadius: 11, border: `1px solid ${N.border}`, background: N.card, color: N.muted, display: "flex", alignItems: "center", gap: 8, flexShrink: 0, textDecoration: "none", fontFamily: N.ui, fontSize: 13.5, fontWeight: 600 }}>
+          <Icon name="tafsir" size={17} /> <span className="ul-hide-sm">Blog</span>
+        </a>
         <button className="ul-link ul-press" onClick={toggleTheme} title={mode === "dark" ? "Switch to a light theme" : "Switch to a dark theme"} style={{ width: 40, height: 40, borderRadius: 11, border: `1px solid ${N.border}`, background: N.card, color: N.muted, display: "grid", placeItems: "center", cursor: "pointer", flexShrink: 0 }}>
           <Icon name={mode === "dark" ? "sun" : "moon"} size={19} />
         </button>

--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Blog", () => {
+  test("the index renders standalone (no app shell) with the empty state", async ({ page }) => {
+    await page.goto("/blog");
+    await expect(page.getByRole("heading", { name: "Building Ummah Library" })).toBeVisible();
+    // docs/articles ships with no articles — the user adds them one at a time.
+    await expect(page.getByText("No posts yet — check back soon.")).toBeVisible();
+    // Shell-excluded: no app sidebar/tool nav, just the slim editorial header.
+    await expect(page.getByRole("link", { name: "Open the app" }).first()).toBeVisible();
+  });
+
+  test("the RSS feed is valid XML with the channel metadata", async ({ request }) => {
+    const res = await request.get("/blog/rss.xml");
+    expect(res.ok()).toBe(true);
+    expect(res.headers()["content-type"]).toContain("application/rss+xml");
+    const body = await res.text();
+    expect(body).toContain('<rss version="2.0">');
+    expect(body).toContain("Building Ummah Library");
+  });
+
+  test("an unpublished/unknown slug 404s — nothing is reachable by URL", async ({ page }) => {
+    const res = await page.goto("/blog/this-slug-does-not-exist");
+    expect(res?.status()).toBe(404);
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import boundaries from "eslint-plugin-boundaries";
+import reactHooks from "eslint-plugin-react-hooks";
 import globals from "globals";
 
 export default tseslint.config(
@@ -29,6 +30,15 @@ export default tseslint.config(
       // CommonJS config files (metro.config.js, babel.config.js) use require().
       "@typescript-eslint/no-require-imports": "off",
     },
+  },
+  {
+    // React/React Native hook rules (rules-of-hooks as an error; exhaustive-deps
+    // as a warning, matching the plugin's own recommended severities) — this is
+    // what the `react-hooks/exhaustive-deps` disable comments in the codebase
+    // are actually suppressing, so the rule needs to be registered for those
+    // comments to reference a real rule instead of erroring as unknown.
+    files: ["**/*.{tsx,jsx}"],
+    ...reactHooks.configs["recommended-latest"],
   },
   {
     // Service worker — browser + service worker globals (self, caches, clients).

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "^9.17.0",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-boundaries": "^6.0.2",
+    "eslint-plugin-react-hooks": "^5",
     "globals": "^15.14.0",
     "prettier": "^3.4.2",
     "turbo": "^2.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       eslint-plugin-boundaries:
         specifier: ^6.0.2
         version: 6.0.2(@typescript-eslint/parser@8.60.1(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5(eslint@9.39.4))(eslint@9.39.4)
+      eslint-plugin-react-hooks:
+        specifier: ^5
+        version: 5.2.0(eslint@9.39.4)
       globals:
         specifier: ^15.14.0
         version: 15.15.0
@@ -226,7 +229,7 @@ importers:
         version: 11.16.0
       next:
         specifier: ^15.1.3
-        version: 15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 15.5.19(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -3674,6 +3677,12 @@ packages:
     engines: {node: '>=18.18'}
     peerDependencies:
       eslint: '>=6.0.0'
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -9960,6 +9969,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4):
+    dependencies:
+      eslint: 9.39.4
+
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -11757,7 +11770,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@15.5.19(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
@@ -11765,7 +11778,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.19
       '@next/swc-darwin-x64': 15.5.19
@@ -12680,12 +12693,10 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
+  styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
-    optionalDependencies:
-      '@babel/core': 7.29.7
 
   styleq@0.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,15 +215,39 @@ importers:
       '@ummahlibrary/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      mdast-util-to-string:
+        specifier: ^4.0.0
+        version: 4.0.0
+      mermaid:
+        specifier: ^11.16.0
+        version: 11.16.0
       next:
         specifier: ^15.1.3
-        version: 15.5.19(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.0.0
         version: 19.2.7
       react-dom:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
+      remark-directive:
+        specifier: ^4.0.0
+        version: 4.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.6.3
@@ -390,6 +414,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -909,6 +936,12 @@ packages:
   '@boundaries/elements@2.0.1':
     resolution: {integrity: sha512-sAWO3D8PFP6pBXdxxW93SQi/KQqqhE2AAHo3AgWfdtJXwO6bfK6/wUN81XnOZk0qRC6vHzUEKhjwVD9dtDWvxg==}
     engines: {node: '>=18.18'}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1495,6 +1528,12 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
   '@ide/backoff@1.0.0':
     resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
 
@@ -1831,6 +1870,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -2292,6 +2334,102 @@ packages:
   '@types/chrome@0.0.287':
     resolution: {integrity: sha512-wWhBNPNXZHwycHKNYnexUcpSbrihVZu++0rdp6GEk5ZgAglenLx+RwdEouh6FrHS0XQiOxSd62yaujM1OoQlZQ==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -2300,6 +2438,9 @@ packages:
 
   '@types/filewriter@0.0.33':
     resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -2325,6 +2466,12 @@ packages:
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
@@ -2341,6 +2488,15 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2519,6 +2675,9 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@urql/core@5.2.0':
     resolution: {integrity: sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==}
@@ -2764,6 +2923,9 @@ packages:
   badgin@1.2.3:
     resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2872,6 +3034,9 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -2887,6 +3052,18 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
@@ -2983,6 +3160,10 @@ packages:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
 
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -3003,6 +3184,12 @@ packages:
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -3035,9 +3222,168 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3066,6 +3412,9 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
@@ -3109,6 +3458,9 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -3132,6 +3484,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
@@ -3150,6 +3505,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3229,6 +3587,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -3257,6 +3618,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-import-context@0.1.9:
     resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
@@ -3490,6 +3855,13 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3681,6 +4053,13 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
@@ -3792,6 +4171,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -3813,8 +4195,21 @@ packages:
   inline-style-prefixer@7.0.1:
     resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -3838,10 +4233,17 @@ packages:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3858,6 +4260,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
@@ -4014,8 +4419,19 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -4024,6 +4440,12 @@ packages:
   lan-network@0.2.1:
     resolution: {integrity: sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==}
     hasBin: true
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -4117,6 +4539,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -4132,6 +4557,9 @@ packages:
   log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
     engines: {node: '>=4'}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -4171,12 +4599,56 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-directive@3.1.0:
+    resolution: {integrity: sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
@@ -4193,6 +4665,9 @@ packages:
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
   metro-babel-transformer@0.83.3:
     resolution: {integrity: sha512-1vxlvj2yY24ES1O5RsSIvg4a4WeL7PFXgKOHvXTXiW0deLvQr28ExXj6LjwCCDZ4YZLhq6HddLpZnX4dEdSq5g==}
@@ -4309,6 +4784,93 @@ packages:
     resolution: {integrity: sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==}
     engines: {node: '>=20.19.4'}
     hasBin: true
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-directive@4.0.0:
+    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -4594,9 +5156,15 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-manager-detector@1.7.0:
+    resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
@@ -4612,6 +5180,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -4679,6 +5250,12 @@ packages:
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4892,6 +5469,18 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
+  remark-directive@4.0.0:
+    resolution: {integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -4945,16 +5534,25 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.61.1:
     resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -4982,6 +5580,10 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5153,6 +5755,9 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@5.2.0:
     resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
     engines: {node: '>=6'}
@@ -5164,6 +5769,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
@@ -5199,6 +5808,9 @@ packages:
 
   styleq@0.1.3:
     resolution: {integrity: sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==}
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -5265,6 +5877,10 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -5314,11 +5930,18 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -5414,6 +6037,21 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -5447,6 +6085,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -5464,6 +6106,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -5718,6 +6366,9 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
 
   '@0no-co/graphql.web@1.2.0': {}
@@ -5728,6 +6379,11 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.7.0
+      tinyexec: 1.2.4
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -6377,6 +7033,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -6994,6 +7654,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@ide/backoff@1.0.0': {}
 
   '@img/colour@1.1.0': {}
@@ -7312,6 +7980,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -7823,6 +8495,127 @@ snapshots:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/estree@1.0.9': {}
 
   '@types/filesystem@0.0.36':
@@ -7830,6 +8623,8 @@ snapshots:
       '@types/filewriter': 0.0.33
 
   '@types/filewriter@0.0.33': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -7855,6 +8650,12 @@ snapshots:
     dependencies:
       '@types/node': 22.19.19
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
+
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
@@ -7872,6 +8673,13 @@ snapshots:
       '@types/node': 22.19.19
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -8041,6 +8849,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@urql/core@5.2.0':
     dependencies:
@@ -8362,6 +9175,8 @@ snapshots:
 
   badgin@1.2.3: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -8467,6 +9282,8 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  ccount@2.0.1: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -8487,6 +9304,14 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@2.2.0: {}
 
@@ -8576,6 +9401,8 @@ snapshots:
 
   commander@7.2.0: {}
 
+  commander@8.3.0: {}
+
   compressible@2.0.18:
     dependencies:
       mime-db: 1.54.0
@@ -8608,6 +9435,14 @@ snapshots:
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   cross-fetch@3.2.0:
     dependencies:
@@ -8649,10 +9484,196 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
+
+  dayjs@1.11.21: {}
 
   debug@2.6.9:
     dependencies:
@@ -8667,6 +9688,10 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
 
   decode-uri-component@0.2.2: {}
 
@@ -8702,6 +9727,10 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -8716,6 +9745,10 @@ snapshots:
   destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   diff-match-patch@1.0.5: {}
 
@@ -8734,6 +9767,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -8800,6 +9837,8 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
+  es-toolkit@1.49.0: {}
+
   esbuild@0.21.5:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.21.5
@@ -8864,6 +9903,8 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-import-context@0.1.9(unrs-resolver@1.12.2):
     dependencies:
@@ -9154,6 +10195,12 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -9363,6 +10410,15 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
+  hachure-fill@0.5.2: {}
+
   handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
@@ -9474,6 +10530,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -9491,9 +10549,20 @@ snapshots:
     dependencies:
       css-in-js-utils: 3.1.0
 
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
+
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-arguments@1.2.0:
     dependencies:
@@ -9516,7 +10585,11 @@ snapshots:
     dependencies:
       hasown: 2.0.4
 
+  is-decimal@2.0.1: {}
+
   is-docker@2.2.1: {}
+
+  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -9533,6 +10606,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-nan@1.3.2:
     dependencies:
@@ -9736,13 +10811,25 @@ snapshots:
 
   json5@2.2.3: {}
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
+  khroma@2.1.0: {}
+
+  kind-of@6.0.3: {}
+
   kleur@3.0.3: {}
 
   lan-network@0.2.1: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   leven@3.1.0: {}
 
@@ -9817,6 +10904,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.debounce@4.0.8: {}
 
   lodash.groupby@4.6.0: {}
@@ -9828,6 +10917,8 @@ snapshots:
   log-symbols@2.2.0:
     dependencies:
       chalk: 2.4.2
+
+  longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -9865,9 +10956,129 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
+
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-directive@3.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.0.14: {}
 
@@ -9880,6 +11091,30 @@ snapshots:
       is-plain-obj: 2.1.0
 
   merge-stream@2.0.0: {}
+
+  mermaid@11.16.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.12
+      es-toolkit: 1.49.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
 
   metro-babel-transformer@0.83.3:
     dependencies:
@@ -10230,6 +11465,207 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-directive@4.0.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -10321,7 +11757,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@15.5.19(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
@@ -10329,7 +11765,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.19
       '@next/swc-darwin-x64': 15.5.19
@@ -10477,9 +11913,21 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.7.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse-ms@4.0.0: {}
 
@@ -10492,6 +11940,8 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
@@ -10540,6 +11990,13 @@ snapshots:
       xmlbuilder: 15.1.1
 
   pngjs@3.4.0: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -10844,6 +12301,41 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  remark-directive@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-directive: 3.1.0
+      micromark-extension-directive: 4.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -10890,6 +12382,8 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.61.1:
     dependencies:
       '@types/estree': 1.0.9
@@ -10921,9 +12415,18 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -10948,6 +12451,11 @@ snapshots:
   scheduler@0.26.0: {}
 
   scheduler@0.27.0: {}
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
 
   semver@6.3.1: {}
 
@@ -11141,6 +12649,11 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@5.2.0:
     dependencies:
       ansi-regex: 4.1.1
@@ -11152,6 +12665,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-final-newline@4.0.0: {}
 
@@ -11165,12 +12680,16 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  styled-jsx@5.1.6(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   styleq@0.1.3: {}
+
+  stylis@4.4.0: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -11249,6 +12768,8 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -11286,9 +12807,13 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  trough@2.2.0: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-dedent@2.3.0: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -11368,6 +12893,35 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unpipe@1.0.0: {}
 
   unrs-resolver@1.12.2:
@@ -11425,6 +12979,8 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@14.0.1: {}
+
   uuid@3.4.0: {}
 
   uuid@7.0.3: {}
@@ -11432,6 +12988,16 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-node@2.1.9(@types/node@22.19.19)(lightningcss@1.32.0)(terser@5.48.0):
     dependencies:
@@ -11645,3 +13211,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## What & why

Implements the engineering blog at `/blog` per the design vendored in #227: a build-time Markdown pipeline, the index/article/RSS routes, and the frontmatter gate that decides which articles are public. See [ADR 0037](docs/adr/0037-engineering-blog.md) for the full rationale.

- **Markdown pipeline** (`apps/web/src/lib/blog/`): `gray-matter` + `unified`/`remark-parse`/`remark-gfm`/`remark-directive` turn `docs/articles/*.md` frontmatter + body into the design's typed block shape (paragraphs, headings, lists, tables, blockquotes with citations, code blocks, Mermaid diagrams). A custom `:ar[قِبْلَة]{translit=qibla}` directive handles inline Arabic terms.
- **Publish gating (the actual "hide an article" mechanism):** an article is public only once it has both a real `date` *and* `status: "published"`. `/blog/[slug]/page.tsx` builds `generateStaticParams` from published slugs only with `dynamicParams = false`, so an unpublished article has no route at all — not reachable by a guessed URL, just absent from the build. The same `getPublishedArticles()` feeds the index, RSS feed, and sitemap.
- **Routes:** `/blog` (index, with series/tag filters + client-side "Load more" pagination over build-time data), `/blog/[slug]` (article), `/blog/rss.xml` (feed) — all static, no new runtime surface.
- **UI:** the full editorial component set under `apps/web/src/components/blog/` (header/footer, cards, prose set, syntax-highlighted code block with copy, Mermaid-rendering diagram frame, scroll-spy TOC, series prev/next nav, contribute callout), reusing the existing `Btn`/`Icon`/`Logo`/`Khatam`/`N` tokens from `@ummahlibrary/ui`. `/blog` is added to `AppShellWrapper`'s shell-exclusion list. Fixed the design mockup's wrong lowercase GitHub org URL while wiring the contribute link.
- **`docs/articles/README.md`** documents the frontmatter schema; `docs/articles/` ships empty otherwise so articles can be added one at a time as separate, reviewable commits.

Closes #226

## Test plan

- 66 new unit/component tests (Markdown parsing, frontmatter validation, publish gating, series/tag selectors, RSS XML, prose rendering) plus a Playwright e2e spec (`e2e/blog.spec.ts`) covering the empty-state index, the RSS feed, and that an unknown/unpublished slug 404s.
- Manually drove `pnpm dev` with a throwaway test article (removed before commit) and screenshot-verified the empty state, index card, and every prose block type end-to-end, including a real rendered Mermaid diagram.
- `pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm build` all green on this branch.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] No module-boundary violations (`apps → packages` only; `core` imports nothing)
- [x] Any Islamic content is attributed and flagged `needs-scholar-review` if applicable — not applicable; no Quranic/Hadith content is added or changed

## Fixes picked up along the way (CI was red for reasons unrelated to the blog)

- **Lint:** `eslint-plugin-react-hooks` was never registered in `eslint.config.mjs`, so the `// eslint-disable-next-line react-hooks/exhaustive-deps` comments already in the codebase (e.g. `HifzDashboardScreen.tsx`) referenced an unknown rule, which ESLint 9's flat config treats as a hard error. Registered the plugin's `recommended-latest` config for `.tsx`/`.jsx` files (`rules-of-hooks` as an error — zero violations anywhere in the repo; `exhaustive-deps` as a warning, its own default severity, so the pre-existing dependency-array gaps it now surfaces don't fail the build).
- **Coverage:** the `apps/web/src/lib/**` function-coverage threshold in `vitest.config.ts` was sitting just under 95% (confirmed pre-existing via `git stash` against a clean `main`). Added a real test for `hifz-review-log-store.ts`, which had no coverage at all — it exercises the read/write round-trip and the corrupt-shape fallback (null/array/scalar) that the file's own doc comment already calls out as a risk for peer-synced data.
