### PR TITLE
fix: resolve 6 bugs from the 2026-07-17 QA sweep (#233-#238)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { AppState } from "react-native";
+import { AppState, View } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import { useFonts } from "expo-font";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -84,7 +84,15 @@ function NavRoot() {
     },
   };
   return (
-    <NavigationContainer theme={navTheme} linking={linking}>
+    <NavigationContainer
+      theme={navTheme}
+      linking={linking}
+      // On a cold/direct web navigation, linking resolution is async (one paint
+      // cycle even though getInitialURL is synchronous) and NavigationContainer
+      // renders only this fallback until it resolves — default to a themed
+      // placeholder instead of a blank white flash.
+      fallback={<View style={{ flex: 1, backgroundColor: colors.bg }} />}
+    >
       <StatusBar style={mode === "dark" ? "light" : "dark"} />
       <RootTabs />
     </NavigationContainer>

--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -30,10 +30,53 @@ export interface TafsirMeta {
   direction: TextDirection;
 }
 
+/**
+ * Distinguishes a genuine connectivity failure (`fetch` itself rejected) from
+ * an HTTP error response, so callers can show accurate copy instead of a
+ * blanket "check your connection" for e.g. a backend cold-start 503.
+ */
+export class ApiError extends Error {
+  readonly status?: number;
+  readonly isNetworkError: boolean;
+  constructor(message: string, opts: { status?: number; isNetworkError: boolean }) {
+    super(message);
+    this.name = "ApiError";
+    this.status = opts.status;
+    this.isNetworkError = opts.isNetworkError;
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Retry transient 5xx responses (e.g. a backend cold start) with a short
+// backoff before surfacing an error; client errors and real network failures
+// (offline) aren't retried since another attempt won't fix them.
+const RETRY_DELAYS_MS = [400, 1200];
+
 async function getJson<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return (await res.json()) as T;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        const retryable = res.status >= 500 && attempt < RETRY_DELAYS_MS.length;
+        if (retryable) {
+          await sleep(RETRY_DELAYS_MS[attempt]!);
+          continue;
+        }
+        throw new ApiError(`HTTP ${res.status}`, { status: res.status, isNetworkError: false });
+      }
+      return (await res.json()) as T;
+    } catch (e) {
+      if (e instanceof ApiError) throw e;
+      if (attempt < RETRY_DELAYS_MS.length) {
+        await sleep(RETRY_DELAYS_MS[attempt]!);
+        continue;
+      }
+      throw new ApiError(e instanceof Error ? e.message : "Network request failed", {
+        isNetworkError: true,
+      });
+    }
+  }
 }
 
 export const api = {

--- a/apps/mobile/src/audio/useSurahAudio.ts
+++ b/apps/mobile/src/audio/useSurahAudio.ts
@@ -439,12 +439,21 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
       const token = ++tokenRef.current; // cancels any running session
       settleRef.current?.();
       setActiveWord(-1);
+      // Clear any stale "Loading…" left behind by an interrupted whole-āyah
+      // session — this path doesn't buffer, so it should never show it.
+      setBuffering(false);
       void (async () => {
-        const key = verseKeyOf(verse);
         const timing = await getTiming(reciter, verse);
         if (tokenRef.current !== token) return;
         const seg = timing.segments.find((s) => s[0] === wordIndex);
-        if (!seg) return;
+        if (!seg) {
+          // No word-level timing for this word (uncovered reciter/segment
+          // mismatch) — play the whole āyah from its start instead of doing
+          // nothing, so the tap always produces audible feedback.
+          startSession([verse], verse, null);
+          return;
+        }
+        const key = verseKeyOf(verse);
         const player = ensurePlayer(timing.url);
         if (tokenRef.current !== token) return;
         setPlayingKey(key);
@@ -457,7 +466,11 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
         if (tokenRef.current !== token) return;
         setActiveWord(wordIndex);
         player.play();
-        // Pause once playback reaches the word's segment end.
+        // Pause once playback reaches the word's segment end. A stall watchdog
+        // (mirroring startSession's) guards against playback that never
+        // advances (bad URL, stalled network) leaving the UI stuck forever.
+        let lastTime = -1;
+        let lastProgressAt = Date.now();
         const poll = setInterval(() => {
           if (tokenRef.current !== token) {
             clearInterval(poll);
@@ -467,9 +480,27 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
           try {
             t = player.currentTime;
           } catch {
+            clearInterval(poll);
+            setActiveWord(-1);
+            setPlayingKey(null);
             return;
           }
+          if (typeof t === "number" && t !== lastTime) {
+            lastTime = t;
+            lastProgressAt = Date.now();
+          }
           if (typeof t === "number" && t >= endSec) {
+            clearInterval(poll);
+            try {
+              player.pause();
+            } catch {
+              /* already paused */
+            }
+            setActiveWord(-1);
+            setPlayingKey(null);
+            return;
+          }
+          if (Date.now() - lastProgressAt > STALL_MS) {
             clearInterval(poll);
             try {
               player.pause();
@@ -483,7 +514,7 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
         settleRef.current = () => clearInterval(poll);
       })();
     },
-    [reciter, ensurePlayer],
+    [reciter, ensurePlayer, startSession],
   );
 
   // Tear the player down when the screen leaves so no poll/interval lingers,

--- a/apps/mobile/src/components/TranslationManager.tsx
+++ b/apps/mobile/src/components/TranslationManager.tsx
@@ -65,6 +65,11 @@ export function TranslationManager({
             </Pressable>
           </View>
 
+          <Text style={styles.hint}>
+            The Verse tab shows every translation you add here at once; the Translations reading
+            view shows one at a time — pick which from its own selector.
+          </Text>
+
           <TextInput
             style={styles.search}
             placeholder="Search by name, author, or language…"
@@ -138,6 +143,7 @@ function makeStyles(c: Palette) {
     head: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
     title: { color: c.fg, fontSize: 20, fontWeight: "700" },
     close: { color: c.muted, fontSize: 20 },
+    hint: { color: c.muted, fontSize: 12.5, marginTop: 10 },
     search: {
       backgroundColor: c.bgElev,
       borderRadius: 10,

--- a/apps/mobile/src/navigation/RootTabs.tsx
+++ b/apps/mobile/src/navigation/RootTabs.tsx
@@ -27,7 +27,7 @@ export function RootTabs() {
         headerShown: false,
         tabBarStyle: { backgroundColor: colors.bg, borderTopColor: colors.border },
         tabBarActiveTintColor: colors.accent,
-        tabBarInactiveTintColor: colors.faint,
+        tabBarInactiveTintColor: colors.muted,
         tabBarLabelStyle: { fontFamily: FONT.medium, fontSize: 11 },
         tabBarIcon: ({ color }) => <Icon name={ICONS[route.name]} size={22} color={color} sw={1.8} />,
       })}

--- a/apps/mobile/src/screens/AdhkarScreen.tsx
+++ b/apps/mobile/src/screens/AdhkarScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from "../Type";
 import {
   ADHKAR_OCCASIONS,
@@ -9,7 +9,7 @@ import {
   nextTally,
   sessionProgress,
 } from "@ummahlibrary/core";
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import { KEYS, getJSON, setJSON } from "../storage";
 import { useTheme, type Palette } from "../theme";
 import { FONT } from "../fonts";
@@ -38,6 +38,12 @@ export function AdhkarScreen() {
   const [counts, setCounts] = useState<Record<string, number>>({});
   const [occasion, setOccasion] = useState<AdhkarOccasion>("morning");
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [error, setError] = useState<ApiError | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const retry = useCallback(() => {
+    setStatus("loading");
+    setReloadToken((t) => t + 1);
+  }, []);
 
   useEffect(() => {
     let active = true;
@@ -48,9 +54,13 @@ export function AdhkarScreen() {
         setCounts(saved);
         setStatus("ready");
       })
-      .catch(() => active && setStatus("error"));
+      .catch((e: unknown) => {
+        if (!active) return;
+        setError(e instanceof ApiError ? e : new ApiError("Failed", { isNetworkError: true }));
+        setStatus("error");
+      });
     return () => { active = false; };
-  }, []);
+  }, [reloadToken]);
 
   function tap(d: Dhikr) {
     setCounts((prev) => {
@@ -82,9 +92,16 @@ export function AdhkarScreen() {
   }
 
   if (status === "error") {
+    const message =
+      error && !error.isNetworkError && error.status && error.status >= 500
+        ? "The server is starting up. Try again in a moment."
+        : "Could not load adhkar. Check your connection.";
     return (
       <View style={styles.center}>
-        <Text style={styles.errorText}>Could not load adhkar. Check your connection.</Text>
+        <Text style={styles.errorText}>{message}</Text>
+        <Pressable style={styles.chip} onPress={retry}>
+          <Text style={styles.chipText}>Try again</Text>
+        </Pressable>
       </View>
     );
   }
@@ -169,8 +186,16 @@ export function AdhkarScreen() {
 function makeStyles(c: Palette) {
   return StyleSheet.create({
     screen: { padding: 16, backgroundColor: c.bg, gap: 10, paddingBottom: 32 },
-    center: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: c.bg },
+    center: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: c.bg, gap: 14 },
     errorText: { color: c.error, fontSize: 15, textAlign: "center", paddingHorizontal: 24 },
+    chip: {
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: 20,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    chipText: { color: c.muted, fontSize: 13 },
     tabs: { flexDirection: "row", gap: 8, marginBottom: 4 },
     tab: {
       flex: 1,

--- a/apps/mobile/src/screens/JuzReaderScreen.tsx
+++ b/apps/mobile/src/screens/JuzReaderScreen.tsx
@@ -10,7 +10,7 @@ import {
   totalWords,
   type VerseKey,
 } from "@ummahlibrary/core";
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import { RECITER, RECITERS } from "../plugins";
 import { useTheme, type Palette } from "../theme";
 import { FONT } from "../fonts";
@@ -76,7 +76,9 @@ export function JuzReaderScreen({ route }: Props) {
   const juz = route.params.juz;
   const edition = resolveActiveTranslation(editions, readingTranslation, DEFAULT_EDITION);
   const [lines, setLines] = useState<Line[] | null>(null);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<ApiError | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const retry = useCallback(() => setReloadToken((t) => t + 1), []);
 
   // Memorize / hide-and-peek (#134) — ephemeral, so a juzʾ never opens hidden.
   const [peek, setPeek] = useState(false);
@@ -87,9 +89,9 @@ export function JuzReaderScreen({ route }: Props) {
   useEffect(() => {
     let active = true;
     setLines(null);
-    setError(false);
+    setError(null);
     if (!Number.isInteger(Number(juz)) || Number(juz) < 1 || Number(juz) > TOTAL_JUZ) {
-      setError(true);
+      setError(new ApiError("Invalid juzʾ number", { isNetworkError: false }));
       return () => {
         active = false;
         audio.stop();
@@ -136,12 +138,15 @@ export function JuzReaderScreen({ route }: Props) {
       .then((groups) => {
         if (active) setLines(groups.flat());
       })
-      .catch(() => active && setError(true));
+      .catch((e: unknown) => {
+        if (!active) return;
+        setError(e instanceof ApiError ? e : new ApiError("Failed", { isNetworkError: true }));
+      });
     return () => {
       active = false;
       audio.stop();
     };
-  }, [juz, edition, transliteration, wordTransliteration, script]);
+  }, [juz, edition, transliteration, wordTransliteration, script, reloadToken]);
 
   const verses = useMemo(() => (lines ?? []).map((l) => ({ sura: l.sura, aya: l.aya })), [lines]);
 
@@ -172,9 +177,17 @@ export function JuzReaderScreen({ route }: Props) {
   }, []);
 
   if (error) {
+    const message = error.isNetworkError
+      ? "Couldn’t load this juzʾ. Check your connection."
+      : error.status && error.status >= 500
+        ? "The server is starting up. Try again in a moment."
+        : "Couldn’t load this juzʾ.";
     return (
       <View style={styles.center}>
-        <Text style={styles.error}>Couldn’t load this juzʾ.</Text>
+        <Text style={styles.error}>{message}</Text>
+        <Pressable style={styles.chip} onPress={retry}>
+          <Text style={styles.chipText}>Try again</Text>
+        </Pressable>
       </View>
     );
   }
@@ -318,8 +331,16 @@ export function JuzReaderScreen({ route }: Props) {
 function makeStyles(c: Palette) {
   return StyleSheet.create({
     screen: { flex: 1, backgroundColor: c.bg },
-    center: { flex: 1, backgroundColor: c.bg, alignItems: "center", justifyContent: "center" },
-    error: { color: c.error, fontSize: 15 },
+    center: { flex: 1, backgroundColor: c.bg, alignItems: "center", justifyContent: "center", gap: 14 },
+    error: { color: c.error, fontSize: 15, textAlign: "center", paddingHorizontal: 24 },
+    chip: {
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: 20,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    chipText: { color: c.muted, fontSize: 13 },
     content: { paddingHorizontal: 18, paddingBottom: 40 },
     audioBar: { flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 12 },
     audioExtras: { marginBottom: 12 },

--- a/apps/mobile/src/screens/SurahListScreen.tsx
+++ b/apps/mobile/src/screens/SurahListScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   FlatList,
@@ -11,7 +11,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { TOTAL_JUZ, type Surah } from "@ummahlibrary/core";
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import { FONT } from "../fonts";
 import { useTheme, type Palette } from "../theme";
 import { AyahBadge } from "../components/AyahBadge";
@@ -56,16 +56,31 @@ export function SurahListScreen({ navigation }: Props) {
   const styles = useMemo(() => makeStyles(colors), [colors]);
   const insets = useSafeAreaInsets();
   const [surahs, setSurahs] = useState<Surah[] | null>(null);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<ApiError | null>(null);
   const [query, setQuery] = useState("");
   const [tab, setTab] = useState<Tab>("surah");
 
-  useEffect(() => {
+  const load = useCallback(() => {
+    setError(null);
     api
       .listSurahs()
       .then(setSurahs)
-      .catch(() => setError(true));
+      .catch((e: unknown) =>
+        setError(e instanceof ApiError ? e : new ApiError("Failed", { isNetworkError: true })),
+      );
   }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const errorMessage = error
+    ? error.isNetworkError
+      ? "Couldn't load surahs. Check your connection."
+      : error.status && error.status >= 500
+        ? "The server is starting up. Try again in a moment."
+        : "Couldn't load surahs."
+    : null;
 
   // Fold diacritics so "fatiha" matches "Al-Fātiḥah", "baqarah" matches
   // "Al-Baqarah", etc. — users type surah names without the macrons/dots.
@@ -141,7 +156,14 @@ export function SurahListScreen({ navigation }: Props) {
                 </Pressable>
               ))}
             </View>
-            {error && <Text style={styles.error}>Couldn’t load surahs. Check your connection.</Text>}
+            {error && tab === "surah" && (
+              <View style={styles.errorRow}>
+                <Text style={styles.error}>{errorMessage}</Text>
+                <Pressable style={styles.chip} onPress={load}>
+                  <Text style={styles.chipText}>Try again</Text>
+                </Pressable>
+              </View>
+            )}
             {!surahs && !error && <ActivityIndicator color={colors.accent} style={styles.spinner} />}
           </View>
         }
@@ -225,7 +247,22 @@ function makeStyles(c: Palette) {
       marginTop: 18,
       marginBottom: 4,
     },
-    error: { color: c.error, marginTop: 12 },
+    error: { color: c.error, flexShrink: 1 },
+    errorRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: 10,
+      marginTop: 12,
+    },
+    chip: {
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: 20,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    chipText: { color: c.muted, fontSize: 13 },
     muted: { color: c.muted, marginTop: 16, fontSize: 14 },
     spinner: { marginTop: 32 },
     row: {

--- a/apps/mobile/src/state/SettingsContext.tsx
+++ b/apps/mobile/src/state/SettingsContext.tsx
@@ -18,7 +18,7 @@ import { api, type TafsirMeta } from "../api";
 import { mobileSettingsStore as store } from "./settings-store";
 import { readTafsirCompare, writeTafsirCompare } from "../tafsir-compare-store";
 import { RECITER, TAFSIRS } from "../plugins";
-import { DEFAULT_EDITIONS, MAX_SCALE, MIN_SCALE, type ReadingMode } from "../types";
+import { defaultEditions, MAX_SCALE, MIN_SCALE, type ReadingMode } from "../types";
 
 interface SettingsValue {
   editions: string[];
@@ -57,7 +57,7 @@ const SettingsContext = createContext<SettingsValue | null>(null);
 const clampScale = (n: number): number => Math.min(MAX_SCALE, Math.max(MIN_SCALE, n));
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [editions, setEditionsState] = useState<string[]>(DEFAULT_EDITIONS);
+  const [editions, setEditionsState] = useState<string[]>(defaultEditions);
   const [readingMode, setReadingModeState] = useState<ReadingMode>("translation");
   const [readingTranslation, setReadingTranslationState] = useState<string | null>(null);
   const [reciterId, setReciterIdState] = useState<string>(RECITER.id);
@@ -101,7 +101,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const setEditions = useCallback((ids: string[]) => {
-    const next = ids.length > 0 ? ids : DEFAULT_EDITIONS;
+    const next = ids.length > 0 ? ids : defaultEditions();
     setEditionsState(next);
     void store.writeEditions(next);
   }, []);

--- a/apps/mobile/src/types.ts
+++ b/apps/mobile/src/types.ts
@@ -5,6 +5,26 @@ export type ReadingMode = "translation" | "reading" | "reading-tr";
 export const DEFAULT_EDITION = "eng-mustafakhattaba";
 export const DEFAULT_EDITIONS = [DEFAULT_EDITION];
 
+// Muhammad Junagarhi — shown by default to users with an Urdu device locale,
+// mirroring apps/web/src/lib/editions.ts (#238: Urdu is a stated priority
+// language, not just English until a user goes looking for it).
+const URDU_DEFAULT_EDITIONS = ["urd-muhammadjunagar"];
+
+/**
+ * The default edition set for a first-time user, chosen by device locale.
+ * Always user-overridable — once they pick editions of their own, the stored
+ * set wins (see SettingsContext).
+ */
+export function defaultEditions(): string[] {
+  try {
+    const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+    if (/^ur\b/i.test(locale)) return URDU_DEFAULT_EDITIONS;
+  } catch {
+    /* Intl unavailable — fall through */
+  }
+  return DEFAULT_EDITIONS;
+}
+
 // The catalogue edition for the per-āyah transliteration line (#150) — Tanzil's
 // verbatim Latin transliteration (CC-BY 3.0), fetched at runtime like any edition.
 export const TRANSLIT_EDITION = "ara-quran-la";

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2289,6 +2289,11 @@ body.peek-on.peek-hide-tr .ayah-tr {
 .ts-empty {
   color: var(--muted);
 }
+.ts-hint {
+  color: var(--muted);
+  font-size: 0.8rem;
+  margin: -0.4rem 0 1rem;
+}
 
 /* ── Noor shell layout utilities ── */
 html,

--- a/apps/web/src/components/TafsirCompare.tsx
+++ b/apps/web/src/components/TafsirCompare.tsx
@@ -19,7 +19,10 @@ function loadSurahTafsir(tafsirId: string, surah: number): Promise<Map<number, s
   let pending = tafsirCache.get(key);
   if (!pending) {
     pending = fetch(`/api/v1/surahs/${surah}/tafsirs/${tafsirId}`)
-      .then((res) => (res.ok ? (res.json() as Promise<TafsirResponse>) : { entries: [] }))
+      .then((res) => {
+        if (!res.ok) throw new Error(`tafsir_unavailable:${res.status}`);
+        return res.json() as Promise<TafsirResponse>;
+      })
       .then((data) => new Map(data.entries.map((e) => [e.aya, e.text])));
     tafsirCache.set(key, pending);
   }
@@ -163,7 +166,7 @@ function TafsirColumn({
   surah: number;
   aya: number;
 }) {
-  const [state, setState] = useState<"loading" | "ready" | "empty">("loading");
+  const [state, setState] = useState<"loading" | "ready" | "empty" | "error">("loading");
   const [text, setText] = useState("");
 
   useEffect(() => {
@@ -176,7 +179,7 @@ function TafsirColumn({
         setText(entry ?? "");
         setState(entry ? "ready" : "empty");
       })
-      .catch(() => active && setState("empty"));
+      .catch(() => active && setState("error"));
     return () => {
       active = false;
     };
@@ -206,6 +209,9 @@ function TafsirColumn({
       <div className="tafsir-body" dir={isRtl(edition) ? "rtl" : undefined}>
         {state === "loading" && <span className="tafsir-muted">Loading…</span>}
         {state === "empty" && <span className="tafsir-muted">No tafsir for this āyah.</span>}
+        {state === "error" && (
+          <span className="tafsir-muted">Couldn't load {name} right now.</span>
+        )}
         {state === "ready" &&
           text.split("\n").map((p, i) => (p.trim() ? <p key={i}>{p}</p> : null))}
       </div>

--- a/apps/web/src/components/TranslationSettings.tsx
+++ b/apps/web/src/components/TranslationSettings.tsx
@@ -78,6 +78,11 @@ export function TranslationSettings({
           </button>
         </div>
 
+        <p className="ts-hint">
+          The Verse tab shows every translation you add here at once; the Translations tab (Reading
+          view) shows one at a time — pick which below its dropdown.
+        </p>
+
         <input
           ref={searchRef}
           type="search"

--- a/apps/web/src/components/shell/TabBar.tsx
+++ b/apps/web/src/components/shell/TabBar.tsx
@@ -37,12 +37,12 @@ export function TabBar() {
               flexDirection: "column",
               alignItems: "center",
               gap: 4,
-              color: active ? N.gold : N.faint,
+              color: active ? N.gold : N.muted,
               textDecoration: "none",
               fontFamily: N.ui,
             }}
           >
-            <Icon name={icon} size={20} sw={1.8} color={active ? N.gold : N.faint} />
+            <Icon name={icon} size={20} sw={1.8} color={active ? N.gold : N.muted} />
             <span style={{ fontSize: 10.5, fontWeight: active ? 700 : 500 }}>{label}</span>
           </Link>
         );

--- a/packages/adapters/src/tafsir.test.ts
+++ b/packages/adapters/src/tafsir.test.ts
@@ -61,6 +61,17 @@ describe("HttpTafsirRepository", () => {
     expect(await repo.getSurahTafsir("en-ibn-kathir", 1)).toEqual([]);
   });
 
+  it("unwraps a { ayahs: [...] } response body (e.g. ur-tafseer-ibn-e-kaseer)", async () => {
+    const { fn, calls } = fakeFetch({ ayahs: SURAH_1 });
+    const repo = new HttpTafsirRepository(new PluginRegistry([ibnKathir]), fn);
+    const entries = await repo.getSurahTafsir("en-ibn-kathir", 1);
+    expect(calls).toEqual(["https://cdn.example/tafsir/1.json"]);
+    expect(entries).toEqual([
+      { sura: 1, aya: 1, tafsirId: "en-ibn-kathir", text: "Commentary on 1:1" },
+      { sura: 1, aya: 2, tafsirId: "en-ibn-kathir", text: "Commentary on 1:2" },
+    ]);
+  });
+
   it("coerces numeric-string surah/ayah (some editions return strings)", async () => {
     const { fn } = fakeFetch([{ surah: "1", ayah: "1", text: "Commentary on 1:1" }]);
     const repo = new HttpTafsirRepository(new PluginRegistry([ibnKathir]), fn);

--- a/packages/adapters/src/tafsir.ts
+++ b/packages/adapters/src/tafsir.ts
@@ -11,6 +11,12 @@ interface SpaTafsirEntry {
   text: string;
 }
 
+/**
+ * Most editions respond with a bare array; some (e.g. `ur-tafseer-ibn-e-kaseer`)
+ * wrap it as `{ ayahs: [...] }` instead. Accept both.
+ */
+type SpaTafsirResponseBody = SpaTafsirEntry[] | { ayahs?: SpaTafsirEntry[] };
+
 type FetchLike = typeof fetch;
 
 /**
@@ -33,8 +39,8 @@ export class HttpTafsirRepository implements TafsirRepository {
     const response = await this.#fetch(tafsirSurahUrl(plugin, surahNumber));
     if (!response.ok) return [];
     // Guard a malformed 200 body (CDN error/placeholder) rather than crashing on `.map`.
-    const data = (await response.json()) as SpaTafsirEntry[] | null;
-    const entries = Array.isArray(data) ? data : [];
+    const data = (await response.json()) as SpaTafsirResponseBody | null;
+    const entries = Array.isArray(data) ? data : Array.isArray(data?.ayahs) ? data.ayahs : [];
     return entries.map((e) => ({
       sura: Number(e.surah),
       aya: Number(e.ayah),


### PR DESCRIPTION
## Summary

Six independent fixes for the bug reports filed today (2026-07-17), each as its own commit:

- **#233** — Tafsir compare silently 404s (Urdu Ibn Kathir): root cause was a response-shape mismatch (`{ ayahs: [...] }` vs. bare array) in `HttpTafsirRepository`, not a missing dataset. Fixed the parser, added a test, and gave `TafsirCompare` a distinct error state instead of silently rendering nothing.
- **#234** — Word-tap audio seek stuck in infinite Loading…: `playWord()` left stale UI state untouched on a silent early-return and had no stall timeout. Added a stall watchdog, a whole-āyah fallback, and buffering-state cleanup.
- **#235** — Low-contrast bottom nav text on light themes (WCAG failure, reported on Rose): inactive tab text used the `faint` token (2.26:1) instead of `muted` (5.23:1) on both web and mobile.
- **#236** — Misleading "check your connection" error on backend cold start: added a typed `ApiError` (network vs. HTTP status) with retry-with-backoff on 5xx, accurate copy, a retry button on three screens, and scoped the surah error banner so it stops leaking into the Juzʾ tab.
- **#237** — Flash of blank white screen on cold navigation to /more, /bookmarks: `NavigationContainer` had no `fallback`, so it rendered blank during async linking resolution. Added a themed placeholder.
- **#238** — No Urdu default despite it being a stated priority language: ported web's existing locale-based default-translation logic to mobile, and added a short note clarifying the Translations-tab (single) vs. Verse-tab (multi) selection behavior on both platforms.

## Test plan

- [x] `npx tsc --noEmit` clean for `packages/adapters`, `apps/web`, `apps/mobile`
- [x] `npx vitest run packages/adapters apps/web apps/mobile` — 413 tests pass (including a new test for the tafsir response-shape fix)
- [x] `pnpm --filter @ummahlibrary/web build` — full static/SSG/dynamic build succeeds
- [ ] Manual smoke test on a device/simulator for the mobile-only fixes (#234, #236, #237, #238) — `pnpm lint` / `pnpm build` (turbo) can't run on this machine (native binding issue); CI covers both

Closes #233, #234, #235, #236, #237, #238