### PR TITLE
fix(web): stop the skip-link from breaking RTL scroll geometry

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -33,18 +33,32 @@
   outline-offset: 2px;
   border-radius: 4px;
 }
+/* Hidden-until-focused via clipping to a 1px box, not an off-canvas offset —
+   an offset like `left: -9999px` extends the document's scrollable area in
+   that direction, which is catastrophic under `dir="rtl"` (ADR 0040): the
+   viewport can end up scrolled to that dead space instead of the app. */
 .skip-link {
   position: absolute;
-  left: -9999px;
   top: 0;
+  inset-inline-start: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
   background: var(--accent);
   color: var(--bg);
   padding: 0.5rem 1rem;
   z-index: 10;
 }
 .skip-link:focus {
-  left: 0.5rem;
   top: 0.5rem;
+  inset-inline-start: 0.5rem;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  clip-path: none;
+  white-space: normal;
 }
 .theme-toggle {
   background: none;


### PR DESCRIPTION
## What broke

Selecting Urdu in Settings produced a full blank screen — no JS error, most severe on narrow/mobile viewports.

## Root cause

`.skip-link` (the "Skip to content" a11y link) hid itself off-screen with `left: -9999px` — a physical offset that assumes the document is always LTR. That was safe until #214 introduced the app's first-ever `dir="rtl"` toggle (Urdu, ADR 0040). Under RTL, Chrome treats that large negative-left offset as legitimate RTL-scrollable canvas rather than dead space: `document.documentElement.scrollWidth` balloons past 10,000px, and the browser can land the viewport scrolled into that dead space instead of over the actual app content — a blank screen, fully interactive underneath, with nothing to catch in the console.

Verified directly in a live repro:
- Before fix: `scrollWidth: 10399`, `scrollLeft: -1289` on a ~400px viewport with Urdu selected.
- After fix: `scrollWidth === innerWidth`, `scrollLeft: 0`, page renders correctly.

## Fix

Replace the off-canvas hide with the standard clip-to-1px "hidden until focused" pattern (used by e.g. Bootstrap's `.visually-hidden-focusable`), which never touches scrollable overflow in either direction, and uses `inset-inline-start` so it stays correct under both text directions.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` all pass
- [x] Manually verified: narrow viewport + Urdu selected renders correctly (previously blank)
- [x] Manually verified: skip-link still hides until keyboard focus, then appears at top-start, in both English/LTR and Urdu/RTL