### PR TITLE
feat(mobile): offline reciter audio — download & play without a connection

### DIFF
--- a/apps/mobile/src/audio/audio-store.test.ts
+++ b/apps/mobile/src/audio/audio-store.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration-style tests for the I/O layer: `expo-file-system` is mocked with
+ * an in-memory fake (same convention as `offlineCache.test.ts`), extended with
+ * `list()`, `size`, and `File.downloadFileAsync` — the surface `audio-store.ts`
+ * additionally relies on beyond the plain read/write the content cache uses.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { VerseKey } from "@ummahlibrary/core";
+
+const { fsState, joinUri } = vi.hoisted(() => {
+  function joinUri(parts: unknown[]): string {
+    return parts.map((p) => (typeof p === "string" ? p : (p as { uri: string }).uri)).join("/");
+  }
+  return {
+    // Directories are membership-only; files map to their downloaded byte size.
+    fsState: { dirs: new Set<string>(), files: new Map<string, number>() },
+    joinUri,
+  };
+});
+
+vi.mock("expo-file-system", () => {
+  class FakeDirectory {
+    uri: string;
+    constructor(...uris: unknown[]) {
+      this.uri = joinUri(uris);
+    }
+    get exists() {
+      return fsState.dirs.has(this.uri);
+    }
+    create() {
+      // Mirrors the real `intermediates: true` behaviour the adapter always
+      // passes: every ancestor under the document root becomes listable too.
+      let uri = this.uri;
+      while (uri.startsWith("file:///document")) {
+        fsState.dirs.add(uri);
+        uri = uri.slice(0, uri.lastIndexOf("/"));
+      }
+    }
+    delete() {
+      const prefix = `${this.uri}/`;
+      fsState.dirs.delete(this.uri);
+      for (const d of [...fsState.dirs]) if (d.startsWith(prefix)) fsState.dirs.delete(d);
+      for (const f of [...fsState.files.keys()]) if (f.startsWith(prefix)) fsState.files.delete(f);
+    }
+    /** Direct children only (one path segment past this directory), like the real API. */
+    list(): (FakeDirectory | FakeFile)[] {
+      const prefix = `${this.uri}/`;
+      const seen = new Map<string, "dir" | "file">();
+      for (const d of fsState.dirs) {
+        if (d.startsWith(prefix) && !d.slice(prefix.length).includes("/")) seen.set(d, "dir");
+      }
+      for (const f of fsState.files.keys()) {
+        if (f.startsWith(prefix) && !f.slice(prefix.length).includes("/")) seen.set(f, "file");
+      }
+      return [...seen].map(([uri, kind]) => (kind === "dir" ? new FakeDirectory(uri) : new FakeFile(uri)));
+    }
+  }
+  class FakeFile {
+    uri: string;
+    constructor(...uris: unknown[]) {
+      this.uri = joinUri(uris);
+    }
+    get exists() {
+      return fsState.files.has(this.uri);
+    }
+    get size() {
+      return fsState.files.get(this.uri) ?? 0;
+    }
+    delete() {
+      fsState.files.delete(this.uri);
+    }
+    static async downloadFileAsync(
+      url: string,
+      dest: FakeFile,
+      options?: { idempotent?: boolean },
+    ) {
+      if (fsState.files.has(dest.uri) && !options?.idempotent) {
+        throw new Error("DestinationAlreadyExists");
+      }
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`UnableToDownload: ${res.status}`);
+      const body = await res.text();
+      fsState.files.set(dest.uri, body.length);
+      return new FakeFile(dest.uri);
+    }
+  }
+  const Paths = { document: new FakeDirectory("file:///document") };
+  return { Directory: FakeDirectory, File: FakeFile, Paths };
+});
+
+const ref = (sura: number, aya: number): VerseKey => ({ sura, aya });
+
+beforeEach(() => {
+  fsState.dirs.clear();
+  fsState.files.clear();
+  vi.resetModules();
+});
+
+async function loadStore() {
+  const mod = await import("./audio-store");
+  return mod.mobileAudioStore;
+}
+
+describe("mobileAudioStore", () => {
+  it("reports not-saved, then saved after save()", async () => {
+    const store = await loadStore();
+    expect(await store.has("mishary", ref(1, 1))).toBe(false);
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("audio", { status: 200 })));
+
+    await store.save("mishary", ref(1, 1), "https://example.com/1-1.mp3");
+
+    expect(await store.has("mishary", ref(1, 1))).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it("save() is idempotent — a second save doesn't refetch", async () => {
+    const store = await loadStore();
+    const fetchMock = vi.fn(async () => new Response("audio", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await store.save("mishary", ref(2, 5), "https://example.com/2-5.mp3");
+    await store.save("mishary", ref(2, 5), "https://example.com/2-5.mp3");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it("save() throws when the remote fetch fails, and leaves nothing behind", async () => {
+    const store = await loadStore();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(null, { status: 404 })));
+
+    await expect(
+      store.save("mishary", ref(1, 2), "https://example.com/missing.mp3"),
+    ).rejects.toThrow(/404/);
+    expect(await store.has("mishary", ref(1, 2))).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it("localUrl() returns a file:// URI once saved, null otherwise", async () => {
+    const store = await loadStore();
+    expect(await store.localUrl("mishary", ref(3, 1))).toBeNull();
+
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("audio", { status: 200 })));
+    await store.save("mishary", ref(3, 1), "https://example.com/3-1.mp3");
+
+    const url = await store.localUrl("mishary", ref(3, 1));
+    expect(url).toContain("/ul-audio/mishary/3/1.mp3");
+    vi.unstubAllGlobals();
+  });
+
+  it("removeSurah() deletes only that surah's ayahs for that reciter", async () => {
+    const store = await loadStore();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("audio", { status: 200 })));
+    await store.save("mishary", ref(4, 1), "https://example.com/4-1.mp3");
+    await store.save("mishary", ref(4, 2), "https://example.com/4-2.mp3");
+    await store.save("mishary", ref(5, 1), "https://example.com/5-1.mp3");
+
+    await store.removeSurah("mishary", 4);
+
+    expect(await store.has("mishary", ref(4, 1))).toBe(false);
+    expect(await store.has("mishary", ref(4, 2))).toBe(false);
+    expect(await store.has("mishary", ref(5, 1))).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it("savedSurahs() aggregates ayah count and bytes, sorted by reciter then surah", async () => {
+    const store = await loadStore();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("12345", { status: 200 })));
+
+    await store.save("zzz-reciter", ref(2, 1), "https://example.com/a.mp3");
+    const oneAyahBytes = (await store.savedSurahs())[0]!.bytes;
+
+    await store.save("aaa-reciter", ref(9, 1), "https://example.com/b.mp3");
+    await store.save("aaa-reciter", ref(2, 1), "https://example.com/c.mp3");
+    await store.save("aaa-reciter", ref(2, 2), "https://example.com/d.mp3");
+
+    const saved = await store.savedSurahs();
+
+    expect(saved).toEqual([
+      { reciterId: "aaa-reciter", surah: 2, ayahCount: 2, bytes: oneAyahBytes * 2 },
+      { reciterId: "aaa-reciter", surah: 9, ayahCount: 1, bytes: oneAyahBytes },
+      { reciterId: "zzz-reciter", surah: 2, ayahCount: 1, bytes: oneAyahBytes },
+    ]);
+    vi.unstubAllGlobals();
+  });
+
+  it("savedSurahs() returns empty before anything is downloaded", async () => {
+    const store = await loadStore();
+    expect(await store.savedSurahs()).toEqual([]);
+  });
+});

--- a/apps/mobile/src/audio/audio-store.ts
+++ b/apps/mobile/src/audio/audio-store.ts
@@ -1,0 +1,76 @@
+/**
+ * Mobile `AudioStore` adapter (#202 mobile follow-up, ADR 0039): reciter audio
+ * saved for offline playback via `expo-file-system`. Each ayah is downloaded once
+ * to `<document dir>/ul-audio/{reciterId}/{surah}/{aya}.mp3` and handed back as a
+ * `file://` URI — no Cache API on this platform, just files under the app's own
+ * document directory (persistent user data, not OS-reclaimable, unlike
+ * `offlineCache.ts`'s disposable `Paths.cache`). The download *orchestration* is
+ * the pure `downloadSurahAudio` in `@ummahlibrary/core`; this file is only
+ * storage, mirroring `apps/web/src/lib/audio-store.ts`.
+ */
+import { Directory, File, Paths } from "expo-file-system";
+import type { AudioStore, DownloadedSurah, VerseKey } from "@ummahlibrary/core";
+
+const AUDIO_DIR_NAME = "ul-audio";
+
+function audioRoot(): Directory {
+  return new Directory(Paths.document, AUDIO_DIR_NAME);
+}
+
+function surahDir(reciterId: string, surah: number): Directory {
+  return new Directory(audioRoot(), reciterId, String(surah));
+}
+
+function ayahFile(reciterId: string, ref: VerseKey): File {
+  return new File(surahDir(reciterId, ref.sura), `${ref.aya}.mp3`);
+}
+
+/** The final path segment of a File/Directory's uri, decoded — its "name". */
+function nameOf(entry: File | Directory): string {
+  const uri = entry.uri.replace(/\/$/, "");
+  return decodeURIComponent(uri.slice(uri.lastIndexOf("/") + 1));
+}
+
+export const mobileAudioStore: AudioStore = {
+  async has(reciterId, ref) {
+    return ayahFile(reciterId, ref).exists;
+  },
+
+  async localUrl(reciterId, ref) {
+    const file = ayahFile(reciterId, ref);
+    return file.exists ? file.uri : null;
+  },
+
+  async save(reciterId, ref, remoteUrl) {
+    const dest = ayahFile(reciterId, ref);
+    if (dest.exists) return; // idempotent
+    const dir = surahDir(reciterId, ref.sura);
+    if (!dir.exists) dir.create({ intermediates: true, idempotent: true });
+    await File.downloadFileAsync(remoteUrl, dest, { idempotent: true });
+  },
+
+  async removeSurah(reciterId, surah) {
+    const dir = surahDir(reciterId, surah);
+    if (dir.exists) dir.delete();
+  },
+
+  async savedSurahs() {
+    const root = audioRoot();
+    if (!root.exists) return [];
+    const result: DownloadedSurah[] = [];
+    for (const reciterEntry of root.list()) {
+      if (!(reciterEntry instanceof Directory)) continue;
+      const reciterId = nameOf(reciterEntry);
+      for (const surahEntry of reciterEntry.list()) {
+        if (!(surahEntry instanceof Directory)) continue;
+        const surah = Number(nameOf(surahEntry));
+        if (!Number.isInteger(surah) || surah < 1) continue;
+        const files = surahEntry.list().filter((e): e is File => e instanceof File);
+        if (files.length === 0) continue;
+        const bytes = files.reduce((n, f) => n + (f.size ?? 0), 0);
+        result.push({ reciterId, surah, ayahCount: files.length, bytes });
+      }
+    }
+    return result.sort((a, b) => a.reciterId.localeCompare(b.reciterId) || a.surah - b.surah);
+  },
+};

--- a/apps/mobile/src/audio/useSurahAudio.ts
+++ b/apps/mobile/src/audio/useSurahAudio.ts
@@ -15,7 +15,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { AppState } from "react-native";
 import { createAudioPlayer, setAudioModeAsync, type AudioPlayer } from "expo-audio";
 import {
+  ayahCountOf,
   clampPlaybackRate,
+  downloadSurahAudio,
   reciterAudioUrl,
   repeatRange,
   type ReciterPlugin,
@@ -23,6 +25,7 @@ import {
 } from "@ummahlibrary/core";
 import { KEYS, getString, setString } from "../storage";
 import { api } from "../api";
+import { mobileAudioStore } from "./audio-store";
 
 const STALL_MS = 8000;
 const POLL_MS = 60;
@@ -123,6 +126,12 @@ export interface SurahAudio {
   /** Tap-a-word-to-hear (#145): play just one word of a verse, from its timing segment. */
   playWord: (verse: VerseKey, wordIndex: number) => void;
   stop: () => void;
+  /** Offline downloads (#202): surahs of the current reciter saved on-device. */
+  savedSurahs: Set<number>;
+  /** In-flight download progress across every surah being downloaded, or null. */
+  downloadProgress: { done: number; total: number } | null;
+  /** Download every listed surah's audio for the current reciter, with progress. */
+  downloadSurahs: (surahs: number[]) => void;
 }
 
 export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
@@ -131,6 +140,12 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
   const [activeWord, setActiveWord] = useState(-1);
   const [loop, setLoopState] = useState(false);
   const [rate, setRateState] = useState(1);
+  // Offline downloads (#202): in-flight progress + which of this reciter's
+  // surahs are already saved on-device.
+  const [downloadProgress, setDownloadProgress] = useState<{ done: number; total: number } | null>(
+    null,
+  );
+  const [savedSurahs, setSavedSurahs] = useState<Set<number>>(new Set());
 
   const playerRef = useRef<AudioPlayer | null>(null);
   const tokenRef = useRef(0);
@@ -182,6 +197,44 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
       /* no active player */
     }
   }, []);
+
+  // Reflect which of this reciter's surahs are already downloaded.
+  const refreshSaved = useCallback(() => {
+    void mobileAudioStore.savedSurahs().then((saved) => {
+      setSavedSurahs(
+        new Set(
+          saved
+            .filter((s) => s.reciterId === reciter.id && s.ayahCount >= ayahCountOf(s.surah))
+            .map((s) => s.surah),
+        ),
+      );
+    });
+  }, [reciter.id]);
+  useEffect(refreshSaved, [refreshSaved]);
+
+  // Download every listed surah's audio for the current reciter (#202), reporting
+  // progress across the whole batch (a juzʾ spans several surahs).
+  const downloadSurahs = useCallback(
+    (surahs: number[]) => {
+      if (downloadProgress) return;
+      const total = surahs.reduce((n, s) => n + ayahCountOf(s), 0);
+      let done = 0;
+      setDownloadProgress({ done: 0, total });
+      void (async () => {
+        try {
+          for (const s of surahs) {
+            await downloadSurahAudio(mobileAudioStore, reciter, s, {
+              onProgress: () => setDownloadProgress({ done: ++done, total }),
+            });
+          }
+        } finally {
+          setDownloadProgress(null);
+          refreshSaved();
+        }
+      })();
+    },
+    [reciter, downloadProgress, refreshSaved],
+  );
 
   // The one persistent player, created lazily and re-sourced with replace().
   const ensurePlayer = useCallback((src: string): AudioPlayer => {
@@ -255,9 +308,16 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
             setBuffering(true);
             setActiveWord(-1);
 
-            const timing = await getTiming(reciter, v);
+            // Offline downloads (#202): prefer a saved copy over streaming. Word
+            // highlighting still needs `getTiming`'s bundled timings, but those are
+            // already read-through cached (`api.ts`/`offlineCache.ts`) so this
+            // resolves offline too once the surah has been opened once online.
+            const [timing, local] = await Promise.all([
+              getTiming(reciter, v),
+              mobileAudioStore.localUrl(reciter.id, v),
+            ]);
             if (tokenRef.current !== token) return;
-            const src = timing.url;
+            const src = local ?? timing.url;
             const segments: Segment[] | null = timing.segments.length ? timing.segments : null;
 
             const player = ensurePlayer(src);
@@ -454,7 +514,11 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
           return;
         }
         const key = verseKeyOf(verse);
-        const player = ensurePlayer(timing.url);
+        // Offline downloads (#202): prefer a saved copy over streaming, same as
+        // the whole-āyah session above.
+        const local = await mobileAudioStore.localUrl(reciter.id, verse);
+        if (tokenRef.current !== token) return;
+        const player = ensurePlayer(local ?? timing.url);
         if (tokenRef.current !== token) return;
         setPlayingKey(key);
         const endSec = seg[3] / 1000;
@@ -545,5 +609,8 @@ export function useSurahAudio(reciter: ReciterPlugin): SurahAudio {
     playRange,
     playWord,
     stop,
+    savedSurahs,
+    downloadProgress,
+    downloadSurahs,
   };
 }

--- a/apps/mobile/src/components/DownloadButton.tsx
+++ b/apps/mobile/src/components/DownloadButton.tsx
@@ -1,0 +1,58 @@
+/**
+ * Offline download button (#202) for the audio dock — shared by the surah and
+ * juzʾ readers. Downloads every listed surah's audio for the current reciter via
+ * {@link useSurahAudio}'s `downloadSurahs`, showing progress while in flight and a
+ * checkmark once every listed surah is fully saved.
+ */
+import { useMemo } from "react";
+import { ActivityIndicator, Pressable, StyleSheet, Text } from "../Type";
+import { Icon } from "@ummahlibrary/ui";
+import type { Palette } from "../theme";
+import type { SurahAudio } from "../audio/useSurahAudio";
+
+export function DownloadButton({
+  audio,
+  surahs,
+  colors,
+}: {
+  audio: SurahAudio;
+  surahs: number[];
+  colors: Palette;
+}) {
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+  if (surahs.length === 0) return null;
+
+  const allSaved = surahs.every((s) => audio.savedSurahs.has(s));
+  const pct = audio.downloadProgress
+    ? Math.round((audio.downloadProgress.done / Math.max(1, audio.downloadProgress.total)) * 100)
+    : 0;
+  const label = audio.downloadProgress
+    ? `Downloading ${pct}%`
+    : allSaved
+      ? "Saved for offline listening"
+      : "Download for offline listening";
+
+  return (
+    <Pressable
+      onPress={() => audio.downloadSurahs(surahs)}
+      disabled={audio.downloadProgress !== null || allSaved}
+      hitSlop={8}
+      accessibilityLabel={label}
+      style={styles.btn}
+    >
+      {audio.downloadProgress ? (
+        <ActivityIndicator size="small" color={colors.accent} />
+      ) : (
+        <Icon name={allSaved ? "check" : "download"} size={19} color={allSaved ? colors.accent : colors.muted} sw={1.8} />
+      )}
+      {audio.downloadProgress && <Text style={styles.pct}>{pct}%</Text>}
+    </Pressable>
+  );
+}
+
+function makeStyles(c: Palette) {
+  return StyleSheet.create({
+    btn: { flexDirection: "row", alignItems: "center", gap: 4 },
+    pct: { color: c.accent, fontSize: 12, fontWeight: "700" },
+  });
+}

--- a/apps/mobile/src/navigation/ToolsStack.tsx
+++ b/apps/mobile/src/navigation/ToolsStack.tsx
@@ -11,6 +11,7 @@ import { HijriCalendarScreen } from "../screens/HijriCalendarScreen";
 import { ZakatScreen } from "../screens/ZakatScreen";
 import { RamadanScreen } from "../screens/RamadanScreen";
 import { DuasScreen } from "../screens/DuasScreen";
+import { DownloadsScreen } from "../screens/DownloadsScreen";
 import type { ToolsStackParamList } from "./types";
 
 const Stack = createNativeStackNavigator<ToolsStackParamList>();
@@ -37,6 +38,7 @@ export function ToolsStack() {
       <Stack.Screen name="Zakat" component={ZakatScreen} options={{ title: "Zakat Calculator" }} />
       <Stack.Screen name="Ramadan" component={RamadanScreen} options={{ title: "Ramadan" }} />
       <Stack.Screen name="Duas" component={DuasScreen} options={{ title: "Duʿās" }} />
+      <Stack.Screen name="Downloads" component={DownloadsScreen} options={{ title: "Downloads" }} />
     </Stack.Navigator>
   );
 }

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -35,6 +35,7 @@ export type ToolsStackParamList = {
   Zakat: undefined;
   Ramadan: undefined;
   Duas: undefined;
+  Downloads: undefined;
 };
 
 /** The "More" tab's stack: a menu → secondary sections. */

--- a/apps/mobile/src/screens/DownloadsScreen.tsx
+++ b/apps/mobile/src/screens/DownloadsScreen.tsx
@@ -1,0 +1,144 @@
+/**
+ * Offline downloads manager (#202, mobile parity with `apps/web`'s `/downloads`):
+ * lists the reciter audio saved on this device (`expo-file-system`), with size
+ * and delete. Reads the `AudioStore` directly — a client/device concern, same as
+ * the web adapter.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from "../Type";
+import { ayahCountOf, type DownloadedSurah } from "@ummahlibrary/core";
+import { Icon } from "@ummahlibrary/ui";
+import { useTheme, type Palette } from "../theme";
+import { FONT } from "../fonts";
+import { api } from "../api";
+import { RECITERS } from "../plugins";
+import { mobileAudioStore } from "../audio/audio-store";
+
+function fmtBytes(b: number): string {
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${Math.round(b / 1024)} KB`;
+  return `${(b / 1024 / 1024).toFixed(1)} MB`;
+}
+
+const RECITER_NAMES: Record<string, string> = Object.fromEntries(
+  RECITERS.map((r) => [r.id, r.name]),
+);
+
+export function DownloadsScreen() {
+  const { colors } = useTheme();
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const [items, setItems] = useState<DownloadedSurah[] | null>(null);
+  const [surahNames, setSurahNames] = useState<Record<number, string>>({});
+
+  const refresh = useCallback(() => {
+    void mobileAudioStore.savedSurahs().then((saved) => setItems([...saved]));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    void api
+      .listSurahs()
+      .then((list) => setSurahNames(Object.fromEntries(list.map((s) => [s.number, s.transliteration]))))
+      .catch(() => {
+        /* names are cosmetic — the list still renders by number */
+      });
+  }, [refresh]);
+
+  if (items === null) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color={colors.accent} />
+      </View>
+    );
+  }
+
+  const total = items.reduce((n, i) => n + i.bytes, 0);
+
+  if (items.length === 0) {
+    return (
+      <View style={styles.center}>
+        <Icon name="download" size={40} color={colors.faint} sw={1.5} />
+        <Text style={styles.emptyTitle}>Nothing downloaded yet</Text>
+        <Text style={styles.emptyDesc}>
+          Open a surah and tap the download button in the audio bar to save it for offline
+          listening. Saved recitations play with no connection.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.screen}>
+      <Text style={styles.summary}>
+        {items.length} download{items.length === 1 ? "" : "s"} · {fmtBytes(total)} on this device
+      </Text>
+      {items.map((it) => {
+        const full = ayahCountOf(it.surah);
+        const partial = it.ayahCount < full;
+        return (
+          <View key={`${it.reciterId}:${it.surah}`} style={styles.card}>
+            <View style={styles.info}>
+              <Text style={styles.title}>{surahNames[it.surah] ?? `Surah ${it.surah}`}</Text>
+              <Text style={styles.sub}>
+                {RECITER_NAMES[it.reciterId] ?? it.reciterId} · {it.ayahCount}/{full} āyāt ·{" "}
+                {fmtBytes(it.bytes)}
+                {partial ? <Text style={styles.partial}> · incomplete</Text> : null}
+              </Text>
+            </View>
+            <Pressable
+              style={styles.deleteBtn}
+              onPress={async () => {
+                await mobileAudioStore.removeSurah(it.reciterId, it.surah);
+                refresh();
+              }}
+              accessibilityLabel={`Delete ${surahNames[it.surah] ?? `Surah ${it.surah}`} download`}
+              hitSlop={8}
+            >
+              <Icon name="close" size={16} color={colors.muted} sw={1.8} />
+            </Pressable>
+          </View>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+function makeStyles(c: Palette) {
+  return StyleSheet.create({
+    screen: { padding: 16, gap: 10 },
+    center: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      padding: 32,
+      gap: 10,
+      backgroundColor: c.bg,
+    },
+    emptyTitle: { color: c.fg, fontSize: 16, fontFamily: FONT.semibold, marginTop: 4 },
+    emptyDesc: { color: c.muted, fontSize: 13.5, textAlign: "center", lineHeight: 20 },
+    summary: { color: c.faint, fontSize: 12.5 },
+    card: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 14,
+      backgroundColor: c.bgElev,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: c.border,
+      padding: 14,
+    },
+    info: { flex: 1, gap: 3 },
+    title: { color: c.fg, fontSize: 15, fontFamily: FONT.semibold },
+    sub: { color: c.faint, fontSize: 12.5 },
+    partial: { color: c.accent },
+    deleteBtn: {
+      width: 34,
+      height: 34,
+      borderRadius: 9,
+      borderWidth: 1,
+      borderColor: c.border,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+  });
+}

--- a/apps/mobile/src/screens/JuzReaderScreen.tsx
+++ b/apps/mobile/src/screens/JuzReaderScreen.tsx
@@ -17,6 +17,7 @@ import { FONT } from "../fonts";
 import { useSettings } from "../state/SettingsContext";
 import { useSurahAudio, verseKeyOf } from "../audio/useSurahAudio";
 import { AudioRangeControls } from "../components/AudioRangeControls";
+import { DownloadButton } from "../components/DownloadButton";
 import { MemorizeBar } from "../components/MemorizeBar";
 import { DEFAULT_EDITION, TRANSLIT_EDITION } from "../types";
 import { fetchSurahWordTranslit } from "../word-translit";
@@ -149,6 +150,7 @@ export function JuzReaderScreen({ route }: Props) {
   }, [juz, edition, transliteration, wordTransliteration, script, reloadToken]);
 
   const verses = useMemo(() => (lines ?? []).map((l) => ({ sura: l.sura, aya: l.aya })), [lines]);
+  const listSurahs = useMemo(() => Array.from(new Set(verses.map((v) => v.sura))), [verses]);
 
   // Peek geometry: per-āyah words and the global index each āyah starts at, so the
   // shared reveal cursor maps onto every word in reading order.
@@ -221,6 +223,7 @@ export function JuzReaderScreen({ route }: Props) {
         >
           <Text style={[styles.loopText, audio.loop && styles.loopTextOn]}>🔁 Loop</Text>
         </Pressable>
+        <DownloadButton audio={audio} surahs={listSurahs} colors={colors} />
       </View>
       <View style={styles.audioExtras}>
         <AudioRangeControls audio={audio} verses={verses} />

--- a/apps/mobile/src/screens/SurahReaderScreen.tsx
+++ b/apps/mobile/src/screens/SurahReaderScreen.tsx
@@ -35,6 +35,7 @@ import { fetchSurahWordTranslit } from "../word-translit";
 import { fetchSurahIndopak } from "../indopak";
 import { ReaderControls } from "../components/ReaderControls";
 import { AudioRangeControls } from "../components/AudioRangeControls";
+import { DownloadButton } from "../components/DownloadButton";
 import { MemorizeBar } from "../components/MemorizeBar";
 import { ReadingTranslationPicker } from "../components/ReadingTranslationPicker";
 import { TranslationManager } from "../components/TranslationManager";
@@ -509,6 +510,7 @@ export function SurahReaderScreen({ navigation, route }: Props) {
             sw={1.8}
           />
         </Pressable>
+        <DownloadButton audio={audio} surahs={[n]} colors={colors} />
       </View>
       <View style={styles.audioExtras}>
         <AudioRangeControls audio={audio} verses={verses} />

--- a/apps/mobile/src/screens/ToolsListScreen.tsx
+++ b/apps/mobile/src/screens/ToolsListScreen.tsx
@@ -17,6 +17,7 @@ const TOOLS: { screen: keyof ToolsStackParamList; icon: IconName; title: string;
   { screen: "HijriCalendar", icon: "moon",    title: "Hijri Calendar", desc: "Islamic lunar calendar" },
   { screen: "Ramadan",       icon: "star",    title: "Ramadan",        desc: "Ifṭār countdown & fasting tracker" },
   { screen: "Zakat",         icon: "layers",  title: "Zakat",          desc: "Estimate your annual zakat" },
+  { screen: "Downloads",     icon: "download",title: "Downloads",      desc: "Reciter audio saved for offline listening" },
 ];
 
 type Props = NativeStackScreenProps<ToolsStackParamList, "ToolsList">;

--- a/docs/adr/0039-offline-reciter-audio.md
+++ b/docs/adr/0039-offline-reciter-audio.md
@@ -27,9 +27,12 @@ Persistence is a platform adapter behind the port:
   **blob object URL**. everyayah sends `Access-Control-Allow-Origin: *`, so the
   cross-origin blob is readable and **no service worker is needed**. Implemented in
   `apps/web/src/lib/audio-store.ts`.
-- **Mobile — `expo-file-system`** (follow-up, same issue): download each ayah under
-  the app document dir and hand back a `file://` URI. The core port is already
-  platform-agnostic and ready for it.
+- **Mobile — `expo-file-system`.** Each ayah downloads to
+  `<document dir>/ul-audio/{reciter}/{sura}/{aya}.mp3` (`File.downloadFileAsync`)
+  and hands back a `file://` URI. Persistent app-document storage, not the
+  OS-reclaimable cache dir `offlineCache.ts` uses for disposable content — a
+  download is a deliberate user action, so it survives storage pressure the same
+  way a user photo would. Implemented in `apps/mobile/src/audio/audio-store.ts`.
 
 The player prefers a saved copy: before streaming, it asks the store for a local
 URL and, when present, plays that and uses the **bundled** word timings (ADR 0036,
@@ -46,8 +49,12 @@ local copy is added.
 - **Cost:** device storage — a full surah of a 128 kbps reciter is a few MB.
   Bounded by the reader downloading explicitly, per surah, and able to delete.
 - **Scope of this change:** web is implemented and verified (download → offline
-  playback via Playwright offline mode). The **mobile adapter + download UI is the
-  remaining follow-up** under this issue; it was deferred here because
-  `expo-file-system` can't be installed/verified in the current dev environment.
-- **Reuse:** the port + orchestration are shared, so the mobile adapter is a thin
-  file-system mirror of the web one.
+  playback via Playwright offline mode). Mobile is implemented — the
+  `expo-file-system` adapter, a download button in the surah/juzʾ audio bar, a
+  `/Downloads` screen under Tools, and the player preferring a saved file over
+  streaming — verified by `tsc`/lint/the adapter's unit test suite; not yet
+  exercised on a physical device or simulator (none available in this dev
+  environment), so a manual airplane-mode pass is recommended before release.
+- **Reuse:** the port + orchestration are shared — the mobile adapter (~80 lines)
+  is a thin file-system mirror of the web one, and both call the same
+  `downloadSurahAudio`/`isSurahDownloaded` in `core`.


### PR DESCRIPTION
Addresses #202 — completes the mobile follow-up that #213 (web) deliberately left open.

## What
The web side of #202 (Cache API, everyayah-backed) shipped in #213. This lands the mirror for `apps/mobile`, per ADR 0039's already-documented plan: an `expo-file-system` adapter, download UI, and a downloads manager.

## How (ADR 0039)
- **`apps/mobile/src/audio/audio-store.ts`** — the `AudioStore` port implemented over `expo-file-system`'s `File`/`Directory` API. Each ayah saves to `<document dir>/ul-audio/{reciter}/{surah}/{ayah}.mp3` and resolves to a `file://` URI. No orchestration changes — `downloadSurahAudio`/`isSurahDownloaded` in `@ummahlibrary/core` already worked for any store.
- **`useSurahAudio`** — new `downloadSurahs`, `downloadProgress`, `savedSurahs`; the per-āyah playback loop and tap-to-hear (`playWord`) both now prefer a saved local file over streaming from everyayah.
- **`DownloadButton`** (shared by `SurahReaderScreen` and `JuzReaderScreen`) — download-for-offline button in the audio bar, with progress and a checkmark once saved.
- **`DownloadsScreen`** — a new screen under Tools listing saved surahs with size and delete, mirroring `apps/web`'s `/downloads`.

## Verification
- `apps/mobile/src/audio/audio-store.test.ts` — 7 tests over an in-memory `expo-file-system` fake (same mocking convention as `offlineCache.test.ts`): has/localUrl/save-idempotent/save-failure/removeSurah/savedSurahs aggregation.
- `pnpm lint && pnpm typecheck && pnpm test && pnpm build` all green across the whole repo.
- **Not verified on a physical device or simulator** — none was available in this environment. Everything here is exercised through `tsc`, the adapter's unit tests, and reading the `expo-file-system` v19 type definitions/source directly; a manual airplane-mode pass on-device is recommended before merge (same caveat #213 flagged for its own Playwright-only web verification).

## Scope
Mobile only supports one reciter today (`alafasy`), so this doesn't add a reciter picker — the store is still reciter-keyed for when a second one lands. RTL/i18n is unrelated and is a separate PR.