### PR TITLE
feat(mobile,extension): i18n infra parity — locale catalog, provider, picker

### DIFF
--- a/apps/extension/src/Popup.tsx
+++ b/apps/extension/src/Popup.tsx
@@ -12,16 +12,30 @@ import { homeUrl, openUrl, settingsUrl, surahUrl } from "./lib/links";
 import { getPref, setPref } from "./lib/storage";
 import { filterSurahs } from "./lib/surah-filter";
 import { applyTheme, getStoredTheme, readThemeSync, setStoredTheme, THEME_KEYS } from "./lib/theme";
+import {
+  applyLocale,
+  getStoredLocale,
+  LOCALES,
+  readLocaleSync,
+  setStoredLocale,
+  type Locale,
+} from "./lib/locale";
+import { MESSAGES, type MessageKey } from "./lib/messages";
 
 const PAD = 16;
 
 export function Popup() {
   const [theme, setTheme] = useState<ThemeKey>(readThemeSync());
+  const [locale, setLocale] = useState<Locale>(readLocaleSync());
 
   useEffect(() => {
     void getStoredTheme().then((key) => {
       setTheme(key);
       applyTheme(key);
+    });
+    void getStoredLocale().then((code) => {
+      setLocale(code);
+      applyLocale(code);
     });
   }, []);
 
@@ -30,12 +44,19 @@ export function Popup() {
     void setStoredTheme(key);
   }
 
+  function changeLocale(code: Locale) {
+    setLocale(code);
+    void setStoredLocale(code);
+  }
+
+  const t = (key: MessageKey): string => MESSAGES[locale]?.[key] ?? MESSAGES.en[key] ?? key;
+
   return (
     <main style={{ padding: PAD, display: "flex", flexDirection: "column", gap: 14 }}>
       <Header />
-      <VerseOfDay />
-      <SurahJump />
-      <Footer theme={theme} onTheme={changeTheme} />
+      <VerseOfDay t={t} />
+      <SurahJump t={t} />
+      <Footer theme={theme} onTheme={changeTheme} locale={locale} onLocale={changeLocale} t={t} />
     </main>
   );
 }
@@ -90,7 +111,7 @@ const LABEL_STYLE = {
   fontFamily: N.ui,
 } as const;
 
-function VerseOfDay() {
+function VerseOfDay({ t }: { t: (key: MessageKey) => string }) {
   const [edition, setEdition] = useState<string>(DEFAULT_EDITION);
   const [editions, setEditions] = useState<readonly Translation[]>([]);
   const [verse, setVerse] = useState<VerseData | null>(null);
@@ -133,7 +154,7 @@ function VerseOfDay() {
       }}
     >
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <span style={LABEL_STYLE}>Verse of the day</span>
+        <span style={LABEL_STYLE}>{t("popup.verseOfDay")}</span>
         {editions.length > 0 && (
           <Dropdown
             ariaLabel="Translation"
@@ -184,7 +205,7 @@ function VerseOfDay() {
   );
 }
 
-function SurahJump() {
+function SurahJump({ t }: { t: (key: MessageKey) => string }) {
   const [surahs, setSurahs] = useState<readonly Surah[]>([]);
   const [query, setQuery] = useState("");
 
@@ -196,7 +217,7 @@ function SurahJump() {
 
   return (
     <section style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-      <span style={LABEL_STYLE}>Jump to a sūra</span>
+      <span style={LABEL_STYLE}>{t("popup.jumpToSurah")}</span>
       <input
         type="search"
         value={query}
@@ -252,7 +273,19 @@ function SurahJump() {
   );
 }
 
-function Footer({ theme, onTheme }: { theme: ThemeKey; onTheme: (key: ThemeKey) => void }) {
+function Footer({
+  theme,
+  onTheme,
+  locale,
+  onLocale,
+  t,
+}: {
+  theme: ThemeKey;
+  onTheme: (key: ThemeKey) => void;
+  locale: Locale;
+  onLocale: (code: Locale) => void;
+  t: (key: MessageKey) => string;
+}) {
   const link = { color: N.muted, fontSize: 12, textDecoration: "none", fontFamily: N.ui } as const;
   return (
     <footer
@@ -265,18 +298,55 @@ function Footer({ theme, onTheme }: { theme: ThemeKey; onTheme: (key: ThemeKey) 
       }}
     >
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <span style={LABEL_STYLE}>Theme</span>
+        <span style={LABEL_STYLE}>{t("popup.theme")}</span>
         <ThemePicker value={theme} onChange={onTheme} />
+      </div>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={LABEL_STYLE}>{t("common.language")}</span>
+        <LanguagePicker value={locale} onChange={onLocale} />
       </div>
       <div style={{ display: "flex", gap: 16, justifyContent: "center" }}>
         <a href={homeUrl()} target="_blank" rel="noreferrer" style={link}>
-          Open Ummah Library
+          {t("popup.openApp")}
         </a>
         <a href={settingsUrl()} target="_blank" rel="noreferrer" style={link}>
-          Settings
+          {t("common.settings")}
         </a>
       </div>
     </footer>
+  );
+}
+
+function LanguagePicker({ value, onChange }: { value: Locale; onChange: (code: Locale) => void }) {
+  return (
+    <div role="radiogroup" aria-label="Language" style={{ display: "flex", gap: 6 }}>
+      {LOCALES.map((l) => {
+        const active = l.code === value;
+        return (
+          <button
+            key={l.code}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            lang={l.code}
+            onClick={() => onChange(l.code)}
+            style={{
+              padding: "3px 9px",
+              borderRadius: 999,
+              border: `1px solid ${active ? N.gold : N.border}`,
+              background: active ? N.goldSoft : "transparent",
+              color: active ? N.gold : N.muted,
+              fontSize: 11,
+              fontWeight: 600,
+              cursor: "pointer",
+              fontFamily: N.ui,
+            }}
+          >
+            {l.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/apps/extension/src/lib/locale-store.ts
+++ b/apps/extension/src/lib/locale-store.ts
@@ -1,0 +1,23 @@
+/**
+ * Synchronous locale mirror for the extension popup (ADR 0024, ADR 0040) — a
+ * `localStorage` copy of the chosen UI language, read before paint to avoid a
+ * flash (the authoritative value lives in `chrome.storage.sync` via `./storage`,
+ * which is async). Mirrors `theme-store.ts`'s split for the same reason.
+ */
+const MIRROR_KEY = "ul.ext.localeMirror";
+
+export function readLocaleMirror(): string | null {
+  try {
+    return localStorage.getItem(MIRROR_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeLocaleMirror(locale: string): void {
+  try {
+    localStorage.setItem(MIRROR_KEY, locale);
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
+}

--- a/apps/extension/src/lib/locale.ts
+++ b/apps/extension/src/lib/locale.ts
@@ -1,0 +1,58 @@
+/**
+ * UI localization (#208, ADR 0040) — extension mirror of the web/mobile i18n
+ * config + runtime, collapsed into `lib/locale.ts` + `lib/locale-store.ts` to
+ * match this app's flat `lib/` layout (compare `theme.ts`/`theme-store.ts`).
+ * The interface language is separate from Quran/translation content.
+ */
+import { getPref, setPref } from "./storage";
+import { readLocaleMirror, writeLocaleMirror } from "./locale-store";
+
+export type Locale = "en" | "ur";
+
+export interface LocaleMeta {
+  code: Locale;
+  /** Endonym — the language's own name, shown in the picker. */
+  label: string;
+  dir: "ltr" | "rtl";
+}
+
+export const LOCALES: readonly LocaleMeta[] = [
+  { code: "en", label: "English", dir: "ltr" },
+  { code: "ur", label: "اردو", dir: "rtl" },
+];
+
+const DEFAULT_LOCALE: Locale = "en";
+
+function isLocale(value: unknown): value is Locale {
+  return typeof value === "string" && LOCALES.some((l) => l.code === value);
+}
+
+export function localeDir(code: Locale): "ltr" | "rtl" {
+  return LOCALES.find((l) => l.code === code)?.dir ?? "ltr";
+}
+
+/** Set `<html lang dir>` so the popup's own chrome mirrors for an RTL locale. */
+export function applyLocale(locale: Locale): void {
+  document.documentElement.lang = locale;
+  document.documentElement.dir = localeDir(locale);
+}
+
+/** Best-effort synchronous read for pre-paint. Falls back to the default. */
+export function readLocaleSync(): Locale {
+  const v = readLocaleMirror();
+  return isLocale(v) ? v : DEFAULT_LOCALE;
+}
+
+/** Authoritative read from synced storage (follows the user across devices),
+ *  falling back to the synchronous mirror, then the default. */
+export async function getStoredLocale(): Promise<Locale> {
+  const v = await getPref<string>("locale", readLocaleSync());
+  return isLocale(v) ? v : DEFAULT_LOCALE;
+}
+
+/** Persist + apply: synced pref (cross-device) + the synchronous mirror. */
+export async function setStoredLocale(locale: Locale): Promise<void> {
+  applyLocale(locale);
+  writeLocaleMirror(locale);
+  await setPref("locale", locale);
+}

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -1,0 +1,42 @@
+/**
+ * UI message catalogue (#208) — extension mirror of
+ * `apps/web/src/i18n/messages.ts`/`apps/mobile/src/i18n/messages.ts`. English is
+ * the source of truth and defines the key set (`MessageKey`); every other locale
+ * is a `Record<MessageKey, string>` the compiler forces to stay complete. This is
+ * a **starter slice** (the popup's own chrome) that proves the mechanism on this
+ * platform, mirroring the other two apps' Phase 0–1 scope (ADR 0040) —
+ * extracting the rest of the popup is incremental follow-up under #208.
+ *
+ * The `common.*` keys and their Urdu text are copied verbatim from the other
+ * apps' catalogues so all three platforms describe the same choice identically;
+ * `popup.*` is extension-only (its compact popup has no nav/tab-bar equivalent).
+ *
+ * The Urdu strings are a first pass flagged for **native review** before
+ * release — the localization *infrastructure* is what this change lands, not
+ * authoritative translations.
+ */
+import type { Locale } from "./locale";
+
+export const en = {
+  "popup.verseOfDay": "Verse of the day",
+  "popup.jumpToSurah": "Jump to a sūra",
+  "popup.theme": "Theme",
+  "popup.openApp": "Open Ummah Library",
+  // Common chrome (kept in sync with the web/mobile catalogues)
+  "common.settings": "Settings",
+  "common.language": "Language",
+} as const;
+
+export type MessageKey = keyof typeof en;
+
+// First-pass Urdu (RTL) — نظرِ ثانی درکار / needs native review.
+const ur: Record<MessageKey, string> = {
+  "popup.verseOfDay": "آج کی آیت",
+  "popup.jumpToSurah": "سورہ تلاش کریں",
+  "popup.theme": "تھیم",
+  "popup.openApp": "امہ لائبریری کھولیں",
+  "common.settings": "ترتیبات",
+  "common.language": "زبان",
+};
+
+export const MESSAGES: Record<Locale, Record<MessageKey, string>> = { en, ur };

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -12,6 +12,7 @@ import {
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { ThemeProvider, useTheme } from "./src/theme";
+import { I18nProvider } from "./src/i18n/I18nProvider";
 import { SettingsProvider } from "./src/state/SettingsContext";
 import { LibraryProvider } from "./src/state/LibraryContext";
 import { RootTabs } from "./src/navigation/RootTabs";
@@ -168,11 +169,13 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <ThemeProvider>
-        <SettingsProvider>
-          <LibraryProvider>
-            <AppGate />
-          </LibraryProvider>
-        </SettingsProvider>
+        <I18nProvider>
+          <SettingsProvider>
+            <LibraryProvider>
+              <AppGate />
+            </LibraryProvider>
+          </SettingsProvider>
+        </I18nProvider>
       </ThemeProvider>
     </SafeAreaProvider>
   );

--- a/apps/mobile/src/i18n/I18nProvider.tsx
+++ b/apps/mobile/src/i18n/I18nProvider.tsx
@@ -1,0 +1,54 @@
+/**
+ * UI localization runtime (#208, ADR 0040) — mobile mirror of
+ * `apps/web/src/i18n/I18nProvider.tsx`. Holds the active locale (persisted via
+ * AsyncStorage under `ul.locale`), and exposes a `t()` lookup with an English
+ * fallback. Local-first: the choice lives on the device, no network.
+ *
+ * Unlike the web provider, this does **not** flip the OS-level layout direction
+ * (`I18nManager.forceRTL`) — that requires a full app restart on native and a
+ * reload mechanism (`expo-updates`) this app doesn't yet depend on, so it's left
+ * as a deliberate follow-up rather than shipped half-verified. `localeDir()` is
+ * still exposed so a screen can apply `writingDirection: "rtl"` to the specific
+ * text it renders in an RTL locale (the same per-element pattern already used
+ * for Arabic, e.g. `SurahReaderScreen`'s `mushaf` style).
+ */
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { DEFAULT_LOCALE, type Locale } from "./config";
+import { readLocale, writeLocale } from "./locale-store";
+import { MESSAGES, type MessageKey } from "./messages";
+
+interface I18nContextValue {
+  locale: Locale;
+  setLocale: (next: Locale) => void;
+  t: (key: MessageKey) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>(DEFAULT_LOCALE);
+
+  useEffect(() => {
+    void readLocale().then(setLocaleState);
+  }, []);
+
+  const setLocale = (next: Locale) => {
+    setLocaleState(next);
+    void writeLocale(next);
+  };
+
+  const t = (key: MessageKey): string => MESSAGES[locale]?.[key] ?? MESSAGES.en[key] ?? key;
+
+  return <I18nContext.Provider value={{ locale, setLocale, t }}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n(): I18nContextValue {
+  const ctx = useContext(I18nContext);
+  if (!ctx) throw new Error("useI18n must be used within an I18nProvider");
+  return ctx;
+}
+
+/** Convenience hook for components that only need the lookup. */
+export function useT(): (key: MessageKey) => string {
+  return useI18n().t;
+}

--- a/apps/mobile/src/i18n/config.ts
+++ b/apps/mobile/src/i18n/config.ts
@@ -1,0 +1,30 @@
+/**
+ * UI localization config (#208, ADR 0040) — mobile mirror of
+ * `apps/web/src/i18n/config.ts`. The interface language is separate from
+ * Quran/translation content: this only localizes the app's own chrome.
+ */
+/** Every UI locale the app can render in. Adding one extends this union, which
+ *  forces its message catalogue to be complete (see `messages.ts`). */
+export type Locale = "en" | "ur";
+
+export interface LocaleMeta {
+  code: Locale;
+  /** Endonym — the language's own name, shown in the picker. */
+  label: string;
+  dir: "ltr" | "rtl";
+}
+
+export const LOCALES: readonly LocaleMeta[] = [
+  { code: "en", label: "English", dir: "ltr" },
+  { code: "ur", label: "اردو", dir: "rtl" },
+];
+
+export const DEFAULT_LOCALE: Locale = "en";
+
+export function isLocale(value: string): value is Locale {
+  return LOCALES.some((l) => l.code === value);
+}
+
+export function localeDir(code: Locale): "ltr" | "rtl" {
+  return LOCALES.find((l) => l.code === code)?.dir ?? "ltr";
+}

--- a/apps/mobile/src/i18n/locale-store.ts
+++ b/apps/mobile/src/i18n/locale-store.ts
@@ -1,0 +1,16 @@
+/**
+ * Mobile persistence for the chosen UI locale (#208, ADR 0024/0040), under
+ * `ul.locale` — the same key the web app uses, matching AsyncStorage instead of
+ * `localStorage`. The i18n *runtime* lives in `I18nProvider`.
+ */
+import { KEYS, getString, setString } from "../storage";
+import { DEFAULT_LOCALE, type Locale, isLocale } from "./config";
+
+export async function readLocale(): Promise<Locale> {
+  const saved = await getString(KEYS.locale);
+  return saved && isLocale(saved) ? saved : DEFAULT_LOCALE;
+}
+
+export async function writeLocale(locale: Locale): Promise<void> {
+  await setString(KEYS.locale, locale);
+}

--- a/apps/mobile/src/i18n/messages.ts
+++ b/apps/mobile/src/i18n/messages.ts
@@ -1,0 +1,47 @@
+/**
+ * UI message catalogue (#208) — mobile mirror of `apps/web/src/i18n/messages.ts`.
+ * English is the source of truth and defines the key set (`MessageKey`); every
+ * other locale is a `Record<MessageKey, string>` the compiler forces to stay
+ * complete. This is a **starter slice** (the bottom tab bar + the Settings
+ * language section) that proves the mechanism end-to-end on this platform,
+ * mirroring web's Phase 0–1 scope (ADR 0040) — extracting the rest of the UI is
+ * incremental follow-up under #208.
+ *
+ * The `common.*` keys and their Urdu text are copied verbatim from web's
+ * catalogue so the two platforms describe the same choice identically; `tab.*`
+ * is mobile-only (the bottom tab bar has no web equivalent).
+ *
+ * The Urdu strings are a first pass flagged for **native review** before
+ * release — the localization *infrastructure* is what this change lands, not
+ * authoritative translations.
+ */
+import type { Locale } from "./config";
+
+export const en = {
+  // Bottom tab bar
+  "tab.home": "Home",
+  "tab.read": "Read",
+  "tab.tools": "Tools",
+  "tab.memorize": "Memorize",
+  "tab.more": "More",
+  // Common chrome (kept in sync with apps/web/src/i18n/messages.ts)
+  "common.settings": "Settings",
+  "common.language": "Language",
+  "settings.languageHint": "Choose the language for the app's interface. Quran and translation text are unaffected.",
+} as const;
+
+export type MessageKey = keyof typeof en;
+
+// First-pass Urdu (RTL) — نظرِ ثانی درکار / needs native review.
+const ur: Record<MessageKey, string> = {
+  "tab.home": "ہوم",
+  "tab.read": "پڑھیں",
+  "tab.tools": "اوزار",
+  "tab.memorize": "حفظ",
+  "tab.more": "مزید",
+  "common.settings": "ترتیبات",
+  "common.language": "زبان",
+  "settings.languageHint": "ایپ کے انٹرفیس کی زبان منتخب کریں۔ قرآن اور ترجمے کا متن متاثر نہیں ہوگا۔",
+};
+
+export const MESSAGES: Record<Locale, Record<MessageKey, string>> = { en, ur };

--- a/apps/mobile/src/navigation/RootTabs.tsx
+++ b/apps/mobile/src/navigation/RootTabs.tsx
@@ -1,6 +1,8 @@
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { Icon, type IconName } from "@ummahlibrary/ui";
 import { useTheme } from "../theme";
+import { useT } from "../i18n/I18nProvider";
+import type { MessageKey } from "../i18n/messages";
 import { FONT } from "../fonts";
 import { HomeStack } from "./HomeStack";
 import { ReadStack } from "./ReadStack";
@@ -19,8 +21,17 @@ const ICONS: Record<keyof RootTabParamList, IconName> = {
   More: "menu",
 };
 
+const LABEL_KEYS: Record<keyof RootTabParamList, MessageKey> = {
+  Home: "tab.home",
+  Read: "tab.read",
+  Tools: "tab.tools",
+  Memorize: "tab.memorize",
+  More: "tab.more",
+};
+
 export function RootTabs() {
   const { colors } = useTheme();
+  const t = useT();
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
@@ -30,6 +41,7 @@ export function RootTabs() {
         tabBarInactiveTintColor: colors.muted,
         tabBarLabelStyle: { fontFamily: FONT.medium, fontSize: 11 },
         tabBarIcon: ({ color }) => <Icon name={ICONS[route.name]} size={22} color={color} sw={1.8} />,
+        tabBarLabel: t(LABEL_KEYS[route.name]),
       })}
     >
       <Tab.Screen name="Home" component={HomeStack} />

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -3,6 +3,8 @@ import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet, Text, View
 import type { MergeStrategy, QuranScript } from "@ummahlibrary/core";
 import { noorThemes } from "@ummahlibrary/ui";
 import { useTheme, THEMES, type Palette } from "../theme";
+import { useI18n } from "../i18n/I18nProvider";
+import { LOCALES } from "../i18n/config";
 import { FONT } from "../fonts";
 import { useSettings } from "../state/SettingsContext";
 import { RECITER, RECITERS } from "../plugins";
@@ -27,6 +29,7 @@ const SCRIPTS: { id: QuranScript; label: string; sub: string }[] = [
 export function SettingsScreen() {
   const { colors, themeKey, setTheme } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
+  const { locale, setLocale, t } = useI18n();
   const {
     scale,
     setScale,
@@ -127,6 +130,27 @@ export function SettingsScreen() {
                 accessibilityLabel={t.label}
               >
                 <View style={[styles.swatchDot, { backgroundColor: noorThemes[t.key].accent }]} />
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      <Text style={styles.sectionLabel}>{t("common.language")}</Text>
+      <View style={styles.card}>
+        <Text style={styles.pickSub}>{t("settings.languageHint")}</Text>
+        <View style={[styles.swatchRow, { marginTop: 13 }]}>
+          {LOCALES.map((l) => {
+            const on = l.code === locale;
+            return (
+              <Pressable
+                key={l.code}
+                onPress={() => setLocale(l.code)}
+                style={[styles.langPill, on && styles.langPillOn]}
+                accessibilityLabel={l.label}
+                accessibilityState={{ selected: on }}
+              >
+                <Text style={[styles.pillText, on && styles.pillTextOn]}>{l.label}</Text>
               </Pressable>
             );
           })}
@@ -359,6 +383,15 @@ function makeStyles(c: Palette) {
       justifyContent: "center",
     },
     swatchDot: { width: 13, height: 13, borderRadius: 7 },
+    langPill: {
+      paddingVertical: 8,
+      paddingHorizontal: 16,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.bg,
+    },
+    langPillOn: { borderColor: c.accent, backgroundColor: c.accentSoft },
     row: {
       flexDirection: "row",
       alignItems: "center",

--- a/apps/mobile/src/storage.ts
+++ b/apps/mobile/src/storage.ts
@@ -56,6 +56,7 @@ export const KEYS = {
   sunnahFastReminders: "ul.sunnahFastReminders",
   islamicEventReminders: "ul.islamicEventReminders",
   adhkarTimings: "ul.adhkarTimings",
+  locale: "ul.locale",
 } as const;
 
 export async function getJSON<T>(

--- a/apps/web/src/i18n/locale-store.ts
+++ b/apps/web/src/i18n/locale-store.ts
@@ -1,5 +1,5 @@
 /**
- * Web persistence for the chosen UI locale (#208, ADR 0024/0038), under
+ * Web persistence for the chosen UI locale (#208, ADR 0024/0040), under
  * `ul.locale`. The sanctioned `localStorage` home; the i18n *runtime* lives in
  * `I18nProvider`. A synced adapter (#25) could replace this without touching the
  * provider.

--- a/docs/adr/0040-ui-localization.md
+++ b/docs/adr/0040-ui-localization.md
@@ -32,7 +32,7 @@ for free and keeps the bundle lean.
 
 ## Scope of this change (phased)
 
-This lands **Phase 0–1**: the infrastructure + RTL wiring + picker, with a
+This lands **Phase 0–1** on web: the infrastructure + RTL wiring + picker, with a
 **starter slice** of strings extracted (the app-shell nav + common chrome) and a
 second locale (**Urdu, RTL**) proving the mechanism end-to-end. Extracting the
 remaining UI strings is incremental follow-up under #208 — each screen swaps its
@@ -41,6 +41,32 @@ literals for `t()` keys with no further architecture change.
 The Urdu strings are a **first pass flagged for native review**; the deliverable
 here is the localization *infrastructure*, not authoritative translations, so this
 carries `needs-scholar-review` for the language content.
+
+**Phase 4 (mobile + extension parity)** is also landed: each platform gets its
+own `en`/`ur` catalogue and runtime, following the pattern already established
+for its persistence layer rather than a shared package (a `packages/i18n` was an
+open question in the original issue; deferred rather than decided here — the
+duplication mirrors how reciter/plugin manifests are already mirrored into
+`apps/mobile/src/plugins.ts`, per that file's own comment).
+
+- **`apps/mobile/src/i18n/`** — `config.ts`/`messages.ts`/`I18nProvider.tsx`
+  (React context, mirrors `apps/mobile/src/theme.tsx`) /`locale-store.ts`
+  (AsyncStorage under `ul.locale`, same key the web app uses). Starter slice:
+  the bottom tab bar labels + the Settings language section. Deliberately does
+  **not** call `I18nManager.forceRTL` — that needs a full app restart and a
+  reload mechanism (`expo-updates`) this app doesn't yet depend on, so native
+  RTL layout mirroring is left as a follow-up rather than shipped unverified (no
+  device/simulator was available to verify it in this change). `localeDir()` is
+  still exposed for the existing per-element `writingDirection: "rtl"` pattern
+  already used for Arabic text.
+- **`apps/extension/src/lib/locale.ts` + `locale-store.ts` + `messages.ts`** —
+  collapsed into the extension's flat `lib/` layout and its existing
+  sync-mirror-plus-`chrome.storage.sync` split (mirrors `theme.ts`/
+  `theme-store.ts`), rather than a Context provider — the popup's whole
+  component tree is small enough that `theme`/`locale` are drilled as props, the
+  same shape the app already uses for its theme. Starter slice: the popup's own
+  chrome (verse-of-day label, sūra search label, theme label, footer links) plus
+  a language picker next to the existing theme picker.
 
 ## Consequences
 


### PR DESCRIPTION
Addresses #208 — Phase 4 (mobile + extension parity), which #214 (web) deliberately left open. **Do not merge yet — for review/testing**, same as #213/#214.

## What
#214 shipped the web i18n infrastructure (ADR 0040): a typed `en`/`ur` message catalog, an `I18nProvider`, RTL wiring, and a `LanguagePicker`, with a starter slice (nav + common chrome). This lands the same mechanism on `apps/mobile` and `apps/extension`.

## How
Each platform gets its own catalog + runtime, following **that platform's existing persistence pattern** rather than introducing a shared `packages/i18n` (an open question in the original issue, still deferred rather than decided here):

- **`apps/mobile/src/i18n/`** — `config.ts`/`messages.ts` (mirrors web's shape), `I18nProvider.tsx` (React context, same shape as `apps/mobile/src/theme.tsx`), `locale-store.ts` (AsyncStorage under `ul.locale` — the same key web uses for `localStorage`). Starter slice: the bottom tab bar labels + a new Settings → Language section.
- **`apps/extension/src/lib/{locale,locale-store,messages}.ts`** — collapsed into the extension's flat `lib/` layout and its existing sync-mirror + `chrome.storage.sync` split (mirrors `theme.ts`/`theme-store.ts`) rather than a Context provider, since the popup's whole tree is small enough that `theme`/`locale` are already drilled as props the same way. Starter slice: the popup's own chrome (verse-of-day/sūra-search/theme labels, footer links) plus a language picker next to the theme picker.
- The `common.settings`/`common.language` keys and their Urdu text are copied verbatim across all three catalogs so the choice reads identically everywhere.
- Fixed a stale ADR cross-reference found along the way: `apps/web/src/i18n/locale-store.ts` pointed at ADR 0038 (nearby mosque finder) instead of ADR 0040 (this feature).

## Scope — what this deliberately does NOT do
- **No native RTL layout mirroring on mobile.** `I18nManager.forceRTL()` requires a full app restart via a reload mechanism (`expo-updates`) this app doesn't depend on yet. Rather than wire that up unverified (no device/simulator available here), `localeDir()` is exposed so screens can apply `writingDirection: "rtl"` per-element (the same pattern already used for Arabic text), and the restart-to-apply flow is left as a follow-up.
- **No further string extraction.** This is infrastructure + a starter slice only, matching web's own Phase 0–1 scope — the bulk of each app's UI stays hardcoded English for now, same as web before further phases land.
- Left #208 open for the remaining phases (string extraction, RTL audit/native reload, contribution workflow).

## Verification
- `pnpm lint && pnpm typecheck && pnpm test && pnpm build` all green across the whole repo (`apps/extension`'s existing `Popup.test.tsx` — including its verse-of-day/footer-link assertions — still passes unchanged).
- Not visually verified in a running mobile app or the loaded extension popup — no device/simulator/Chrome available in this environment. Recommend an eyeball pass (English default, then switching to Urdu) before merge.