### PR TITLE
fix(extension): match the v3 incremental-pull SyncBackend protocol

### DIFF
--- a/apps/extension/src/lib/sync/http-sync-backend.test.ts
+++ b/apps/extension/src/lib/sync/http-sync-backend.test.ts
@@ -21,13 +21,13 @@ describe("createHttpSyncBackend (extension)", () => {
     const out = await createHttpSyncBackend({ fetchImpl }).exchange("acc", [good]);
     expect(captured!.url).toBe("https://ummahlibrary.org/api/sync");
     expect((captured!.init.headers as Record<string, string>).authorization).toBe("Bearer acc");
-    expect(out).toEqual([good]);
+    expect(out.entries).toEqual([good]);
   });
 
   it("drops reply entries with a malformed clock", async () => {
     const bad = [good, { id: "z", hlc: { millis: -1, counter: 0, node: "n" }, ciphertext: "c", nonce: "i" }, "x"];
     const fetchImpl = (async () => resp({ entries: bad })) as unknown as typeof fetch;
-    expect(await createHttpSyncBackend({ fetchImpl }).exchange("a", [])).toEqual([good]);
+    expect((await createHttpSyncBackend({ fetchImpl }).exchange("a", [])).entries).toEqual([good]);
   });
 
   it("throws on a non-OK response", async () => {

--- a/apps/extension/src/lib/sync/http-sync-backend.ts
+++ b/apps/extension/src/lib/sync/http-sync-backend.ts
@@ -40,15 +40,19 @@ export function createHttpSyncBackend(options: HttpSyncBackendOptions = {}): Syn
   const endpoint = options.endpoint ?? `${BASE_URL}/api/sync`;
   const doFetch = options.fetchImpl ?? fetch;
   return {
-    exchange: async (accountId, entries) => {
+    exchange: async (accountId, entries, cursor) => {
       const res = await doFetch(endpoint, {
         method: "POST",
         headers: { "content-type": "application/json", authorization: `Bearer ${accountId}` },
-        body: JSON.stringify({ entries }),
+        body: JSON.stringify({ entries, cursor }),
       });
       if (!res.ok) throw new Error(`sync failed (${res.status})`);
-      const data = (await res.json()) as { entries?: unknown };
-      return Array.isArray(data.entries) ? data.entries.filter(isValidEntry) : [];
+      const data = (await res.json()) as { entries?: unknown; cursor?: unknown; more?: unknown };
+      return {
+        entries: Array.isArray(data.entries) ? data.entries.filter(isValidEntry) : [],
+        cursor: typeof data.cursor === "number" ? data.cursor : undefined,
+        more: data.more === true,
+      };
     },
   };
 }

--- a/apps/extension/src/lib/sync/sync-e2e.test.ts
+++ b/apps/extension/src/lib/sync/sync-e2e.test.ts
@@ -43,7 +43,7 @@ function inMemoryServer(): SyncBackend {
     exchange: async (accountId, entries) => {
       const { merged } = mergeEntries(store.get(accountId) ?? [], entries);
       store.set(accountId, merged);
-      return merged;
+      return { entries: merged };
     },
   };
 }


### PR DESCRIPTION
## Problem

The extension's `HttpSyncBackend` (#170) implemented the pre-#173 `SyncBackend.exchange()` contract — a raw `SyncEntry[]` return. #173 changed the port to return `SyncExchangeResult` (`{entries, cursor?, more?}`) for the incremental-pull cursor. #173's own branch never included the extension package (it wasn't in that PR's ancestry — #170 and #171/#172/#173 are siblings off #169), so nothing caught the mismatch until both landed on `main` and the extension's typecheck broke.

## Fix

Update `apps/extension/src/lib/sync/http-sync-backend.ts` to the same shape as the web/mobile implementations: send `cursor`, return `{entries, cursor, more}`. Updated its two dependent tests (`http-sync-backend.test.ts`, `sync-e2e.test.ts`'s in-memory server stub) to match.

`pnpm lint && typecheck && test && build` all green.