### PR TITLE
Fix 4 bugs found in a full-site web QA pass

### DIFF
--- a/apps/mobile/src/screens/TasbihScreen.tsx
+++ b/apps/mobile/src/screens/TasbihScreen.tsx
@@ -1,46 +1,51 @@
 import { useEffect, useMemo, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, Vibration, View } from "../Type";
 import Svg, { Circle } from "react-native-svg";
-import { DHIKR_PHRASES, TASBIH_TARGETS, tasbihState } from "@ummahlibrary/core";
+import {
+  DHIKR_PHRASES,
+  TASBIH_TARGETS,
+  type TasbihRecord,
+  tasbihPhraseProgress,
+  tasbihState,
+} from "@ummahlibrary/core";
 import { mobileTasbihStore as store } from "../tasbih-store";
 import { useTheme, type Palette } from "../theme";
 import { FONT } from "../fonts";
 
-interface Stored {
-  total: number;
-  target: number;
-  phraseId: string;
-}
-
-const DEFAULT: Stored = { total: 0, target: 33, phraseId: "subhanallah" };
+const DEFAULT: TasbihRecord = { phraseId: "subhanallah", phrases: {} };
 
 export function TasbihScreen() {
   const { colors } = useTheme();
   const styles = useMemo(() => makeStyles(colors), [colors]);
 
-  const [state, setState] = useState<Stored>(DEFAULT);
+  const [state, setState] = useState<TasbihRecord>(DEFAULT);
 
   useEffect(() => {
     void store.read().then((s) => setState(s ?? DEFAULT));
   }, []);
 
-  function persist(next: Stored) {
+  function persist(next: TasbihRecord) {
     setState(next);
     void store.write(next);
   }
 
-  const view = tasbihState(state.total, state.target);
+  // Each phrase's own progress — switching the chip below never touches this.
+  const progress = tasbihPhraseProgress(state, state.phraseId);
+  const view = tasbihState(progress.total, progress.target);
   const phrase = DHIKR_PHRASES.find((p) => p.id === state.phraseId) ?? DHIKR_PHRASES[0]!;
-  const justLapped = view.count === 0 && state.total > 0;
+  const justLapped = view.count === 0 && progress.total > 0;
 
   function tap() {
-    persist({ ...state, total: state.total + 1 });
-    Vibration.vibrate(view.count + 1 === state.target ? 60 : 12);
+    persist({
+      ...state,
+      phrases: { ...state.phrases, [state.phraseId]: { ...progress, total: progress.total + 1 } },
+    });
+    Vibration.vibrate(view.count + 1 === progress.target ? 60 : 12);
   }
 
   const ringR = 118;
   const ringC = 2 * Math.PI * ringR;
-  const pct = Math.min(1, (justLapped ? state.target : view.count) / state.target);
+  const pct = Math.min(1, (justLapped ? progress.target : view.count) / progress.target);
 
   return (
     <ScrollView contentContainerStyle={styles.screen}>
@@ -78,9 +83,9 @@ export function TasbihScreen() {
         <Pressable style={styles.dial} onPress={tap} accessibilityRole="button" accessibilityLabel="Count">
           <Text style={styles.dialAr}>{phrase.arabic}</Text>
           <Text style={[styles.dialCount, justLapped && styles.dialCountLapped]}>
-            {justLapped ? state.target : view.count}
+            {justLapped ? progress.target : view.count}
           </Text>
-          <Text style={styles.dialTarget}>of {state.target}</Text>
+          <Text style={styles.dialTarget}>of {progress.target}</Text>
         </Pressable>
       </View>
 
@@ -102,10 +107,15 @@ export function TasbihScreen() {
             {TASBIH_TARGETS.map((t) => (
               <Pressable
                 key={t}
-                style={[styles.chip, t === state.target && styles.chipOn]}
-                onPress={() => persist({ ...state, target: t })}
+                style={[styles.chip, t === progress.target && styles.chipOn]}
+                onPress={() =>
+                  persist({
+                    ...state,
+                    phrases: { ...state.phrases, [state.phraseId]: { ...progress, target: t } },
+                  })
+                }
               >
-                <Text style={[styles.chipText, t === state.target && styles.chipTextOn]}>
+                <Text style={[styles.chipText, t === progress.target && styles.chipTextOn]}>
                   {t}
                 </Text>
               </Pressable>
@@ -113,7 +123,15 @@ export function TasbihScreen() {
           </View>
         </View>
 
-        <Pressable style={styles.resetBtn} onPress={() => persist({ ...state, total: 0 })}>
+        <Pressable
+          style={styles.resetBtn}
+          onPress={() =>
+            persist({
+              ...state,
+              phrases: { ...state.phrases, [state.phraseId]: { ...progress, total: 0 } },
+            })
+          }
+        >
           <Text style={styles.resetText}>Reset</Text>
         </Pressable>
       </View>

--- a/apps/mobile/src/tasbih-store.ts
+++ b/apps/mobile/src/tasbih-store.ts
@@ -7,14 +7,39 @@
 import type { TasbihRecord, TasbihStore } from "@ummahlibrary/core";
 import { KEYS, getJSON, isObjectRecord, setJSON } from "./storage";
 
-const isTasbihRecord = (v: unknown): boolean =>
-  v === null ||
-  (isObjectRecord(v) &&
-    typeof (v as TasbihRecord).total === "number" &&
-    typeof (v as TasbihRecord).target === "number" &&
-    typeof (v as TasbihRecord).phraseId === "string");
+/** The pre-per-phrase-progress shape (a single shared total/target). */
+interface LegacyRecord {
+  phraseId: string;
+  total: number;
+  target: number;
+}
+
+const isLegacyRecord = (v: unknown): v is LegacyRecord =>
+  isObjectRecord(v) &&
+  typeof (v as LegacyRecord).phraseId === "string" &&
+  typeof (v as LegacyRecord).total === "number" &&
+  typeof (v as LegacyRecord).target === "number";
+
+const isTasbihRecord = (v: unknown): v is TasbihRecord =>
+  isObjectRecord(v) &&
+  typeof (v as TasbihRecord).phraseId === "string" &&
+  isObjectRecord((v as TasbihRecord).phrases);
 
 export const mobileTasbihStore: TasbihStore = {
-  read: () => getJSON<TasbihRecord | null>(KEYS.tasbih, null, isTasbihRecord),
+  read: async () => {
+    const raw = await getJSON<unknown>(KEYS.tasbih, null);
+    if (isTasbihRecord(raw)) return raw;
+    // Migrate the old single-total shape: the phrase being counted when this
+    // was last saved keeps its progress, filed under its own entry.
+    if (isLegacyRecord(raw)) {
+      const migrated: TasbihRecord = {
+        phraseId: raw.phraseId,
+        phrases: { [raw.phraseId]: { total: raw.total, target: raw.target } },
+      };
+      await setJSON(KEYS.tasbih, migrated);
+      return migrated;
+    }
+    return null;
+  },
   write: (record) => setJSON(KEYS.tasbih, record),
 };

--- a/apps/web/src/app/api/v1/hadith/[collection]/route.ts
+++ b/apps/web/src/app/api/v1/hadith/[collection]/route.ts
@@ -4,7 +4,11 @@ import { apiJson } from "../../../../../lib/api-response";
 // Prerendered from the ingested datasets at build time (ADR 0022): the whole
 // collection in one static response, which the client caches for offline search.
 export const dynamic = "force-static";
-export const dynamicParams = false;
+// Deliberately not `dynamicParams = false`: an id outside generateStaticParams
+// must still reach the GET handler below so it returns the JSON 404 error
+// instead of Next's generic HTML not-found page (the public API's documented
+// error shape — see openapi.json).
+export const dynamicParams = true;
 
 export function generateStaticParams() {
   return pluginRegistry.byKind("hadith").map((c) => ({ collection: c.id }));

--- a/apps/web/src/app/api/v1/recitations/[reciterId]/surahs/[number]/timings/route.ts
+++ b/apps/web/src/app/api/v1/recitations/[reciterId]/surahs/[number]/timings/route.ts
@@ -6,7 +6,11 @@ import { apiJson } from "../../../../../../../../lib/api-response";
 // word-by-word timings are bundled, so the player reads them as a static file and
 // highlights words / tap-to-hear without a runtime call to the quran.com API.
 export const dynamic = "force-static";
-export const dynamicParams = false;
+// Deliberately not `dynamicParams = false`: an id outside generateStaticParams
+// must still reach the GET handler below so it returns the JSON 404 error
+// instead of Next's generic HTML not-found page (the public API's documented
+// error shape — see openapi.json).
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
   const reciters = await recitationTimingRepository.reciterIds();

--- a/apps/web/src/app/api/v1/surahs/[number]/route.ts
+++ b/apps/web/src/app/api/v1/surahs/[number]/route.ts
@@ -3,7 +3,11 @@ import { quranRepository } from "@ummahlibrary/api";
 import { apiJson } from "../../../../../lib/api-response";
 
 export const dynamic = "force-static";
-export const dynamicParams = false;
+// Deliberately not `dynamicParams = false`: an id outside generateStaticParams
+// must still reach the GET handler below so it returns the JSON 404 error
+// instead of Next's generic HTML not-found page (the public API's documented
+// error shape — see openapi.json).
+export const dynamicParams = true;
 
 export function generateStaticParams() {
   return Array.from({ length: TOTAL_SURAHS }, (_, i) => ({ number: String(i + 1) }));

--- a/apps/web/src/app/api/v1/surahs/[number]/translations/[edition]/route.ts
+++ b/apps/web/src/app/api/v1/surahs/[number]/translations/[edition]/route.ts
@@ -3,7 +3,11 @@ import { quranRepository, translationRepository } from "@ummahlibrary/api";
 import { apiJson } from "../../../../../../../lib/api-response";
 
 export const dynamic = "force-static";
-export const dynamicParams = false;
+// Deliberately not `dynamicParams = false`: an id outside generateStaticParams
+// must still reach the GET handler below so it returns the JSON 404 error
+// instead of Next's generic HTML not-found page (the public API's documented
+// error shape — see openapi.json).
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
   const editions = await translationRepository.listTranslations();

--- a/apps/web/src/app/tools/page.tsx
+++ b/apps/web/src/app/tools/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { N } from "@ummahlibrary/ui";
 import { ToolsPrayerCard } from "../../components/ToolsPrayerCard";
+import { ToolsQiblaCard } from "../../components/ToolsQiblaCard";
 
 const TOOLS = [
   { key: "/prayer-times", label: "Prayer Times", glyph: "🕌", note: "Daily salah times" },
@@ -9,7 +10,7 @@ const TOOLS = [
   { key: "/tracker", label: "Prayer Tracker", glyph: "📿", note: "Log & build streaks" },
   { key: "/duas", label: "Duʿās", glyph: "🤲", note: "Fortress of the Muslim" },
   { key: "/plans", label: "Reading Plans", glyph: "🗺", note: "Structured journeys" },
-  { key: "/qibla", label: "Qibla", glyph: "🧭", note: "118° SE · Direction to Makkah" },
+  { key: "/qibla", label: "Qibla", glyph: "🧭", note: "Direction to Makkah" },
   { key: "/mosques", label: "Nearby Mosques", glyph: "📍", note: "Find a place to pray" },
   { key: "/hifz", label: "Hifz Review", glyph: "✦", note: "Spaced repetition" },
   { key: "/calendar", label: "Hijri Calendar", glyph: "☾", note: "Islamic dates" },
@@ -63,90 +64,7 @@ export default function ToolsPage() {
           <ToolsPrayerCard />
 
           {/* Qibla featured */}
-          <Link
-            href="/qibla"
-            style={{
-              borderRadius: 18,
-              padding: 24,
-              background: N.card,
-              border: `1px solid ${N.border}`,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              textAlign: "center",
-              textDecoration: "none",
-            }}
-          >
-            {/* Compass decoration */}
-            <div style={{ position: "relative", width: 150, height: 150, marginBottom: 16 }}>
-              <div
-                style={{
-                  position: "absolute",
-                  inset: 0,
-                  borderRadius: "50%",
-                  border: `1px solid ${N.border}`,
-                }}
-              />
-              <div
-                style={{
-                  position: "absolute",
-                  inset: 14,
-                  borderRadius: "50%",
-                  border: `1px dashed ${N.borderSoft}`,
-                }}
-              />
-              {(["N", "E", "S", "W"] as const).map((d, i) => (
-                <span
-                  key={d}
-                  style={{
-                    position: "absolute",
-                    fontSize: 11,
-                    color: N.faint,
-                    top: i === 0 ? 6 : i === 2 ? "auto" : "50%",
-                    bottom: i === 2 ? 6 : "auto",
-                    left: i === 3 ? 8 : i === 1 ? "auto" : "50%",
-                    right: i === 1 ? 8 : "auto",
-                    transform: i === 0 || i === 2 ? "translateX(-50%)" : "translateY(-50%)",
-                  }}
-                >
-                  {d}
-                </span>
-              ))}
-              {/* Needle */}
-              <div
-                style={{
-                  position: "absolute",
-                  top: "50%",
-                  left: "50%",
-                  width: 4,
-                  height: 56,
-                  background: N.goldGrad,
-                  borderRadius: 2,
-                  transformOrigin: "bottom center",
-                  transform: "translate(-50%, -100%) rotate(118deg)",
-                }}
-              />
-              <div
-                style={{
-                  position: "absolute",
-                  top: "50%",
-                  left: "50%",
-                  width: 12,
-                  height: 12,
-                  borderRadius: 6,
-                  background: N.gold,
-                  transform: "translate(-50%, -50%)",
-                }}
-              />
-            </div>
-            <div style={{ fontSize: 16, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>
-              Qibla · 118° SE
-            </div>
-            <div style={{ fontSize: 13, color: N.muted, marginTop: 3, fontFamily: N.ui }}>
-              Direction to the Kaʿbah
-            </div>
-          </Link>
+          <ToolsQiblaCard />
         </div>
 
         {/* All tools grid */}

--- a/apps/web/src/components/TasbihPageClient.test.tsx
+++ b/apps/web/src/components/TasbihPageClient.test.tsx
@@ -27,16 +27,32 @@ describe("TasbihPageClient", () => {
     expect(dial()).toHaveAccessibleName(/1 of 33/);
   });
 
-  it("switching the dhikr preset resets the count and its target", async () => {
+  it("switching the dhikr preset shows that phrase's own count, at its own target", async () => {
     render(<TasbihPageClient />);
 
     await userEvent.click(await screen.findByRole("button", { name: /Count/ })); // count → 1
     await userEvent.click(screen.getByRole("button", { name: "Allāhu Akbar" }));
 
-    expect(dial()).toHaveAccessibleName(/0 of 34/); // reset, target 34
+    // A never-counted phrase starts at zero, at its own default target (34).
+    expect(dial()).toHaveAccessibleName(/0 of 34/);
   });
 
-  it("the Reset button clears the running count and persists it", async () => {
+  it("switching phrases and back does not lose the earlier phrase's progress", async () => {
+    render(<TasbihPageClient />);
+
+    const d = await screen.findByRole("button", { name: /Count/ });
+    await userEvent.click(d);
+    await userEvent.click(d);
+    expect(dial()).toHaveAccessibleName(/2 of 33/); // SubḥānAllāh at 2
+
+    await userEvent.click(screen.getByRole("button", { name: "Alḥamdulillāh" }));
+    expect(dial()).toHaveAccessibleName(/0 of 33/); // a different, uncounted phrase
+
+    await userEvent.click(screen.getByRole("button", { name: "SubḥānAllāh" }));
+    expect(dial()).toHaveAccessibleName(/2 of 33/); // SubḥānAllāh's count is still there
+  });
+
+  it("the Reset button clears only the current phrase's count, and persists it", async () => {
     render(<TasbihPageClient />);
 
     const d = await screen.findByRole("button", { name: /Count/ });
@@ -46,6 +62,7 @@ describe("TasbihPageClient", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Reset" }));
     expect(dial()).toHaveAccessibleName(/0 of 33/);
-    expect(JSON.parse(localStorage.getItem("ul.tasbih2") ?? "{}").total).toBe(0);
+    const stored = JSON.parse(localStorage.getItem("ul.tasbih2") ?? "{}");
+    expect(stored.phrases.subhanallah.total).toBe(0);
   });
 });

--- a/apps/web/src/components/TasbihPageClient.tsx
+++ b/apps/web/src/components/TasbihPageClient.tsx
@@ -1,19 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { DHIKR_PHRASES, type TasbihRecord, tasbihState } from "@ummahlibrary/core";
+import {
+  DHIKR_PHRASES,
+  type TasbihRecord,
+  tasbihPhraseProgress,
+  tasbihState,
+} from "@ummahlibrary/core";
 import { N } from "@ummahlibrary/ui";
 import { NoorPageFrame } from "./NoorPageFrame";
 import { DEFAULT_TASBIH, readTasbih, writeTasbih } from "../lib/tasbih";
 
 const PRESET_IDS = ["subhanallah", "alhamdulillah", "allahuakbar", "tahlil"] as const;
-
-const PHRASE_TARGETS: Record<string, number> = {
-  subhanallah: 33,
-  alhamdulillah: 33,
-  allahuakbar: 34,
-  tahlil: 100,
-};
 
 export function TasbihPageClient() {
   const [ready, setReady] = useState(false);
@@ -29,8 +27,10 @@ export function TasbihPageClient() {
 
   const presets = DHIKR_PHRASES.filter((p) => (PRESET_IDS as readonly string[]).includes(p.id));
   const phrase = DHIKR_PHRASES.find((p) => p.id === state.phraseId) ?? presets[0]!;
-  const view = tasbihState(state.total, state.target);
-  const target = state.target;
+  // Each phrase's own progress — switching phrases (below) never touches this.
+  const progress = tasbihPhraseProgress(state, state.phraseId);
+  const view = tasbihState(progress.total, progress.target);
+  const target = progress.target;
 
   function update(next: TasbihRecord) {
     setState(next);
@@ -40,22 +40,29 @@ export function TasbihPageClient() {
   function tap() {
     setPulse((v) => v + 1);
     setState((prev) => {
-      const next: TasbihRecord = { ...prev, total: prev.total + 1 };
+      const cur = tasbihPhraseProgress(prev, prev.phraseId);
+      const nextProgress = { total: cur.total + 1, target: cur.target };
+      const next: TasbihRecord = {
+        ...prev,
+        phrases: { ...prev.phrases, [prev.phraseId]: nextProgress },
+      };
       void writeTasbih(next);
       if (typeof navigator !== "undefined" && "vibrate" in navigator) {
         // count wraps to 0 exactly when a round completes
-        navigator.vibrate(tasbihState(next.total, next.target).count === 0 ? 60 : 12);
+        navigator.vibrate(tasbihState(nextProgress.total, nextProgress.target).count === 0 ? 60 : 12);
       }
       return next;
     });
   }
 
   function selectPhrase(phraseId: string) {
-    update({ phraseId, total: 0, target: PHRASE_TARGETS[phraseId] ?? 33 });
+    // Only the displayed phrase changes — each phrase's own total/target stays
+    // put, so switching away and back doesn't lose (or merge into) progress.
+    update({ ...state, phraseId });
   }
 
   function reset() {
-    update({ ...state, total: 0 });
+    update({ ...state, phrases: { ...state.phrases, [state.phraseId]: { total: 0, target } } });
   }
 
   const pct = target > 0 ? view.count / target : 0;

--- a/apps/web/src/components/ToolsQiblaCard.tsx
+++ b/apps/web/src/components/ToolsQiblaCard.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { type Coordinates, compassPoint, qiblaDirection } from "@ummahlibrary/core";
+import { N } from "@ummahlibrary/ui";
+import { webPrayerSettingsStore } from "../lib/prayer-settings-store";
+
+const cardStyle = {
+  borderRadius: 18,
+  padding: 24,
+  background: N.card,
+  border: `1px solid ${N.border}`,
+  display: "flex",
+  flexDirection: "column" as const,
+  alignItems: "center",
+  justifyContent: "center",
+  textAlign: "center" as const,
+  textDecoration: "none",
+};
+
+/** The Tools "Qibla" featured card — the real bearing from the saved location
+ *  (shared with Prayer Times/Qibla via `webPrayerSettingsStore`), or a neutral
+ *  prompt when no location is set yet. Mirrors `ToolsPrayerCard`'s ready/CTA
+ *  split so this card never shows a number that isn't actually computed. */
+export function ToolsQiblaCard() {
+  const [coords, setCoords] = useState<Coordinates | null>(null);
+
+  useEffect(() => {
+    void webPrayerSettingsStore.read().then(({ coords: saved }) => {
+      if (saved) setCoords(saved);
+    });
+  }, []);
+
+  const bearing = coords ? qiblaDirection(coords) : null;
+
+  return (
+    <Link href="/qibla" style={cardStyle}>
+      {/* Compass decoration */}
+      <div style={{ position: "relative", width: 150, height: 150, marginBottom: 16 }}>
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            borderRadius: "50%",
+            border: `1px solid ${N.border}`,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            inset: 14,
+            borderRadius: "50%",
+            border: `1px dashed ${N.borderSoft}`,
+          }}
+        />
+        {(["N", "E", "S", "W"] as const).map((d, i) => (
+          <span
+            key={d}
+            style={{
+              position: "absolute",
+              fontSize: 11,
+              color: N.faint,
+              top: i === 0 ? 6 : i === 2 ? "auto" : "50%",
+              bottom: i === 2 ? 6 : "auto",
+              left: i === 3 ? 8 : i === 1 ? "auto" : "50%",
+              right: i === 1 ? 8 : "auto",
+              transform: i === 0 || i === 2 ? "translateX(-50%)" : "translateY(-50%)",
+            }}
+          >
+            {d}
+          </span>
+        ))}
+        {/* Needle — only drawn once we have a real bearing to point it at */}
+        {bearing !== null && (
+          <div
+            style={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              width: 4,
+              height: 56,
+              background: N.goldGrad,
+              borderRadius: 2,
+              transformOrigin: "bottom center",
+              transform: `translate(-50%, -100%) rotate(${bearing}deg)`,
+            }}
+          />
+        )}
+        <div
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            width: 12,
+            height: 12,
+            borderRadius: 6,
+            background: N.gold,
+            transform: "translate(-50%, -50%)",
+          }}
+        />
+      </div>
+      {bearing !== null ? (
+        <>
+          <div style={{ fontSize: 16, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>
+            Qibla · {Math.round(bearing)}° {compassPoint(bearing)}
+          </div>
+          <div style={{ fontSize: 13, color: N.muted, marginTop: 3, fontFamily: N.ui }}>
+            Direction to the Kaʿbah
+          </div>
+        </>
+      ) : (
+        <>
+          <div style={{ fontSize: 16, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>Qibla</div>
+          <div style={{ fontSize: 13, color: N.muted, marginTop: 3, fontFamily: N.ui }}>
+            Set your location to see the direction
+          </div>
+        </>
+      )}
+    </Link>
+  );
+}

--- a/apps/web/src/components/ZakatCalculator.tsx
+++ b/apps/web/src/components/ZakatCalculator.tsx
@@ -32,6 +32,13 @@ function num(s: string): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+/** Strip digits from the currency symbol field — a symbol/code ("$", "AED") never
+ *  contains one, and allowing digits here let a stray one silently fuse into the
+ *  displayed totals (money() concatenates currency + amount with no separator). */
+function sanitizeCurrency(s: string): string {
+  return s.replace(/[0-9]/g, "");
+}
+
 const sectionLabel = {
   fontSize: 12,
   letterSpacing: 1,
@@ -125,6 +132,9 @@ export function ZakatCalculator() {
       setState({
         ...DEFAULT_STATE,
         ...saved,
+        // Self-heal a currency value saved before sanitizeCurrency existed — a
+        // stray digit in it used to silently fuse into the displayed totals.
+        currency: sanitizeCurrency(saved.currency ?? DEFAULT_STATE.currency) || DEFAULT_STATE.currency,
         assets: { ...EMPTY_ASSETS, ...(saved.assets ?? {}) },
       });
     }
@@ -150,8 +160,10 @@ export function ZakatCalculator() {
     [state],
   );
 
-  const money = (n: number) =>
-    `${state.currency}${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const money = (n: number) => {
+    const symbol = sanitizeCurrency(state.currency) || DEFAULT_STATE.currency;
+    return `${symbol}${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  };
 
   const havePrices = num(state.goldPricePerGram) > 0 && num(state.silverPricePerGram) > 0;
 
@@ -200,7 +212,7 @@ export function ZakatCalculator() {
             <Field
               label="Currency"
               value={state.currency}
-              onChange={(v) => setState((s) => ({ ...s, currency: v.slice(0, 4) }))}
+              onChange={(v) => setState((s) => ({ ...s, currency: sanitizeCurrency(v).slice(0, 4) }))}
               placeholder="$"
             />
             <Field

--- a/apps/web/src/lib/tasbih-store.ts
+++ b/apps/web/src/lib/tasbih-store.ts
@@ -8,15 +8,51 @@ import type { TasbihRecord, TasbihStore } from "@ummahlibrary/core";
 
 const KEY = "ul.tasbih2";
 
+/** The pre-per-phrase-progress shape (a single shared total/target). */
+interface LegacyRecord {
+  phraseId: string;
+  total: number;
+  target: number;
+}
+
+function isLegacyRecord(r: unknown): r is LegacyRecord {
+  return (
+    typeof r === "object" &&
+    r !== null &&
+    typeof (r as LegacyRecord).phraseId === "string" &&
+    typeof (r as LegacyRecord).total === "number" &&
+    typeof (r as LegacyRecord).target === "number"
+  );
+}
+
+function isRecord(r: unknown): r is TasbihRecord {
+  return (
+    typeof r === "object" &&
+    r !== null &&
+    typeof (r as TasbihRecord).phraseId === "string" &&
+    typeof (r as TasbihRecord).phrases === "object" &&
+    (r as TasbihRecord).phrases !== null
+  );
+}
+
 export const webTasbihStore: TasbihStore = {
   read: async () => {
     try {
       const raw = localStorage.getItem(KEY);
       if (!raw) return null;
-      const r = JSON.parse(raw) as Partial<TasbihRecord>;
-      return typeof r.total === "number" && typeof r.target === "number" && typeof r.phraseId === "string"
-        ? { phraseId: r.phraseId, total: r.total, target: r.target }
-        : null;
+      const parsed: unknown = JSON.parse(raw);
+      if (isRecord(parsed)) return parsed;
+      // Migrate the old single-total shape: the phrase being counted when this
+      // was last saved keeps its progress, filed under its own entry.
+      if (isLegacyRecord(parsed)) {
+        const migrated: TasbihRecord = {
+          phraseId: parsed.phraseId,
+          phrases: { [parsed.phraseId]: { total: parsed.total, target: parsed.target } },
+        };
+        localStorage.setItem(KEY, JSON.stringify(migrated));
+        return migrated;
+      }
+      return null;
     } catch {
       return null;
     }

--- a/apps/web/src/lib/tasbih.ts
+++ b/apps/web/src/lib/tasbih.ts
@@ -9,8 +9,7 @@ import { webTasbihStore as store } from "./tasbih-store";
 
 export const DEFAULT_TASBIH: TasbihRecord = {
   phraseId: DHIKR_PHRASES[0]!.id,
-  total: 0,
-  target: 33,
+  phrases: {},
 };
 
 export async function readTasbih(): Promise<TasbihRecord> {

--- a/packages/core/src/tasbih.test.ts
+++ b/packages/core/src/tasbih.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DHIKR_PHRASES, TASBIH_TARGETS, tasbihState } from "./tasbih";
+import { DHIKR_PHRASES, TASBIH_TARGETS, tasbihPhraseProgress, tasbihState } from "./tasbih";
 
 describe("tasbihState", () => {
   it("cycles the count within a round and counts rounds", () => {
@@ -37,5 +37,28 @@ describe("catalogues", () => {
 
   it("offers the common per-round targets", () => {
     expect(TASBIH_TARGETS).toEqual([33, 99, 100]);
+  });
+});
+
+describe("tasbihPhraseProgress", () => {
+  it("returns a phrase's own stored progress untouched", () => {
+    const record = {
+      phraseId: "alhamdulillah",
+      phrases: { subhanallah: { total: 35, target: 33 }, alhamdulillah: { total: 5, target: 33 } },
+    };
+    expect(tasbihPhraseProgress(record, "alhamdulillah")).toEqual({ total: 5, target: 33 });
+    // Switching away and back must not touch another phrase's entry.
+    expect(tasbihPhraseProgress(record, "subhanallah")).toEqual({ total: 35, target: 33 });
+  });
+
+  it("starts an uncounted phrase at zero, using its default target", () => {
+    const record = { phraseId: "tahlil", phrases: {} };
+    expect(tasbihPhraseProgress(record, "tahlil")).toEqual({ total: 0, target: 100 });
+    expect(tasbihPhraseProgress(record, "allahuakbar")).toEqual({ total: 0, target: 34 });
+  });
+
+  it("falls back to 33 for a phrase with no known default (e.g. istighfar)", () => {
+    const record = { phraseId: "istighfar", phrases: {} };
+    expect(tasbihPhraseProgress(record, "istighfar")).toEqual({ total: 0, target: 33 });
   });
 });

--- a/packages/core/src/tasbih.ts
+++ b/packages/core/src/tasbih.ts
@@ -27,6 +27,15 @@ export const DHIKR_PHRASES: readonly DhikrPhrase[] = [
 /** Common per-round targets. */
 export const TASBIH_TARGETS: readonly number[] = [33, 99, 100];
 
+/** Default per-round target for each built-in phrase — used the first time a
+ *  phrase is selected, before it has its own stored progress. */
+export const DEFAULT_TASBIH_TARGETS: Record<string, number> = {
+  subhanallah: 33,
+  alhamdulillah: 33,
+  allahuakbar: 34,
+  tahlil: 100,
+};
+
 export interface TasbihState {
   /** Position within the current round (0…target-1). */
   count: number;
@@ -42,9 +51,25 @@ export function tasbihState(total: number, target: number): TasbihState {
   return { count: safeTotal % t, rounds: Math.floor(safeTotal / t), total: safeTotal };
 }
 
-/** The persisted tasbih counter: the chosen phrase, a running total, the round size. */
-export interface TasbihRecord {
-  phraseId: string;
+/** One phrase's own running total and round size. */
+export interface TasbihPhraseProgress {
   total: number;
   target: number;
+}
+
+/**
+ * The persisted tasbih counter: the currently-displayed phrase, plus every
+ * phrase's own progress keyed by phrase id. Each dhikr keeps its own total —
+ * switching phrases (to check on another, or to work through the classic
+ * 33/33/34 post-prayer sequence) must never lose or merge a phrase's count.
+ */
+export interface TasbihRecord {
+  phraseId: string;
+  phrases: Record<string, TasbihPhraseProgress>;
+}
+
+/** A phrase's stored progress, or a fresh zero at its default target when it
+ *  hasn't been counted yet. */
+export function tasbihPhraseProgress(record: TasbihRecord, phraseId: string): TasbihPhraseProgress {
+  return record.phrases[phraseId] ?? { total: 0, target: DEFAULT_TASBIH_TARGETS[phraseId] ?? 33 };
 }


### PR DESCRIPTION
# Fix 4 bugs found in a full-site web QA pass

Full-site QA pass of `apps/web` (every top-level route, the public REST API, and a
mobile-viewport check) turned up four confirmed, reproducible bugs. All four are fixed,
tested, and verified here. Full findings write-up: see the QA report shared alongside
this PR (not checked in — it documents the investigation, not the code).

## Bugs fixed

**Zakat calculator: unsanitized Currency field corrupts every money display**
The "Currency" field accepted any text (no character-class restriction), and `money()`
concatenated it directly onto every amount with no separator. Typing "85" into Currency
turned every total into a garbled string like `$851,000.00` — really `"$85"` glued to
`"1,000.00"` — and it survived Reset and page reloads since `currency` is deliberately
preserved across a reset. Mirrors the mobile Zakat currency bug already fixed this
session (`44c9a33`).

**Tools hub: Qibla card showed a hardcoded fake "118° SE" for everyone**
The Qibla featured card on `/tools` always rendered the literal string `"118° SE"` and a
needle fixed at `rotate(118deg)` — not computed from the visitor's location at all,
unlike the `ToolsPrayerCard` right next to it (which correctly shows a neutral "View
prayer times" CTA when no location is set). Extracted a `ToolsQiblaCard` that reads the
shared saved coordinates and computes the real bearing via the same `qiblaDirection()`
the actual `/qibla` page uses, falling back to a neutral "Set your location" prompt.

**Tasbih counter: no per-phrase counter — progress lost (web) or mislabeled (mobile)**
`TasbihRecord` stored a single `{ phraseId, total, target }` — one running total
re-labelled by whichever phrase happened to be selected. Web's `selectPhrase` reset
`total` to 0 on every switch, so tapping back to check an earlier phrase silently lost
its progress. Mobile had the opposite bug: switching `phraseId` left `total` untouched,
so the count carried over under the new label, implying recitations that never
happened. Both defeat the standard post-prayer tasbih routine (33× SubḥānAllāh, 33×
Alḥamdulillāh, 34× Allāhu Akbar).

Fixed by keying progress by phrase id (`phrases: Record<string, { total, target }>`) in
`packages/core`, shared by both platforms, with an in-place migration on read so no
one's existing stored progress is lost.

**Public REST API: invalid path params returned an HTML 404 page, not the documented
JSON error**
`/api/v1/surahs/[number]`, `hadith/[collection]`, `surahs/[number]/translations/
[edition]`, and `recitations/.../timings` all set `dynamicParams = false` alongside
`force-static`. For any id outside `generateStaticParams()`, Next intercepted the
request and served the app's generic HTML not-found page *before the route handler
ran* — so each handler's own `apiJson({ error }, { status: 404 })` branch was dead code
for real invalid input. Any client parsing the response as JSON (per the published
`openapi.json`) got a `SyntaxError` instead of the documented error shape.

Switched `dynamicParams` to `true` (the default) on all four routes: the known id space
is still fully prerendered at build time exactly as before — verified via the build
output that all four routes still list the same pre-rendered paths — but a request
outside it now reaches the handler and gets a real JSON 404. Verified against an actual
production server (`next start`), not just dev mode, since this is specifically a
build-time/production behavior.

## Verification

- `pnpm lint && pnpm typecheck && pnpm test && pnpm build` all pass.
- New/updated tests: `packages/core/src/tasbih.test.ts` (per-phrase progress helper),
  `apps/web/src/components/TasbihPageClient.test.tsx` (switch-and-back no longer loses
  progress; Reset only clears the current phrase).
- Manually verified all four fixes live in a browser against the dev server, and the
  API fix additionally against a `next start` production server.

## Commits

Four commits, one per bug — see individual messages for full rationale.
