### PR TITLE
Fix 6 bugs found in a live browser QA pass on the web app

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "remark-directive": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
+    "tz-lookup": "^6.1.25",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0"
   },
@@ -37,6 +38,7 @@
     "@types/node": "^22.10.2",
     "@types/react": "19.2.3",
     "@types/react-dom": "19.2.3",
+    "@types/tz-lookup": "^6.1.2",
     "@vitejs/plugin-react": "^4.3.4",
     "jsdom": "^25.0.1",
     "sharp": "^0.34.0",

--- a/apps/web/src/components/FastingQadaTracker.tsx
+++ b/apps/web/src/components/FastingQadaTracker.tsx
@@ -5,13 +5,14 @@ import { useEffect, useState } from "react";
 import {
   type FastingQadaLog,
   type HaidLog,
+  adjustFastingMadeUp,
   fastingMadeUp,
   fastingQadaOwed,
   fastingQadaRemaining,
 } from "@ummahlibrary/core";
 import { N } from "@ummahlibrary/ui";
 import { HAID_EVENT, readHaid } from "../lib/haid";
-import { FASTING_QADA_EVENT, adjustFastingMadeUpCount, readFastingQada } from "../lib/fasting-qada";
+import { FASTING_QADA_EVENT, readFastingQada, writeFastingQada } from "../lib/fasting-qada";
 import { readHijriAdjust } from "../lib/hijri";
 import { today } from "../lib/prayer-tracker";
 
@@ -62,6 +63,14 @@ export function FastingQadaTracker() {
   const remaining = fastingQadaRemaining(log, owed);
   const madeUp = fastingMadeUp(log, owed);
 
+  function adjustMadeUp(delta: number) {
+    setLog((prev) => {
+      const next = adjustFastingMadeUp(prev, delta, owed);
+      void writeFastingQada(next);
+      return next;
+    });
+  }
+
   return (
     <div style={{ ...card, padding: 24, marginTop: 18 }}>
       <div
@@ -95,7 +104,7 @@ export function FastingQadaTracker() {
                 label="Mark one fast made up"
                 symbol="−"
                 disabled={remaining === 0}
-                onClick={() => void adjustFastingMadeUpCount(1, owed).then(setLog)}
+                onClick={() => adjustMadeUp(1)}
               />
               <span
                 aria-live="polite"
@@ -114,7 +123,7 @@ export function FastingQadaTracker() {
                 label="Undo one made-up fast"
                 symbol="+"
                 disabled={madeUp === 0}
-                onClick={() => void adjustFastingMadeUpCount(-1, owed).then(setLog)}
+                onClick={() => adjustMadeUp(-1)}
               />
             </div>
           </div>

--- a/apps/web/src/components/HifzReview.tsx
+++ b/apps/web/src/components/HifzReview.tsx
@@ -109,7 +109,7 @@ export function HifzReview({
           All caught up!
         </div>
         <div style={{ fontSize: 14.5, color: N.muted, marginBottom: 28, fontFamily: N.ui }}>
-          {queue.length} āyah{queue.length !== 1 ? "āt" : ""} reviewed · {total} tracked in total.
+          {queue.length} {queue.length === 1 ? "āyah" : "āyāt"} reviewed · {total} tracked in total.
         </div>
         <Link
           href="/hifz"

--- a/apps/web/src/components/HomeHeroCards.tsx
+++ b/apps/web/src/components/HomeHeroCards.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
+  type Coordinates,
   PRAYER_LABELS,
   type PrayerTimings,
   computeStreak,
@@ -10,14 +11,10 @@ import {
 } from "@ummahlibrary/core";
 import { Khatam, N } from "@ummahlibrary/ui";
 import { HomePrayerCard } from "./HomePrayerCard";
+import { fmtPrayerTime } from "../lib/prayer-time-format";
+import { webPrayerSettingsStore } from "../lib/prayer-settings-store";
 import { webPrayerTimingsProvider } from "../lib/prayer-timings-provider";
 import { readReadingState, today } from "../lib/reading-goals";
-
-function fmtTime(src: string | Date): string {
-  const d = typeof src === "string" ? new Date(src) : src;
-  if (Number.isNaN(d.getTime())) return "—"; // polar-empty timing → Invalid Date
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
 
 function countdown(target: Date, now: Date): string {
   if (Number.isNaN(target.getTime())) return "—";
@@ -34,6 +31,7 @@ const C = 2 * Math.PI * 27;
 export function HomeHeroCards() {
   const [ready, setReady] = useState(false);
   const [timings, setTimings] = useState<PrayerTimings | null>(null);
+  const [coords, setCoords] = useState<Coordinates | null>(null);
   const [now, setNow] = useState(() => new Date());
   const [reading, setReading] = useState({ pages: 0, goal: 4, streak: 0 });
 
@@ -42,6 +40,7 @@ export function HomeHeroCards() {
     void readReadingState().then((s) =>
       setReading({ pages: s.pagesToday, goal: s.goal, streak: computeStreak(s.activeDates, today()) }),
     );
+    void webPrayerSettingsStore.read().then(({ coords: c }) => setCoords(c));
     void webPrayerTimingsProvider.getTodaysTimings().then((t) => {
       if (t) setTimings(t);
     });
@@ -139,7 +138,7 @@ export function HomeHeroCards() {
                 {PRAYER_LABELS[next.name]}
               </span>
               <span style={{ fontSize: 19, fontWeight: 700, lineHeight: 1.1, color: N.fg }}>
-                {fmtTime(next.at)}
+                {fmtPrayerTime(next.at, coords)}
               </span>
             </div>
             <div style={{ fontSize: 12.5, color: N.muted }}>

--- a/apps/web/src/components/PrayerTimesView.tsx
+++ b/apps/web/src/components/PrayerTimesView.tsx
@@ -27,6 +27,7 @@ import {
   readPrayerReminderPrefs,
   setPrayerReminder,
 } from "../lib/prayer-reminders";
+import { fmtPrayerTime } from "../lib/prayer-time-format";
 import { webPrayerSettingsStore } from "../lib/prayer-settings-store";
 import { WebNotifier } from "../lib/web-notifier";
 
@@ -36,13 +37,6 @@ type Status = "idle" | "locating" | "loading" | "ready" | "error" | "denied";
 function localDate(d: Date): string {
   const p = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
-}
-
-function fmtTime(src: string | Date): string {
-  const d = typeof src === "string" ? new Date(src) : src;
-  // A polar-invalid timing is "" (→ Invalid Date); show a dash, not "Invalid Date" / a throw.
-  if (Number.isNaN(d.getTime())) return "—";
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
 function countdown(target: Date, now: Date): string {
@@ -312,7 +306,7 @@ export function PrayerTimesView() {
                   {PRAYER_LABELS[next.name]}
                 </span>
                 <span style={{ fontSize: 26, fontWeight: 700, color: N.fg }}>
-                  {fmtTime(next.at)}
+                  {fmtPrayerTime(next.at, coords)}
                 </span>
               </div>
               <div style={{ fontSize: 14, color: N.muted }}>
@@ -363,7 +357,7 @@ export function PrayerTimesView() {
                       flexShrink: 0,
                     }}
                   >
-                    {fmtTime(timings[name])}
+                    {fmtPrayerTime(timings[name], coords)}
                   </span>
                   {/* Reserve the toggle slot on every card (incl. Sunrise) so the
                       times line up in a column. */}
@@ -438,7 +432,7 @@ export function PrayerTimesView() {
                     flexShrink: 0,
                   }}
                 >
-                  {timings[name] ? fmtTime(timings[name]) : "—"}
+                  {timings[name] ? fmtPrayerTime(timings[name], coords) : "—"}
                 </span>
               </div>
             ))}
@@ -492,7 +486,7 @@ export function PrayerTimesView() {
                             fontVariantNumeric: "tabular-nums",
                           }}
                         >
-                          {d.timings ? fmtTime(d.timings[p]) : "—"}
+                          {d.timings ? fmtPrayerTime(d.timings[p], coords) : "—"}
                         </div>
                       ))}
                     </div>

--- a/apps/web/src/components/QadaTracker.tsx
+++ b/apps/web/src/components/QadaTracker.tsx
@@ -2,9 +2,17 @@
 
 import type { CSSProperties } from "react";
 import { useEffect, useState } from "react";
-import { OBLIGATORY_PRAYERS, PRAYER_LABELS, type QadaLog, owedFor, totalOwed } from "@ummahlibrary/core";
+import {
+  OBLIGATORY_PRAYERS,
+  PRAYER_LABELS,
+  type PrayerName,
+  type QadaLog,
+  adjustQada,
+  owedFor,
+  totalOwed,
+} from "@ummahlibrary/core";
 import { N } from "@ummahlibrary/ui";
-import { QADA_EVENT, adjustQadaCount, readQada } from "../lib/qada";
+import { QADA_EVENT, readQada, writeQada } from "../lib/qada";
 
 const card: CSSProperties = {
   background: N.card,
@@ -30,6 +38,14 @@ export function QadaTracker() {
     window.addEventListener(QADA_EVENT, onChange);
     return () => window.removeEventListener(QADA_EVENT, onChange);
   }, []);
+
+  function adjust(prayer: PrayerName, delta: number) {
+    setLog((prev) => {
+      const next = adjustQada(prev, prayer, delta);
+      void writeQada(next);
+      return next;
+    });
+  }
 
   if (!ready) return null;
 
@@ -67,7 +83,7 @@ export function QadaTracker() {
                   label={`Make up one ${PRAYER_LABELS[p]}`}
                   symbol="−"
                   disabled={owed === 0}
-                  onClick={() => void adjustQadaCount(p, -1).then(setLog)}
+                  onClick={() => adjust(p, -1)}
                 />
                 <span
                   aria-live="polite"
@@ -85,7 +101,7 @@ export function QadaTracker() {
                 <Step
                   label={`Record a missed ${PRAYER_LABELS[p]}`}
                   symbol="+"
-                  onClick={() => void adjustQadaCount(p, 1).then(setLog)}
+                  onClick={() => adjust(p, 1)}
                 />
               </div>
             </div>

--- a/apps/web/src/components/RamadanView.tsx
+++ b/apps/web/src/components/RamadanView.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { type PrayerTimings, gregorianToHijri, hijriMonth } from "@ummahlibrary/core";
+import { type Coordinates, type PrayerTimings, gregorianToHijri, hijriMonth } from "@ummahlibrary/core";
 import { N, Khatam, Icon } from "@ummahlibrary/ui";
 import type { IconName } from "@ummahlibrary/ui";
+import { fmtPrayerTime } from "../lib/prayer-time-format";
 import { webPrayerSettingsStore } from "../lib/prayer-settings-store";
 import { webPrayerTimingsProvider } from "../lib/prayer-timings-provider";
 import { RAMADAN_EVENT, readFasts, readWorship, toggleFast, toggleWorship } from "../lib/ramadan";
@@ -20,11 +21,6 @@ const WORSHIP: { key: string; label: string; icon: IconName }[] = [
 function localDate(d: Date): string {
   const p = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
-}
-function fmtTime(src: string | Date): string {
-  const d = typeof src === "string" ? new Date(src) : src;
-  if (Number.isNaN(d.getTime())) return "—"; // polar-empty timing → Invalid Date
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 function countdown(target: Date, now: Date): string {
   if (Number.isNaN(target.getTime())) return "—";
@@ -58,7 +54,7 @@ const sectionLabel = {
 export function RamadanView() {
   const [now, setNow] = useState(() => new Date());
   const [timings, setTimings] = useState<PrayerTimings | null>(null);
-  const [hasCoords, setHasCoords] = useState(false);
+  const [coords, setCoords] = useState<Coordinates | null>(null);
   const [fasts, setFasts] = useState<Record<number, true>>({});
   const [worship, setWorship] = useState<Record<string, true>>({});
   const [pagesRead, setPagesRead] = useState(0);
@@ -73,7 +69,7 @@ export function RamadanView() {
     sync();
     window.addEventListener(RAMADAN_EVENT, sync);
 
-    void webPrayerSettingsStore.read().then(({ coords }) => setHasCoords(coords !== null));
+    void webPrayerSettingsStore.read().then(({ coords: c }) => setCoords(c));
     void webPrayerTimingsProvider.getTodaysTimings().then((t) => {
       if (t) setTimings(t);
     });
@@ -146,8 +142,8 @@ export function RamadanView() {
               {beforeIftar ? countdown(iftar, now) : "🌙 Iftar mubarak"}
             </div>
             <div style={{ display: "flex", justifyContent: "space-between", marginTop: 8, fontSize: 12.5, color: N.muted, fontFamily: N.ui }}>
-              <span>Suhūr {fmtTime(timings!.fajr)}</span>
-              <span>Ifṭār {fmtTime(timings!.maghrib)}</span>
+              <span>Suhūr {fmtPrayerTime(timings!.fajr, coords)}</span>
+              <span>Ifṭār {fmtPrayerTime(timings!.maghrib, coords)}</span>
             </div>
             <div style={{ height: 7, borderRadius: 4, background: N.border, overflow: "hidden", marginTop: 6 }}>
               <div style={{ width: `${dayProgress}%`, height: "100%", background: N.goldGrad }} />
@@ -159,9 +155,9 @@ export function RamadanView() {
               Ifṭār countdown
             </div>
             <div style={{ fontSize: 14.5, color: N.muted, marginTop: 10, fontFamily: N.ui }}>
-              {hasCoords ? "Loading today’s times…" : "Set your location to see suhūr & ifṭār times."}
+              {coords ? "Loading today’s times…" : "Set your location to see suhūr & ifṭār times."}
             </div>
-            {!hasCoords && (
+            {!coords && (
               <Link
                 href="/prayer-times"
                 style={{

--- a/apps/web/src/components/ReadingGoalsView.test.tsx
+++ b/apps/web/src/components/ReadingGoalsView.test.tsx
@@ -27,4 +27,17 @@ describe("ReadingGoalsView", () => {
       expect(JSON.parse(localStorage.getItem("ul.readingGoal") ?? "{}").target).toBe(16),
     );
   });
+
+  it("shows a completion message instead of 'Resume' once the khatm is finished", async () => {
+    localStorage.setItem(
+      "ul.khatma",
+      JSON.stringify({ totalPages: 604, currentPage: 604, targetDate: "2026-09-18" }),
+    );
+
+    render(<ReadingGoalsView />);
+
+    expect(await screen.findByText(/khatm complete/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Resume p/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/d left/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/ReadingGoalsView.tsx
+++ b/apps/web/src/components/ReadingGoalsView.tsx
@@ -313,6 +313,18 @@ export function ReadingGoalsView() {
               {d} days
             </button>
           ))
+        ) : khatma.currentPage >= khatma.totalPages ? (
+          <>
+            <span style={{ fontSize: 13, color: N.gold, fontWeight: 700, fontFamily: N.ui }}>
+              Alhamdulillah — khatm complete! 🎉
+            </span>
+            <button onClick={() => adjustKhatma(-1)} style={pill(false)}>
+              −1
+            </button>
+            <button onClick={() => void clearKhatma()} style={pill(false)}>
+              Start a new khatm
+            </button>
+          </>
         ) : (
           <>
             <span style={{ fontSize: 13, color: N.muted, fontFamily: N.ui }}>

--- a/apps/web/src/components/ToolsPrayerCard.tsx
+++ b/apps/web/src/components/ToolsPrayerCard.tsx
@@ -3,19 +3,16 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
+  type Coordinates,
   OBLIGATORY_PRAYERS,
   PRAYER_LABELS,
   type PrayerTimings,
   nextPrayer,
 } from "@ummahlibrary/core";
 import { Icon, Khatam, N } from "@ummahlibrary/ui";
+import { fmtPrayerTime } from "../lib/prayer-time-format";
+import { webPrayerSettingsStore } from "../lib/prayer-settings-store";
 import { webPrayerTimingsProvider } from "../lib/prayer-timings-provider";
-
-function fmtTime(src: string | Date): string {
-  const d = typeof src === "string" ? new Date(src) : src;
-  if (Number.isNaN(d.getTime())) return "—"; // polar-empty timing → Invalid Date
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
 
 function countdown(target: Date, now: Date): string {
   if (Number.isNaN(target.getTime())) return "—";
@@ -42,10 +39,12 @@ const heroStyle = {
 export function ToolsPrayerCard() {
   const [ready, setReady] = useState(false);
   const [timings, setTimings] = useState<PrayerTimings | null>(null);
+  const [coords, setCoords] = useState<Coordinates | null>(null);
   const [now, setNow] = useState(() => new Date());
 
   useEffect(() => {
     setReady(true);
+    void webPrayerSettingsStore.read().then(({ coords: c }) => setCoords(c));
     void webPrayerTimingsProvider.getTodaysTimings().then((t) => {
       if (t) setTimings(t);
     });
@@ -127,7 +126,7 @@ export function ToolsPrayerCard() {
               {PRAYER_LABELS[next.name]}
             </span>
             <span style={{ fontSize: 20, fontWeight: 700, color: N.fg, fontFamily: N.ui }}>
-              {fmtTime(next.at)}
+              {fmtPrayerTime(next.at, coords)}
             </span>
           </div>
           <div style={{ fontSize: 13.5, color: N.muted, fontFamily: N.ui, marginBottom: 16 }}>
@@ -173,7 +172,7 @@ export function ToolsPrayerCard() {
                       fontVariantNumeric: "tabular-nums",
                     }}
                   >
-                    {fmtTime(timings[p])}
+                    {fmtPrayerTime(timings[p], coords)}
                   </div>
                 </div>
               );

--- a/apps/web/src/components/ZakatCalculator.test.tsx
+++ b/apps/web/src/components/ZakatCalculator.test.tsx
@@ -15,4 +15,28 @@ describe("ZakatCalculator", () => {
     // Total assets and Net zakatable both read $10,000.00 (no liabilities).
     expect(screen.getAllByText("$10,000.00").length).toBeGreaterThan(0);
   });
+
+  it("keeps the gold/silver prices and niṣāb basis when Reset amounts is clicked", async () => {
+    render(<ZakatCalculator />);
+
+    await userEvent.type(screen.getByPlaceholderText("e.g. 75"), "75");
+    await userEvent.type(screen.getByPlaceholderText("e.g. 0.85"), "0.85");
+    await userEvent.type(screen.getAllByPlaceholderText("0")[0]!, "10000");
+    await userEvent.click(screen.getByRole("button", { name: "Gold (higher)" }));
+
+    await userEvent.click(screen.getByRole("button", { name: "Reset amounts" }));
+
+    expect(screen.getByPlaceholderText("e.g. 75")).toHaveValue("75");
+    expect(screen.getByPlaceholderText("e.g. 0.85")).toHaveValue("0.85");
+    expect(screen.getByText("Niṣāb (gold)")).toBeInTheDocument(); // basis stayed "gold", not reset to "silver"
+    expect(screen.getAllByPlaceholderText("0")[0]).toHaveValue("");
+  });
+
+  it("blocks a minus sign in an amount field instead of silently ignoring it", async () => {
+    render(<ZakatCalculator />);
+
+    await userEvent.type(screen.getAllByPlaceholderText("0")[0]!, "-500");
+
+    expect(screen.getAllByPlaceholderText("0")[0]).toHaveValue("500");
+  });
 });

--- a/apps/web/src/components/ZakatCalculator.tsx
+++ b/apps/web/src/components/ZakatCalculator.tsx
@@ -39,6 +39,19 @@ function sanitizeCurrency(s: string): string {
   return s.replace(/[0-9]/g, "");
 }
 
+/** Strip anything but digits and a single decimal point from an amount field.
+ *  Wealth/price amounts can't be negative — `sumValues`/the niṣāb math already
+ *  treat a negative entry as if the field were blank, so accepting the "-"
+ *  keystroke just let a mistyped value vanish from the totals with no
+ *  explanation. Blocking it at input time (like the currency field already
+ *  blocks digits) is the same fix in the same spot. */
+function sanitizeAmount(s: string): string {
+  const cleaned = s.replace(/[^0-9.]/g, "");
+  const dot = cleaned.indexOf(".");
+  if (dot === -1) return cleaned;
+  return cleaned.slice(0, dot + 1) + cleaned.slice(dot + 1).replace(/\./g, "");
+}
+
 const sectionLabel = {
   fontSize: 12,
   letterSpacing: 1,
@@ -168,10 +181,13 @@ export function ZakatCalculator() {
   const havePrices = num(state.goldPricePerGram) > 0 && num(state.silverPricePerGram) > 0;
 
   function setAsset(id: string, value: string) {
-    setState((s) => ({ ...s, assets: { ...s.assets, [id]: value } }));
+    setState((s) => ({ ...s, assets: { ...s.assets, [id]: sanitizeAmount(value) } }));
   }
+  // "Reset amounts" clears what it says — the entered wealth figures — and
+  // leaves currency, gold/silver prices, and the niṣāb basis alone; a user
+  // recalculating for a new scenario shouldn't lose prices they looked up.
   function reset() {
-    setState({ ...DEFAULT_STATE, currency: state.currency });
+    setState((s) => ({ ...s, assets: { ...EMPTY_ASSETS }, liabilities: "" }));
   }
 
   return (
@@ -219,13 +235,13 @@ export function ZakatCalculator() {
               label="Gold / gram"
               placeholder="e.g. 75"
               value={state.goldPricePerGram}
-              onChange={(v) => setState((s) => ({ ...s, goldPricePerGram: v }))}
+              onChange={(v) => setState((s) => ({ ...s, goldPricePerGram: sanitizeAmount(v) }))}
             />
             <Field
               label="Silver / gram"
               placeholder="e.g. 0.85"
               value={state.silverPricePerGram}
-              onChange={(v) => setState((s) => ({ ...s, silverPricePerGram: v }))}
+              onChange={(v) => setState((s) => ({ ...s, silverPricePerGram: sanitizeAmount(v) }))}
             />
           </div>
           <div style={{ fontSize: 13.5, color: N.muted, margin: "2px 0 8px", fontFamily: N.ui }}>
@@ -278,7 +294,7 @@ export function ZakatCalculator() {
             hint="Immediate debts & bills due now"
             prefix={state.currency}
             value={state.liabilities}
-            onChange={(v) => setState((s) => ({ ...s, liabilities: v }))}
+            onChange={(v) => setState((s) => ({ ...s, liabilities: sanitizeAmount(v) }))}
           />
         </div>
 

--- a/apps/web/src/lib/fasting-qada.ts
+++ b/apps/web/src/lib/fasting-qada.ts
@@ -5,7 +5,7 @@
  * adapter `webFastingQadaStore`, ADR 0024). A window event lets the tracker page
  * re-render on change — the established pattern from the prayer/qaḍāʾ trackers.
  */
-import { type FastingQadaLog, adjustFastingMadeUp } from "@ummahlibrary/core";
+import type { FastingQadaLog } from "@ummahlibrary/core";
 import { webFastingQadaStore as store } from "./fasting-qada-store";
 
 export const FASTING_QADA_EVENT = "ul.fastingQada";
@@ -22,10 +22,14 @@ export function readFastingQada(): Promise<FastingQadaLog> {
   return store.read();
 }
 
-/** Make up one fast (`+1`) or undo (`-1`), clamped to `[0, owed]`, and persist. */
-export async function adjustFastingMadeUpCount(delta: number, owed: number): Promise<FastingQadaLog> {
-  const next = adjustFastingMadeUp(await store.read(), delta, owed);
-  await store.write(next);
+/**
+ * Persist an already-computed log and notify subscribers. The +/- stepper
+ * computes `next` from its own in-memory state via `adjustFastingMadeUp`
+ * (from `@ummahlibrary/core`) and passes it straight here — reading from the
+ * store fresh on every tap would race when taps land faster than the
+ * read/write round trip resolves, silently dropping updates.
+ */
+export async function writeFastingQada(log: FastingQadaLog): Promise<void> {
+  await store.write(log);
   emit();
-  return next;
 }

--- a/apps/web/src/lib/prayer-time-format.ts
+++ b/apps/web/src/lib/prayer-time-format.ts
@@ -1,0 +1,32 @@
+/**
+ * Formats a computed prayer instant (an absolute UTC `Date`/ISO string) as a
+ * wall-clock time in the timezone of the *coordinates it was computed for* —
+ * not the device's own timezone. `Date#toLocaleTimeString` falls back to
+ * `Intl.DateTimeFormat().resolvedOptions().timeZone` (the device clock) when
+ * no `timeZone` is given, which silently mis-renders every prayer time
+ * whenever the viewing device's timezone doesn't match the saved location
+ * (a traveler who hasn't updated their phone's TZ, a desktop browser, etc).
+ * `tz-lookup` derives the IANA zone for the coordinates offline, so the
+ * result matches local wall-clock time (including DST) for that place.
+ */
+import tzLookup from "tz-lookup";
+import type { Coordinates } from "@ummahlibrary/core";
+
+/** The IANA timezone for a location, or `undefined` if none is known/valid. */
+export function timeZoneFor(coords: Coordinates | null | undefined): string | undefined {
+  if (!coords) return undefined;
+  try {
+    return tzLookup(coords.latitude, coords.longitude);
+  } catch {
+    return undefined; // out-of-range lat/lng — let the caller fall back to device TZ
+  }
+}
+
+/** A prayer instant as `HH:MM`, in the location's timezone when known. */
+export function fmtPrayerTime(src: string | Date, coords: Coordinates | null | undefined): string {
+  const d = typeof src === "string" ? new Date(src) : src;
+  // A polar-invalid timing is "" (→ Invalid Date); show a dash, not "Invalid Date" / a throw.
+  if (Number.isNaN(d.getTime())) return "—";
+  const timeZone = timeZoneFor(coords);
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", ...(timeZone && { timeZone }) });
+}

--- a/apps/web/src/lib/qada.test.ts
+++ b/apps/web/src/lib/qada.test.ts
@@ -1,5 +1,6 @@
+import { adjustQada, setQada } from "@ummahlibrary/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { QADA_EVENT, adjustQadaCount, readQada, setQadaCount } from "./qada";
+import { QADA_EVENT, readQada, writeQada } from "./qada";
 
 afterEach(() => {
   localStorage.clear();
@@ -12,24 +13,27 @@ describe("qada store (web)", () => {
   });
 
   it("adjusts a backlog up and down, clamped at zero, and persists", async () => {
-    expect((await adjustQadaCount("fajr", 1)).fajr).toBe(1);
-    expect((await adjustQadaCount("fajr", 1)).fajr).toBe(2);
+    await writeQada(adjustQada(await readQada(), "fajr", 1));
+    expect((await readQada()).fajr).toBe(1);
+    await writeQada(adjustQada(await readQada(), "fajr", 1));
+    expect((await readQada()).fajr).toBe(2);
     // Cannot go negative — the entry drops at zero.
-    expect((await adjustQadaCount("fajr", -5)).fajr).toBeUndefined();
+    await writeQada(adjustQada(await readQada(), "fajr", -5));
+    expect((await readQada()).fajr).toBeUndefined();
     expect(await readQada()).toEqual({});
   });
 
   it("sets an explicit count and survives a fresh read", async () => {
-    await setQadaCount("isha", 4);
+    await writeQada(setQada(await readQada(), "isha", 4));
     expect((await readQada()).isha).toBe(4);
-    await setQadaCount("isha", 0);
+    await writeQada(setQada(await readQada(), "isha", 0));
     expect(await readQada()).toEqual({});
   });
 
   it("emits a change event so subscribers can re-render", async () => {
     const handler = vi.fn();
     window.addEventListener(QADA_EVENT, handler);
-    await adjustQadaCount("asr", 1);
+    await writeQada(adjustQada(await readQada(), "asr", 1));
     window.removeEventListener(QADA_EVENT, handler);
     expect(handler).toHaveBeenCalledOnce();
   });

--- a/apps/web/src/lib/qada.ts
+++ b/apps/web/src/lib/qada.ts
@@ -5,7 +5,7 @@
  * `@ummahlibrary/core`. A window event lets the tracker page re-render on change
  * — the established pattern from the prayer tracker.
  */
-import { type PrayerName, type QadaLog, adjustQada, setQada } from "@ummahlibrary/core";
+import type { QadaLog } from "@ummahlibrary/core";
 import { webQadaStore as store } from "./qada-store";
 
 export const QADA_EVENT = "ul.qada";
@@ -22,18 +22,15 @@ export function readQada(): Promise<QadaLog> {
   return store.read();
 }
 
-/** Adjust a prayer's backlog by `delta` (clamped at zero) and persist. */
-export async function adjustQadaCount(prayer: PrayerName, delta: number): Promise<QadaLog> {
-  const next = adjustQada(await store.read(), prayer, delta);
-  await store.write(next);
+/**
+ * Persist an already-computed backlog and notify subscribers. Callers that
+ * mutate on every tap (the +/- steppers) compute `next` from their own
+ * in-memory state via `adjustQada`/`setQada` (from `@ummahlibrary/core`) and
+ * pass it straight here — routing every tap through a fresh `store.read()`
+ * first would race when taps land faster than the read/write round trip
+ * resolves, silently dropping updates.
+ */
+export async function writeQada(log: QadaLog): Promise<void> {
+  await store.write(log);
   emit();
-  return next;
-}
-
-/** Set a prayer's backlog to an explicit count and persist. */
-export async function setQadaCount(prayer: PrayerName, count: number): Promise<QadaLog> {
-  const next = setQada(await store.read(), prayer, count);
-  await store.write(next);
-  emit();
-  return next;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,7 +248,7 @@ importers:
         version: 11.16.0
       next:
         specifier: ^15.1.3
-        version: 15.5.19(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -264,6 +264,9 @@ importers:
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
+      tz-lookup:
+        specifier: ^6.1.25
+        version: 6.1.25
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -289,6 +292,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.3)
+      '@types/tz-lookup':
+        specifier: ^6.1.2
+        version: 6.1.2
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@5.4.21(@types/node@22.19.19)(lightningcss@1.32.0)(terser@5.48.0))
@@ -2522,6 +2528,9 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/tz-lookup@6.1.2':
+    resolution: {integrity: sha512-9y31Xf/8FHXrCHjvVjGZLcsayAa6ABNc8bZlk6MPOQLLlr41tICSqW3TRPRIx2nodbzdKs5N7ipHWBrUsWUiAA==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2764,10 +2773,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -6037,6 +6048,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  tz-lookup@6.1.25:
+    resolution: {integrity: sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==}
+
   ua-parser-js@1.0.41:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
@@ -8719,6 +8733,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/tz-lookup@6.1.2': {}
 
   '@types/unist@2.0.11': {}
 
@@ -11811,7 +11827,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@15.5.19(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@15.5.19(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
@@ -11819,7 +11835,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.19
       '@next/swc-darwin-x64': 15.5.19
@@ -12734,10 +12750,12 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  styled-jsx@5.1.6(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   styleq@0.1.3: {}
 
@@ -12920,6 +12938,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  tz-lookup@6.1.25: {}
 
   ua-parser-js@1.0.41: {}
 


### PR DESCRIPTION
Fixes 6 bugs found in a live, hands-on browser QA pass across the whole web app (clicking, typing, mocking real GPS coordinates, tapping counters rapidly — not just a code read-through). Full writeup was delivered separately as `WEB_QA_LIVE_BROWSER_REPORT.md` and isn't part of this diff.

## Bugs fixed

### 1. Prayer times rendered in the device's timezone, not the location's (High)
`toLocaleTimeString()` with no explicit `timeZone` falls back to the browser's own clock timezone. `AdhanPrayerTimes` already computes correct absolute UTC instants for the given coordinates, but every display site silently re-rendered them in the *viewer's device* timezone instead of the *location's* — found by mocking geolocation to London on a machine set to `Asia/Dubai`, where Dhuhr showed **04:04 PM** instead of the correct **~01:04 PM**.

Adds a shared `fmtPrayerTime()` helper (`apps/web/src/lib/prayer-time-format.ts`) that derives the location's IANA timezone offline via `tz-lookup` and passes it explicitly, replacing 4 duplicated device-timezone-based formatters (`PrayerTimesView`, home "Next prayer" card, `RamadanView`'s suhūr/ifṭār times, Tools prayer card).

### 2. Qaḍāʾ +/- steppers lost taps on rapid clicks (Medium)
`adjustQadaCount`/`adjustFastingMadeUpCount` read the store fresh before every tap. Taps landing faster than that read/write round trip resolves all read the same pre-write value and the last write wins — 3 rapid taps only ever applied +1. `QadaTracker`/`FastingQadaTracker` now hold the log in React state and update via the functional `setState` form (mirroring the pattern mobile's `PrayerTrackerScreen` already uses), persisting as a side effect.

### 3 & 4. Zakat calculator: Reset wiped prices; negative amounts silently ignored (Low)
`reset()` cleared the whole state (minus currency) including researched gold/silver prices and the niṣāb basis — now it only clears the asset/liability figures the button name promises. Separately, amount fields accepted a `-` keystroke that `sumValues()` then silently excluded from every total with zero feedback; fields now strip anything but digits/decimal at input time, same as the currency field already does for stray digits.

### 5. Hifz review completion message: "āyahāt" → "āyāt" (Low, copy)
String concatenation (`"āyah" + "āt"`) produced a malformed plural inconsistent with the rest of the app's Arabic terminology.

### 6. Finishing a khatm showed no completion state (Low, UX)
A khatm at `currentPage === totalPages` kept rendering "30d left · 0/day" and a "Resume" link back to the page just finished, with zero acknowledgment. Now shows the same "Alhamdulillah — you finished" pattern Reading Plans already uses elsewhere.

## Verification

- `pnpm lint && pnpm typecheck && pnpm test && pnpm build` all pass across all 8 packages.
- Every fix re-verified live against a running dev server with the exact repro from the QA report (mocked London GPS + `Asia/Dubai` device clock for #1; synchronous rapid clicks for #2; live input for #3/#4; a seeded due-review queue for #5; a seeded 604/604 khatm for #6) — all now produce the correct output.
- Added/updated tests: `qada.test.ts` (rewritten around the new `writeQada` primitive), `ZakatCalculator.test.tsx` (reset-preserves-prices, negative-input-blocked), `ReadingGoalsView.test.tsx` (completion state).

## Commits

1. `fix(web): render prayer times in the location's timezone, not the device's`
2. `fix(qada): stop the +/- steppers from losing taps on rapid clicks`
3. `fix(zakat): keep gold/silver prices on reset, and block negative amounts`
4. `fix(hifz): correct "āyahāt" to "āyāt" in the review completion message`
5. `fix(web): show a completion state when a khatm reaches its last page`
