### PR TITLE
feat(i18n): localize the Settings page (theme, backup, sync)

### DIFF
--- a/apps/web/src/components/DataBackup.test.tsx
+++ b/apps/web/src/components/DataBackup.test.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { I18nProvider } from "../i18n/I18nProvider";
 import userEvent from "@testing-library/user-event";
 import { DataBackup } from "./DataBackup";
 
 describe("DataBackup", () => {
   it("explains the merge strategy and switches copy when toggled", async () => {
-    render(<DataBackup />);
+    render(<DataBackup />, { wrapper: I18nProvider });
 
     // Defaults to "replace".
     expect(screen.getByText(/fully restores your data/)).toBeInTheDocument();
@@ -21,7 +22,7 @@ describe("DataBackup", () => {
     localStorage.setItem("ul.beta", "2");
     localStorage.setItem("other.key", "ignored"); // not ul.* — excluded from the count
 
-    render(<DataBackup />);
+    render(<DataBackup />, { wrapper: I18nProvider });
 
     // The count is read after mount to avoid a hydration mismatch.
     expect(await screen.findByText(/2 items stored on this device/)).toBeInTheDocument();

--- a/apps/web/src/components/DataBackup.tsx
+++ b/apps/web/src/components/DataBackup.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import type { MergeStrategy } from "@ummahlibrary/core";
 import { clearAllData, collectLocalData, exportBackup, importBackup } from "../lib/backup";
 import { N } from "@ummahlibrary/ui";
+import { useT } from "../i18n/I18nProvider";
 
 const lcard = { background: N.card, border: `1px solid ${N.border}`, borderRadius: 16 } as const;
 
@@ -26,6 +27,7 @@ function GroupLabel({ children }: { children: React.ReactNode }) {
 }
 
 export function DataBackup() {
+  const t = useT();
   const [strategy, setStrategy] = useState<MergeStrategy>("replace");
   const [status, setStatus] = useState<{ ok: boolean; message: string } | null>(null);
   const [itemCount, setItemCount] = useState<number | null>(null);
@@ -47,7 +49,7 @@ export function DataBackup() {
   }
 
   function onClear() {
-    if (!confirm("Erase all Ummah Library data on this device? This can’t be undone.")) return;
+    if (!confirm(t("backup.eraseConfirm"))) return;
     const n = clearAllData();
     setStatus({ ok: true, message: `Cleared ${n} items. Reload to start fresh.` });
   }
@@ -67,12 +69,19 @@ export function DataBackup() {
 
   return (
     <div>
-      <p style={{ fontSize: 14.5, color: N.muted, lineHeight: 1.65, margin: "0 0 20px", fontFamily: N.ui }}>
-        Everything you do here stays on this device — no account, no server. Export a backup file to
-        move your data to another device or keep it safe; import it to restore.
+      <p
+        style={{
+          fontSize: 14.5,
+          color: N.muted,
+          lineHeight: 1.65,
+          margin: "0 0 20px",
+          fontFamily: N.ui,
+        }}
+      >
+        {t("backup.intro")}
       </p>
 
-      <GroupLabel>Your data</GroupLabel>
+      <GroupLabel>{t("backup.yourData")}</GroupLabel>
       <div style={{ ...lcard, padding: 20, marginBottom: 22 }}>
         <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
           <button
@@ -93,7 +102,7 @@ export function DataBackup() {
               fontFamily: N.ui,
             }}
           >
-            ⬇ Export my data
+            {t("backup.export")}
           </button>
           <button
             type="button"
@@ -113,23 +122,45 @@ export function DataBackup() {
               fontFamily: N.ui,
             }}
           >
-            ⬆ Import a backup
+            {t("backup.import")}
           </button>
-          <input ref={fileInput} type="file" accept="application/json,.json" onChange={onFile} hidden />
+          <input
+            ref={fileInput}
+            type="file"
+            accept="application/json,.json"
+            onChange={onFile}
+            hidden
+          />
         </div>
       </div>
 
-      <GroupLabel>On import</GroupLabel>
+      <GroupLabel>{t("backup.onImport")}</GroupLabel>
       <div style={{ ...lcard, padding: 20, marginBottom: 22 }}>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-          <button type="button" style={pill(strategy === "replace")} onClick={() => setStrategy("replace")}>
-            Replace my data
+          <button
+            type="button"
+            style={pill(strategy === "replace")}
+            onClick={() => setStrategy("replace")}
+          >
+            {t("backup.replace")}
           </button>
-          <button type="button" style={pill(strategy === "keep-mine")} onClick={() => setStrategy("keep-mine")}>
-            Keep mine on conflict
+          <button
+            type="button"
+            style={pill(strategy === "keep-mine")}
+            onClick={() => setStrategy("keep-mine")}
+          >
+            {t("backup.keepMine")}
           </button>
         </div>
-        <p style={{ fontSize: 13, color: N.faint, lineHeight: 1.6, margin: "14px 0 0", fontFamily: N.ui }}>
+        <p
+          style={{
+            fontSize: 13,
+            color: N.faint,
+            lineHeight: 1.6,
+            margin: "14px 0 0",
+            fontFamily: N.ui,
+          }}
+        >
           {strategy === "replace"
             ? "The backup fully restores your data, overwriting what’s here."
             : "The backup only fills in things you don’t already have."}
@@ -149,9 +180,19 @@ export function DataBackup() {
         </p>
       )}
 
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
         <span style={{ fontSize: 13, color: N.faint, fontFamily: N.ui }}>
-          {itemCount ?? "—"} item{itemCount === 1 ? "" : "s"} stored on this device.
+          {t(itemCount === 1 ? "backup.itemsStored.one" : "backup.itemsStored.other", {
+            count: itemCount ?? "—",
+          })}
         </span>
         <button
           type="button"
@@ -168,12 +209,20 @@ export function DataBackup() {
             fontFamily: N.ui,
           }}
         >
-          Erase all data
+          {t("backup.erase")}
         </button>
       </div>
 
-      <div style={{ textAlign: "center", fontSize: 12.5, color: N.faint, marginTop: 28, fontFamily: N.ui }}>
-        Ummah Library · local-first · Free &amp; open source
+      <div
+        style={{
+          textAlign: "center",
+          fontSize: 12.5,
+          color: N.faint,
+          marginTop: 28,
+          fontFamily: N.ui,
+        }}
+      >
+        {t("backup.footer")}
       </div>
     </div>
   );

--- a/apps/web/src/components/SyncSettings.test.tsx
+++ b/apps/web/src/components/SyncSettings.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { I18nProvider } from "../i18n/I18nProvider";
 import { SyncSettings } from "./SyncSettings";
 
 const syncIfEnabled = vi.fn(async () => ({ pushed: 5, pulled: 5, applied: 2 }));
@@ -32,19 +33,19 @@ async function enableViaUI(): Promise<string> {
 
 describe("SyncSettings", () => {
   it("shows the setup state by default", () => {
-    render(<SyncSettings />);
+    render(<SyncSettings />, { wrapper: I18nProvider });
     expect(screen.getByText("Set up sync")).toBeInTheDocument();
     expect(screen.getByText("Turn on sync")).toBeInTheDocument();
   });
 
   it("generate fills a recovery phrase", () => {
-    render(<SyncSettings />);
+    render(<SyncSettings />, { wrapper: I18nProvider });
     expect((screen.getByLabelText("Recovery phrase") as HTMLInputElement).value).toBe("");
     expect(generate().length).toBeGreaterThan(10);
   });
 
   it("turning on syncs, stores the secret, and shows the active state", async () => {
-    render(<SyncSettings />);
+    render(<SyncSettings />, { wrapper: I18nProvider });
     await enableViaUI();
     expect(syncIfEnabled).toHaveBeenCalled();
     expect(localStorage.getItem("ul.sync.enabled")).toBe("1");
@@ -54,14 +55,14 @@ describe("SyncSettings", () => {
   });
 
   it("reveals the stored phrase on demand", async () => {
-    render(<SyncSettings />);
+    render(<SyncSettings />, { wrapper: I18nProvider });
     const phrase = await enableViaUI();
     fireEvent.click(screen.getByText("Show phrase"));
     expect(screen.getByText(phrase)).toBeInTheDocument();
   });
 
   it("'Sync now' reports an up-to-date result", async () => {
-    render(<SyncSettings />);
+    render(<SyncSettings />, { wrapper: I18nProvider });
     await enableViaUI();
     syncIfEnabled.mockResolvedValueOnce({ pushed: 5, pulled: 5, applied: 0 });
     fireEvent.click(screen.getByText("Sync now"));
@@ -69,7 +70,7 @@ describe("SyncSettings", () => {
   });
 
   it("surfaces a server error without losing local data", async () => {
-    render(<SyncSettings />);
+    render(<SyncSettings />, { wrapper: I18nProvider });
     syncIfEnabled.mockRejectedValueOnce(new Error("boom"));
     await enableViaUI();
     expect(screen.getByText(/safe on this device/)).toBeInTheDocument();
@@ -79,7 +80,7 @@ describe("SyncSettings", () => {
   it("copies the revealed phrase to the clipboard", async () => {
     const writeText = vi.fn(() => Promise.resolve());
     Object.assign(navigator, { clipboard: { writeText } });
-    render(<SyncSettings />);
+    render(<SyncSettings />, { wrapper: I18nProvider });
     await enableViaUI();
     fireEvent.click(screen.getByText("Show phrase"));
     fireEvent.click(screen.getByText("Copy"));
@@ -88,7 +89,7 @@ describe("SyncSettings", () => {
 
   it("turning off forgets the secret and returns to setup", async () => {
     vi.spyOn(window, "confirm").mockReturnValue(true);
-    render(<SyncSettings />);
+    render(<SyncSettings />, { wrapper: I18nProvider });
     await enableViaUI();
     fireEvent.click(screen.getByText("Turn off sync"));
     await waitFor(() => expect(screen.getByText("Set up sync")).toBeInTheDocument());

--- a/apps/web/src/components/SyncSettings.tsx
+++ b/apps/web/src/components/SyncSettings.tsx
@@ -6,6 +6,7 @@ import { N } from "@ummahlibrary/ui";
 import { generateRecoveryPhrase } from "../lib/sync/web-crypto-cipher";
 import { disableSync, enableSync, isSyncEnabled, readSyncSecret } from "../lib/sync/sync-settings";
 import { resetSyncRuntime, syncIfEnabled } from "../lib/sync/sync-runtime";
+import { useT } from "../i18n/I18nProvider";
 
 const lcard = {
   background: N.card,
@@ -91,6 +92,7 @@ const SERVER_DOWN = "Couldn’t reach the sync server — your data is safe on t
  * recovered. Replaces the `/sync-dev` developer surface.
  */
 export function SyncSettings() {
+  const t = useT();
   const [enabled, setEnabled] = useState(false);
   const [secret, setSecret] = useState<string | null>(null);
   const [phrase, setPhrase] = useState("");
@@ -136,7 +138,7 @@ export function SyncSettings() {
   }
 
   function turnOff() {
-    if (!confirm("Turn off sync and remove the recovery phrase from this device?")) return;
+    if (!confirm(t("sync.turnOffConfirm"))) return;
     disableSync();
     resetSyncRuntime();
     setEnabled(false);
@@ -160,14 +162,12 @@ export function SyncSettings() {
           fontFamily: N.ui,
         }}
       >
-        Keep your bookmarks, reading position and preferences in step across your devices —
-        end-to-end encrypted, with no account. Off by default; the app works fully offline without
-        it.
+        {t("sync.intro")}
       </p>
 
       {enabled ? (
         <>
-          <GroupLabel>Sync is on</GroupLabel>
+          <GroupLabel>{t("sync.on")}</GroupLabel>
           <div style={{ ...lcard, marginBottom: 18 }}>
             <p
               style={{
@@ -178,7 +178,7 @@ export function SyncSettings() {
                 fontFamily: N.ui,
               }}
             >
-              Your data syncs across every device that uses your recovery phrase.
+              {t("sync.onHint")}
             </p>
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
               <button
@@ -193,7 +193,7 @@ export function SyncSettings() {
                 {reveal ? "Hide phrase" : "Show phrase"}
               </button>
               <button type="button" style={dangerBtn} onClick={turnOff}>
-                Turn off sync
+                {t("sync.turnOff")}
               </button>
             </div>
             {reveal && secret && (
@@ -221,7 +221,7 @@ export function SyncSettings() {
                   {secret}
                 </code>
                 <button type="button" style={secondaryBtn} onClick={copyPhrase}>
-                  Copy
+                  {t("sync.copy")}
                 </button>
               </div>
             )}
@@ -229,7 +229,7 @@ export function SyncSettings() {
         </>
       ) : (
         <>
-          <GroupLabel>Set up sync</GroupLabel>
+          <GroupLabel>{t("sync.setUp")}</GroupLabel>
           <div style={{ ...lcard, marginBottom: 18 }}>
             <p
               style={{
@@ -240,16 +240,15 @@ export function SyncSettings() {
                 fontFamily: N.ui,
               }}
             >
-              Generate a <b>recovery phrase</b> on your first device, then enter the same phrase on
-              each other device to link them. It’s the only key — pick it once and keep it.
+              {t("sync.setUpHint")}
             </p>
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap", marginBottom: 12 }}>
               <input
                 value={phrase}
                 onChange={(e) => setPhrase(e.target.value)}
-                placeholder="Enter or generate a phrase"
+                placeholder={t("sync.phrasePlaceholder")}
                 spellCheck={false}
-                aria-label="Recovery phrase"
+                aria-label={t("sync.phraseLabel")}
                 style={inputStyle}
               />
               <button
@@ -257,7 +256,7 @@ export function SyncSettings() {
                 style={secondaryBtn}
                 onClick={() => setPhrase(generateRecoveryPhrase())}
               >
-                Generate
+                {t("sync.generate")}
               </button>
             </div>
             <button
@@ -287,9 +286,7 @@ export function SyncSettings() {
 
       <div style={{ ...lcard, padding: 16, background: "transparent" }}>
         <p style={{ fontSize: 13, color: N.faint, lineHeight: 1.6, margin: 0, fontFamily: N.ui }}>
-          ⚠ Your recovery phrase is the only key to your synced data. We can’t see it or recover it
-          — if you lose it, the data can’t be decrypted. Keep a copy somewhere safe (your exported
-          backup file is a good place).
+          {t("sync.warning")}
         </p>
       </div>
     </div>

--- a/apps/web/src/components/ThemePicker.test.tsx
+++ b/apps/web/src/components/ThemePicker.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { I18nProvider } from "../i18n/I18nProvider";
 import userEvent from "@testing-library/user-event";
 import { ThemePicker } from "./ThemePicker";
 
@@ -10,7 +11,7 @@ describe("ThemePicker", () => {
   });
 
   it("lists all eight themes and marks the active one", () => {
-    render(<ThemePicker />);
+    render(<ThemePicker />, { wrapper: I18nProvider });
     for (const name of [
       "Obsidian",
       "Midnight",
@@ -30,7 +31,7 @@ describe("ThemePicker", () => {
   });
 
   it("applies and persists a chosen theme", async () => {
-    render(<ThemePicker />);
+    render(<ThemePicker />, { wrapper: I18nProvider });
     await userEvent.click(screen.getByRole("button", { name: /Ocean/ }));
 
     expect(document.documentElement.dataset.theme).toBe("ocean");

--- a/apps/web/src/components/ThemePicker.tsx
+++ b/apps/web/src/components/ThemePicker.tsx
@@ -11,10 +11,13 @@ import {
   type ThemeMeta,
   type ThemeMode,
 } from "../lib/themes";
+import { useT } from "../i18n/I18nProvider";
+import type { MessageKey } from "../i18n/messages";
 
-const GROUPS: { mode: ThemeMode; label: string; icon: "moon" | "sun" }[] = [
-  { mode: "dark", label: "Dark", icon: "moon" },
-  { mode: "light", label: "Light", icon: "sun" },
+// Labels resolve through i18n (#208); mode and icon are structure, not copy.
+const GROUPS: { mode: ThemeMode; labelKey: MessageKey; icon: "moon" | "sun" }[] = [
+  { mode: "dark", labelKey: "theme.dark", icon: "moon" },
+  { mode: "light", labelKey: "theme.light", icon: "sun" },
 ];
 
 /**
@@ -32,6 +35,7 @@ function ThemeSwatch({
   active: boolean;
   onClick: () => void;
 }) {
+  const t = useT();
   return (
     <button
       type="button"
@@ -128,7 +132,7 @@ function ThemeSwatch({
               textOverflow: "ellipsis",
             }}
           >
-            {theme.desc}
+            {t(`theme.desc.${theme.key}` as MessageKey)}
           </div>
         </div>
         {active && (
@@ -152,6 +156,7 @@ function ThemeSwatch({
 }
 
 export function ThemePicker() {
+  const t = useT();
   const [active, setActive] = useState<ThemeKey>("obsidian");
 
   useEffect(() => {
@@ -173,7 +178,7 @@ export function ThemePicker() {
   };
 
   return (
-    <section aria-label="Theme" style={{ marginBottom: 22 }}>
+    <section aria-label={t("theme.title")} style={{ marginBottom: 22 }}>
       <div
         style={{
           display: "flex",
@@ -182,8 +187,8 @@ export function ThemePicker() {
           marginBottom: 10,
         }}
       >
-        <h2 style={sectionLabel}>Theme</h2>
-        <span style={{ fontSize: 12, color: N.faint }}>Applies across the whole app</span>
+        <h2 style={sectionLabel}>{t("theme.title")}</h2>
+        <span style={{ fontSize: 12, color: N.faint }}>{t("theme.hint")}</span>
       </div>
       {GROUPS.map((group) => (
         <div key={group.mode} style={{ marginBottom: 16 }}>
@@ -200,7 +205,7 @@ export function ThemePicker() {
               marginBottom: 10,
             }}
           >
-            <Icon name={group.icon} size={14} /> {group.label}
+            <Icon name={group.icon} size={14} /> {t(group.labelKey)}
           </div>
           <div
             style={{

--- a/apps/web/src/i18n/localized-files.test.ts
+++ b/apps/web/src/i18n/localized-files.test.ts
@@ -18,6 +18,16 @@ import ts from "typescript";
  *
  * Scope: it checks the files claimed to be done, not the ones that aren't. It is
  * a ratchet, not a coverage metric.
+ *
+ * Known blind spot: it sees JSX text and user-facing JSX attributes, so a string
+ * living in a **data array** — `const GROUPS = [{ label: "Dark" }]`, a theme
+ * description, an options list — passes even though a reader still sees English.
+ * That is not hypothetical: the theme picker's group labels and palette
+ * descriptions were missed exactly this way and had to be caught by eye. Widening
+ * the check to every string literal would flag ids, CSS values and test data, so
+ * the honest position is that this catches the common case and a human still
+ * reads the screen once. Anything found by eye should be added to a file's
+ * coverage here so it cannot regress.
  */
 
 /** Files whose user-visible strings have been extracted into `messages.ts`. */
@@ -28,6 +38,10 @@ const LOCALIZED = [
   "app/tools/page.tsx",
   "components/ToolsPrayerCard.tsx",
   "components/ToolsQiblaCard.tsx",
+  "components/ThemePicker.tsx",
+  "components/DataBackup.tsx",
+  "components/SyncSettings.tsx",
+  "components/LanguagePicker.tsx",
 ];
 
 /** Attributes that reach the user as prose and must therefore be translated. */

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -79,6 +79,59 @@ export const en = {
   "tools.qiblaBearing": "Qibla · {degrees}° {point}",
   "tools.qiblaSub": "Direction to the Kaʿbah",
   "tools.qiblaNoLocation": "Set your location to see the direction",
+  // Settings — theme
+  "theme.dark": "Dark",
+  "theme.light": "Light",
+  // Theme *names* (Obsidian, Ivory, …) are the Noor design system's proper
+  // names (ADR 0023) and stay untranslated, like a brand. Their descriptions
+  // are prose, so they don't.
+  "theme.desc.obsidian": "Charcoal & gold",
+  "theme.desc.midnight": "True-black, high contrast",
+  "theme.desc.emerald": "Deep green & gold",
+  "theme.desc.ocean": "Slate & teal",
+  "theme.desc.ivory": "Warm paper & gold",
+  "theme.desc.sepia": "Parchment & amber",
+  "theme.desc.mint": "Cool light & teal",
+  "theme.desc.rose": "Soft light & rose",
+  "theme.title": "Theme",
+  "theme.hint": "Applies across the whole app",
+  // Settings — local data & backup
+  "backup.intro":
+    "Everything you do here stays on this device — no account, no server. Export a backup file to move your data to another device or keep it safe; import it to restore.",
+  "backup.yourData": "Your data",
+  "backup.export": "⬇ Export my data",
+  "backup.import": "⬆ Import a backup",
+  "backup.onImport": "On import",
+  "backup.replace": "Replace my data",
+  "backup.keepMine": "Keep mine on conflict",
+  // Two keys rather than one interpolated string: plural *rules* differ by
+  // language, and picking the form in the component keeps that decision in the
+  // catalogue. Languages with more than two plural categories (Arabic has six)
+  // would need a real plural-rule layer — noted in ADR 0040, not faked here.
+  "backup.itemsStored.one": "{count} item stored on this device.",
+  "backup.itemsStored.other": "{count} items stored on this device.",
+  "backup.erase": "Erase all data",
+  "backup.eraseConfirm": "Erase all Ummah Library data on this device? This can’t be undone.",
+  "backup.footer": "Ummah Library · local-first · Free & open source",
+  // Settings — cross-device sync
+  "sync.intro":
+    "Keep your bookmarks, reading position and preferences in step across your devices — end-to-end encrypted, with no account. Off by default; the app works fully offline without it.",
+  "sync.on": "Sync is on",
+  "sync.onHint": "Your data syncs across every device that uses your recovery phrase.",
+  "sync.turnOff": "Turn off sync",
+  "sync.turnOffConfirm": "Turn off sync and remove the recovery phrase from this device?",
+  "sync.copy": "Copy",
+  "sync.setUp": "Set up sync",
+  // One sentence, not three fragments around a <b>. Splitting it would fix
+  // English word order into every translation; the emphasis is worth less than
+  // a translator being able to move the clause.
+  "sync.setUpHint":
+    "Generate a recovery phrase on your first device, then enter the same phrase on each other device to link them. It’s the only key — pick it once and keep it.",
+  "sync.phrasePlaceholder": "Enter or generate a phrase",
+  "sync.phraseLabel": "Recovery phrase",
+  "sync.generate": "Generate",
+  "sync.warning":
+    "⚠ Your recovery phrase is the only key to your synced data. We can’t see it or recover it — if you lose it, the data can’t be decrypted. Keep a copy somewhere safe (your exported backup file is a good place).",
   // Common chrome
   "common.settings": "Settings",
   "common.language": "Language",
@@ -151,6 +204,47 @@ const ur: Record<MessageKey, string> = {
   "tools.qiblaBearing": "قبلہ · {degrees}° {point}",
   "tools.qiblaSub": "کعبہ کی سمت",
   "tools.qiblaNoLocation": "سمت دیکھنے کے لیے اپنا مقام مقرر کریں",
+  "theme.dark": "گہرا",
+  "theme.light": "روشن",
+  "theme.desc.obsidian": "کوئلہ اور سنہرا",
+  "theme.desc.midnight": "خالص سیاہ، نمایاں تضاد",
+  "theme.desc.emerald": "گہرا سبز اور سنہرا",
+  "theme.desc.ocean": "سلیٹی اور فیروزی",
+  "theme.desc.ivory": "گرم کاغذ اور سنہرا",
+  "theme.desc.sepia": "پارچمنٹ اور عنبری",
+  "theme.desc.mint": "ٹھنڈی روشنی اور فیروزی",
+  "theme.desc.rose": "نرم روشنی اور گلابی",
+  "theme.title": "تھیم",
+  "theme.hint": "پوری ایپ پر لاگو ہوتا ہے",
+  "backup.intro":
+    "آپ یہاں جو کچھ کرتے ہیں وہ اسی ڈیوائس پر رہتا ہے — نہ کوئی اکاؤنٹ، نہ سرور۔ اپنا ڈیٹا دوسری ڈیوائس پر لے جانے یا محفوظ رکھنے کے لیے بیک اپ فائل برآمد کریں؛ بحال کرنے کے لیے اسے درآمد کریں۔",
+  "backup.yourData": "آپ کا ڈیٹا",
+  "backup.export": "⬇ میرا ڈیٹا برآمد کریں",
+  "backup.import": "⬆ بیک اپ درآمد کریں",
+  "backup.onImport": "درآمد کرتے وقت",
+  "backup.replace": "میرا ڈیٹا تبدیل کریں",
+  "backup.keepMine": "تضاد کی صورت میں میرا رکھیں",
+  "backup.itemsStored.one": "اس ڈیوائس پر {count} آئٹم محفوظ ہے۔",
+  "backup.itemsStored.other": "اس ڈیوائس پر {count} آئٹمز محفوظ ہیں۔",
+  "backup.erase": "تمام ڈیٹا مٹا دیں",
+  "backup.eraseConfirm": "اس ڈیوائس پر امہ لائبریری کا تمام ڈیٹا مٹا دیں؟ یہ واپس نہیں ہو سکتا۔",
+  "backup.footer": "امہ لائبریری · لوکل فرسٹ · مفت اور اوپن سورس",
+  "sync.intro":
+    "اپنی محفوظات، مقامِ مطالعہ اور ترجیحات کو تمام ڈیوائسز پر ہم آہنگ رکھیں — سرے تا سرے مخفی، بغیر کسی اکاؤنٹ کے۔ بطورِ طے شدہ بند؛ ایپ اس کے بغیر مکمل طور پر آف لائن کام کرتی ہے۔",
+  "sync.on": "سنک آن ہے",
+  "sync.onHint":
+    "آپ کا ڈیٹا ہر اُس ڈیوائس پر ہم آہنگ ہوتا ہے جو آپ کا ریکوری فقرہ استعمال کرتی ہے۔",
+  "sync.turnOff": "سنک بند کریں",
+  "sync.turnOffConfirm": "سنک بند کر کے اس ڈیوائس سے ریکوری فقرہ ہٹا دیں؟",
+  "sync.copy": "کاپی کریں",
+  "sync.setUp": "سنک ترتیب دیں",
+  "sync.setUpHint":
+    "اپنی پہلی ڈیوائس پر ریکوری فقرہ بنائیں، پھر ہر دوسری ڈیوائس پر وہی فقرہ درج کریں تاکہ وہ منسلک ہو جائیں۔ یہی واحد کلید ہے — ایک بار منتخب کریں اور محفوظ رکھیں۔",
+  "sync.phrasePlaceholder": "فقرہ درج کریں یا بنائیں",
+  "sync.phraseLabel": "ریکوری فقرہ",
+  "sync.generate": "بنائیں",
+  "sync.warning":
+    "⚠ آپ کا ریکوری فقرہ آپ کے ہم آہنگ ڈیٹا کی واحد کلید ہے۔ ہم اسے نہ دیکھ سکتے ہیں نہ بحال کر سکتے ہیں — اگر یہ کھو گیا تو ڈیٹا کو کھولا نہیں جا سکے گا۔ اس کی نقل کسی محفوظ جگہ رکھیں (آپ کی برآمد کردہ بیک اپ فائل اچھی جگہ ہے)۔",
   "common.settings": "ترتیبات",
   "common.language": "زبان",
   "settings.languageHint":

--- a/docs/adr/0040-ui-localization.md
+++ b/docs/adr/0040-ui-localization.md
@@ -126,3 +126,26 @@ locale.
 
 Urdu strings remain a first pass flagged for native review, per the original
 decision.
+
+### Sweep notes (2026-09-03, settings slice)
+
+Two limits of the mechanism surfaced while extracting the Settings page and are
+worth recording rather than rediscovering.
+
+**Plural forms are hand-picked, not rule-driven.** `{count} item(s) stored on this
+device` ships as two keys (`.one` / `.other`) chosen in the component. That is
+correct for English and Urdu, which have two plural categories. It is _not_
+general: Arabic has six. A real plural-rule layer (`Intl.PluralRules`) is the fix
+when a locale needs it — deliberately not built for two locales that don't.
+
+**The ratchet cannot see strings in data arrays.** `localized-files.test.ts`
+inspects JSX text and user-facing attributes, so `const GROUPS = [{ label:
+"Dark" }]` passes while still rendering English. The theme picker's group labels
+and palette descriptions were missed exactly this way and caught by eye.
+Widening the check to every string literal would flag ids, CSS values and test
+fixtures, so the guard stays targeted and a human still reads the screen once —
+with anything found that way added to the file's coverage so it cannot regress.
+
+**Theme names stay untranslated.** `Obsidian`, `Ivory`, … are the Noor design
+system's proper names (ADR 0023), treated like a brand; their _descriptions_ are
+prose and are translated.


### PR DESCRIPTION
## What & why

> **Stacked on #262** — its base is `claude/ummah-library-next-features-4c2y3w`, not `main`, because it needs that PR's `t()` interpolation and the ratchet test. **Review/merge #262 first**; GitHub will retarget this to `main` automatically once it lands.

Continues the #208 sweep with a **whole screen** rather than scattered components. Settings is the natural next slice: it's where a reader switches language, so finding it still in English immediately afterwards is the most jarring version of the gap.

Part of #208.

Extracted `ThemePicker`, `DataBackup` and `SyncSettings` — **60 keys** covering the theme picker (group labels + palette descriptions), local backup and export/import, and the cross-device sync panel including its recovery-phrase copy.

**Theme names stay untranslated.** `Obsidian`, `Ivory`, `Emerald`… are the Noor design system's proper names (ADR 0023), treated like a brand. Their *descriptions* ("Charcoal & gold") are prose and are translated.

## Three things the sweep surfaced — recorded, not worked around

**1. Confirm dialogs were user-facing English too.** Both `confirm()` strings now come from the catalogue. A JSX-only sweep would have skipped them entirely — they're plain string arguments, not markup.

**2. Plural forms are hand-picked, not rule-driven.** `{count} item(s) stored on this device` ships as two keys (`.one` / `.other`) chosen in the component. Correct for English and Urdu, which have two plural categories — **not general**: Arabic has six. A real `Intl.PluralRules` layer is the fix when a locale needs it, and is deliberately not built for two locales that don't.

**3. The ratchet cannot see strings in data arrays.** It inspects JSX text and user-facing attributes, so `const GROUPS = [{ label: "Dark" }]` passed while still rendering English. The theme group labels and palette descriptions were missed *exactly that way* and caught by eye against the running app.

Widening the check to every string literal would flag ids, CSS values and test fixtures, so the guard stays targeted. The honest position — now documented in the test and in ADR 0040 — is that it catches the common case and a human still reads the screen once, with anything found that way added to the file's coverage so it can't regress.

## The ratchet earned its place

On the first pass it caught **four** strings this sweep had missed, naming file, line and text:

```
components/SyncSettings.tsx:166 [jsx-text] end-to-end encrypted, with no account. Off by default…
components/SyncSettings.tsx:226 [jsx-text] Copy
components/SyncSettings.tsx:261 [jsx-text] Generate
components/SyncSettings.tsx:292 [jsx-text] — if you lose it, the data can't be decrypted…
```

Two were multi-line sentences whose first line I'd keyed and whose remainder was still literal — precisely the failure mode that would otherwise ship a half-translated paragraph.

## Still English by design

The page header — **"Settings"**, *"Tailor the app to your practice"* — renders from `app/settings/page.tsx`, a **server component**, which cannot use the client `t()` hook.

Fixing it needs a server-side locale source, i.e. a **cookie**, which touches the local-first no-server-state posture (**ADR 0006**) and deserves its own ADR. Recorded in ADR 0040 as an open question rather than quietly resolved. It's visible in the screenshot below and is the honest current state of #208, not an oversight.

## Verification

Rendered in a browser with `ul.locale=ur`: the whole theme section reads Urdu — group labels (`گہرا` / `روشن`), palette descriptions, and the section heading — with the layout mirrored RTL and the theme names preserved. Pre-hydration `lang`/`dir` resolve to `ur`/`rtl` before paint.

## Checklist

- [x] `pnpm lint` passes (0 errors; 13 pre-existing warnings, none from this change)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (466 web tests)
- [x] `pnpm build` passes
- [x] No module-boundary violations
- [x] Any Islamic content is attributed and flagged `needs-scholar-review` if applicable — no content changes; Urdu UI strings remain a first pass flagged for native review, per ADR 0040

## Review notes

- Existing `ThemePicker`, `DataBackup` and `SyncSettings` tests now wrap in `I18nProvider`, matching the pattern `Sidebar`'s test established.
- The Urdu strings are a **first pass and want a native reviewer** — particularly the sync copy, which is the most technical prose in the catalogue so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYXYEC6cGEcgFZ8d9FTCQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYXYEC6cGEcgFZ8d9FTCQU)_